### PR TITLE
add include-path so Doctrine.php can be loaded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
         {"name": "Konsta Vesterinen", "email": "kvesteri@cc.hut.fi"},
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
+    "include-path": [
+        "lib/"
+    ],
     "require": {
         "php": ">=5.2.3",
         "ext-pdo": "*"


### PR DESCRIPTION
The autoload namespace is Doctrine_, so the main Doctrine class doesn't get picked up by this. Adding this include-path definition causes it to fall back to looking for files in lib/.