### PR TITLE
Update sfYamlParser to latest from symfony1 repository

### DIFF
--- a/lib/Doctrine/Parser/sfYaml/sfYamlParser.php
+++ b/lib/Doctrine/Parser/sfYaml/sfYamlParser.php
@@ -26,11 +26,11 @@ if (!defined('PREG_BAD_UTF8_OFFSET_ERROR'))
 class sfYamlParser
 {
   protected
-    $offset        = 0,
-    $lines         = array(),
-    $currentLineNb = -1,
-    $currentLine   = '',
-    $refs          = array();
+      $offset        = 0,
+      $lines         = array(),
+      $currentLineNb = -1,
+      $currentLine   = '',
+      $refs          = array();
 
   /**
    * Constructor
@@ -78,7 +78,7 @@ class sfYamlParser
       }
 
       $isRef = $isInPlace = $isProcessed = false;
-      if (preg_match('#^\-((?P<leadspaces>\s+)(?P<value>.+?))?\s*$#u', $this->currentLine, $values))
+      if (preg_match('#^\-(\s+(?P<value>.+?))?\s*$#u', $this->currentLine, $values))
       {
         if (isset($values['value']) && preg_match('#^&(?P<ref>[^ ]+) *(?P<value>.*)#u', $values['value'], $matches))
         {
@@ -96,22 +96,9 @@ class sfYamlParser
         }
         else
         {
-          if (isset($values['leadspaces'])
-            && ' ' == $values['leadspaces']
-            && preg_match('#^(?P<key>'.sfYamlInline::REGEX_QUOTED_STRING.'|[^ \'"\{].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $values['value'], $matches))
+          if (preg_match('/^([^ ]+)\: +({.*?)$/u', $values['value'], $matches))
           {
-            // this is a compact notation element, add to next block and parse
-            $c = $this->getRealCurrentLineNb();
-            $parser = new sfYamlParser($c);
-            $parser->refs =& $this->refs;
-
-            $block = $values['value'];
-            if (!$this->isNextLineIndented())
-            {
-              $block .= "\n".$this->getNextEmbedBlock($this->getCurrentLineIndentation() + 2);
-            }
-
-            $data[] = $parser->parse($block);
+            $data[] = array($matches[1] => sfYamlInline::load($matches[2]));
           }
           else
           {
@@ -119,7 +106,7 @@ class sfYamlParser
           }
         }
       }
-      else if (preg_match('#^(?P<key>'.sfYamlInline::REGEX_QUOTED_STRING.'|[^ \'"].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $this->currentLine, $values))
+      else if (preg_match('#^(?P<key>'.sfYamlInline::REGEX_QUOTED_STRING.'|[^ \{\[].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $this->currentLine, $values))
       {
         $key = sfYamlInline::parseScalar($values['key']);
 
@@ -168,7 +155,7 @@ class sfYamlParser
             else
             {
               // Associative array, merge
-              $merged = array_merge($merge, $parsed);
+              $merged = array_merge($merged, $parsed);
             }
 
             $isProcessed = $merged;
@@ -302,26 +289,17 @@ class sfYamlParser
   /**
    * Returns the next embed block of YAML.
    *
-   * @param integer $indentation The indent level at which the block is to be read, or null for default
-   *
    * @return string A YAML string
    */
-  protected function getNextEmbedBlock($indentation = null)
+  protected function getNextEmbedBlock()
   {
     $this->moveToNextLine();
 
-    if (null === $indentation)
-    {
-      $newIndent = $this->getCurrentLineIndentation();
+    $newIndent = $this->getCurrentLineIndentation();
 
-      if (!$this->isCurrentLineEmpty() && 0 == $newIndent)
-      {
-        throw new InvalidArgumentException(sprintf('Indentation problem at line %d (%s)', $this->getRealCurrentLineNb() + 1, $this->currentLine));
-      }
-    }
-    else
+    if (!$this->isCurrentLineEmpty() && 0 == $newIndent)
     {
-      $newIndent = $indentation;
+      throw new InvalidArgumentException(sprintf('Indentation problem at line %d (%s)', $this->getRealCurrentLineNb() + 1, $this->currentLine));
     }
 
     $data = array(substr($this->currentLine, $newIndent));


### PR DESCRIPTION
We really like your doctrine1 repo and want to start using it within a legacy codebase alongside symfony1. The doctrine1 repo contains some sfYaml classes which are copied from the symfony1 repo, which in usual symfony1 usage get ignored as the symfony1 version gets loaded first. However, when changing to loading doctrine1 from composer, the ordering of class loading probably cannot be relied upon, and so we don't to accidentally load up an older (and presumably buggier) version of the parser.

The simplest approach to this seems to be to drop in the most up-to-date version of the parser which is covered by the tests in the symfony1 repository:

https://github.com/symfony/symfony1/blob/1.4/lib/yaml/sfYamlParser.php

Please let me know if you'd prefer another approach, or if this isn't something you're interested in at all!