### PR TITLE
PHP 7 fix for Doctrine_Record_Filter_Compound

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 install: composer install

--- a/lib/Doctrine/Record/Filter/Compound.php
+++ b/lib/Doctrine/Record/Filter/Compound.php
@@ -56,15 +56,18 @@ class Doctrine_Record_Filter_Compound extends Doctrine_Record_Filter
     public function filterSet(Doctrine_Record $record, $name, $value)
     {
         foreach ($this->_aliases as $alias) {
+            $relation = $record[$alias];
+
             if ( ! $record->exists()) {
-                if (isset($record[$alias][$name])) {
-                    $record[$alias][$name] = $value;
+
+                if (isset($relation[$name])) {
+                    $relation[$name] = $value;
                     
                     return $record;
                 }
             } else {
-                if (isset($record[$alias][$name])) {
-                    $record[$alias][$name] = $value;
+                if (isset($relation[$name])) {
+                    $relation[$name] = $value;
                 }
 
                 return $record;

--- a/tests/RecordFilterTestCase.php
+++ b/tests/RecordFilterTestCase.php
@@ -1,5 +1,5 @@
 <?php
-class Doctrine_Record_Filter_TestCase extends Doctrine_UnitTestCase {
+class Doctrine_RecordFilter_TestCase extends Doctrine_UnitTestCase {
     public function prepareData() { }
     public function prepareTables() { }
 

--- a/tests/RecordFilterTestCase.php
+++ b/tests/RecordFilterTestCase.php
@@ -1,15 +1,22 @@
 <?php
 class Doctrine_RecordFilter_TestCase extends Doctrine_UnitTestCase {
     public function prepareData() { }
-    public function prepareTables() { }
+    public function prepareTables() {
+        $this->tables = array('RecordFilterTest');
+
+        parent::prepareTables();
+    }
 
     public function testValueWrapper() {
+        $orig = Doctrine_Manager::getInstance()->getAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE);
+        Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE, true);
+
         $e = new RecordFilterTest;
         $e->name = "something";
         $e->password = "123";
 
-
         $this->assertEqual($e->get('name'), 'SOMETHING');
+
         // test repeated calls
         $this->assertEqual($e->get('name'), 'SOMETHING');
         $this->assertEqual($e->id, null);
@@ -41,5 +48,6 @@ class Doctrine_RecordFilter_TestCase extends Doctrine_UnitTestCase {
         $this->assertEqual($e->rawGet('name'), 'something');
         $this->assertEqual($e->password, '202cb962ac59075b964b07152d234b70');
 
+        Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE, $orig);
     }
 }

--- a/tests/models/RecordFilterTest.php
+++ b/tests/models/RecordFilterTest.php
@@ -7,10 +7,12 @@ class RecordFilterTest extends Doctrine_Record
         $this->hasColumn("name", "string", 200);
         $this->hasColumn("password", "string", 32);
     }
-    public function setPassword($password) {
-        return md5($password);
+
+    public function setPassword($value, $load, $fieldName) {
+        $this->_set($fieldName, md5($value), $load);
     }
-    public function getName($name) {
-        return strtoupper($name);
+
+    public function getName($load, $fieldName) {
+        return strtoupper($this->_get($fieldName, $load));
     }
 }

--- a/tests/run.php
+++ b/tests/run.php
@@ -241,6 +241,7 @@ $test->addTestCase($query_tests);
 $record = new GroupTest('Record Tests', 'record');
 $record->addTestCase(new Doctrine_Record_Hook_TestCase());
 $record->addTestCase(new Doctrine_Record_CascadingDelete_TestCase());
+$record->addTestCase(new Doctrine_RecordFilter_TestCase());
 $record->addTestCase(new Doctrine_Record_Filter_TestCase());
 $record->addTestCase(new Doctrine_Record_TestCase());
 $record->addTestCase(new Doctrine_Record_State_TestCase());


### PR DESCRIPTION
The build used to pass on this repo for PHP 7.0, but it seems that there were two test classes which shared the class name `Doctrine_Record_Filter_TestCase`, neither of which were actually running!

This PR:

* Enables both the tests
* Fixes Doctrine_Record_Filter_Compound for PHP 7
* Updated one of the tests, which looks like it has not passed for a long time
* Adds PHP 7.1 as a build target
