### PR TITLE
Fixes for phpstan level 0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
         "psr-0": {
             "Doctrine_": "lib/",
             "sfYaml": "lib/Doctrine/Parser/sfYaml/"
-        }
+        },
+        "files": [
+            "lib/Doctrine.php"
+        ]
     },
     "include-path": [
         "lib/"

--- a/lib/Doctrine/Adapter/Mock.php
+++ b/lib/Doctrine/Adapter/Mock.php
@@ -67,7 +67,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
      * $conn = new Doctrine_Adapter_Mock('mysql');
      * </code>
      *
-     * @param string $name 
+     * @param string $name
      * @return void
      */
     public function __construct($name = null)
@@ -116,7 +116,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
      */
     public function prepare($query)
     {
-        $mock = new Doctrine_Adapter_Statement_Mock($this, $query);
+        $mock = new Doctrine_Adapter_Statement_Mock($this);
         $mock->queryString = $query;
 
         return $mock;
@@ -125,7 +125,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
     /**
      * Add query to the stack of executed queries
      *
-     * @param string $query 
+     * @param string $query
      * @return void
      */
     public function addQuery($query)
@@ -136,7 +136,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
     /**
      * Fake the execution of query and add it to the stack of executed queries
      *
-     * @param string $query 
+     * @param string $query
      * @return Doctrine_Adapter_Statement_Mock $stmt
      */
     public function query($query)
@@ -153,7 +153,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
             throw new $name($e[1], $e[2]);
         }
 
-        $stmt = new Doctrine_Adapter_Statement_Mock($this, $query);
+        $stmt = new Doctrine_Adapter_Statement_Mock($this);
         $stmt->queryString = $query;
 
         return $stmt;
@@ -172,7 +172,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
     /**
      * Quote a value for the dbms
      *
-     * @param string $input 
+     * @param string $input
      * @return string $quoted
      */
     public function quote($input)
@@ -183,7 +183,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
     /**
      * Execute a raw sql statement
      *
-     * @param string $statement 
+     * @param string $statement
      * @return void
      */
     public function exec($statement)

--- a/lib/Doctrine/Adapter/Statement/Oracle.php
+++ b/lib/Doctrine/Adapter/Statement/Oracle.php
@@ -236,7 +236,7 @@ class Doctrine_Adapter_Statement_Oracle implements Doctrine_Adapter_Statement_In
 
         if ($oci_error) {
             //store the error
-            $this->oci_errors[] = $oci_error;
+            $this->ociErrors[] = $oci_error;
         } else if (count($this->ociErrors) > 0) {
             $oci_error = $this->ociErrors[count($this->ociErrors)-1];
         }
@@ -419,6 +419,9 @@ class Doctrine_Adapter_Statement_Oracle implements Doctrine_Adapter_Statement_In
         if ($row === false) {
             return false;
         }
+
+        // gets overwritten by eval'd code
+        $object = new stdClass();
 
         $instantiation_code = "\$object = new $className(";
         $firstParam=true;

--- a/lib/Doctrine/Builder.php
+++ b/lib/Doctrine/Builder.php
@@ -38,7 +38,7 @@ class Doctrine_Builder
      * So we do some string replacing to clean it up
      *
      * @param string $var
-     * @return void
+     * @return string
      */
     public function varExport($var)
     {

--- a/lib/Doctrine/Cache/Db.php
+++ b/lib/Doctrine/Cache/Db.php
@@ -53,8 +53,7 @@ class Doctrine_Cache_Db extends Doctrine_Cache_Driver
              throw new Doctrine_Cache_Exception('Table name option not set.');
         }
 
-
-        $this->_options = $options;
+        parent::__construct($options);
     }
 
     /**

--- a/lib/Doctrine/Cli/AnsiColorFormatter.php
+++ b/lib/Doctrine/Cli/AnsiColorFormatter.php
@@ -90,11 +90,11 @@ class Doctrine_Cli_AnsiColorFormatter extends Doctrine_Cli_Formatter
         if (isset($parameters['fg'])) {
             $codes[] = $this->_foreground[$parameters['fg']];
         }
-        
+
         if (isset($parameters['bg'])) {
             $codes[] = $this->_background[$parameters['bg']];
         }
-        
+
         foreach ($this->_options as $option => $value) {
             if (isset($parameters[$option]) && $parameters[$option]) {
                 $codes[] = $value;
@@ -129,7 +129,7 @@ class Doctrine_Cli_AnsiColorFormatter extends Doctrine_Cli_Formatter
     public function excerpt($text, $size = null)
     {
         if ( ! $size) {
-            $size = $this->size;
+            $size = $this->_size;
         }
 
         if (strlen($text) < $size) {

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -137,7 +137,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param array $data
      * @return Doctrine_Collection
      */
-    public function setData(array $data) 
+    public function setData(array $data)
     {
         $this->data = $data;
     }
@@ -200,7 +200,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     public function setKeyColumn($column)
     {
         $this->keyColumn = $column;
-        
+
         return $this;
     }
 
@@ -274,7 +274,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         $this->reference = $record;
         $this->relation  = $relation;
 
-        if ($relation instanceof Doctrine_Relation_ForeignKey || 
+        if ($relation instanceof Doctrine_Relation_ForeignKey ||
                 $relation instanceof Doctrine_Relation_LocalKey) {
             $this->referenceField = $relation->getForeignFieldName();
 
@@ -330,7 +330,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Search a Doctrine_Record instance
      *
-     * @param string $Doctrine_Record 
+     * @param string $Doctrine_Record
      * @return void
      */
     public function search(Doctrine_Record $record)
@@ -371,7 +371,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
             if ($key === null) {
                 $this->data[] = $record;
             } else {
-                $this->data[$key] = $record;      	
+                $this->data[$key] = $record;
             }
 
             if (isset($this->keyColumn)) {
@@ -496,10 +496,10 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
 
         return true;
     }
-    
+
     /**
      * Merges collection into $this and returns merged collection
-     * 
+     *
      * @param Doctrine_Collection $coll
      * @return Doctrine_Collection
      */
@@ -507,15 +507,15 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     {
         $localBase = $this->getTable()->getComponentName();
         $otherBase = $coll->getTable()->getComponentName();
-        
+
         if ($otherBase != $localBase && !is_subclass_of($otherBase, $localBase) ) {
             throw new Doctrine_Collection_Exception("Can't merge collections with incompatible record types");
         }
-        
+
         foreach ($coll->getData() as $record) {
             $this->add($record);
         }
-        
+
         return $this;
     }
 
@@ -633,7 +633,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Get normal iterator - an iterator that will not expand this collection
      *
-     * @return Doctrine_Iterator_Normal $iterator
+     * @return Doctrine_Collection_Iterator_Normal $iterator
      */
     public function getNormalIterator()
     {
@@ -655,7 +655,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     public function takeSnapshot()
     {
         $this->_snapshot = $this->data;
-        
+
         return $this;
     }
 
@@ -680,7 +680,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return Doctrine_Collection
      */
-    public function processDiff() 
+    public function processDiff()
     {
         foreach (array_udiff($this->_snapshot, $this->data, array($this, "compareRecords")) as $record) {
             $record->delete();
@@ -698,20 +698,20 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     {
         $data = array();
         foreach ($this as $key => $record) {
-            
+
             $key = $prefixKey ? get_class($record) . '_' .$key:$key;
-            
+
             $data[$key] = $record->toArray($deep, $prefixKey);
         }
-        
+
         return $data;
     }
 
     /**
      * Build an array made up of the values from the 2 specified columns
      *
-     * @param string $key 
-     * @param string $value 
+     * @param string $key
+     * @param string $value
      * @return array $result
      */
     public function toKeyValueArray($key, $value)
@@ -774,7 +774,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Populate a Doctrine_Collection from an array of data
      *
-     * @param string $array 
+     * @param string $array
      * @return void
      */
     public function fromArray($array, $deep = true)
@@ -819,8 +819,8 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Export a Doctrine_Collection to one of the supported Doctrine_Parser formats
      *
-     * @param string $type 
-     * @param string $deep 
+     * @param string $type
+     * @param string $deep
      * @return void
      */
     public function exportTo($type, $deep = true)
@@ -835,16 +835,16 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Import data to a Doctrine_Collection from one of the supported Doctrine_Parser formats
      *
-     * @param string $type 
-     * @param string $data 
+     * @param string $type
+     * @param string $data
      * @return void
      */
     public function importFrom($type, $data)
     {
         if ($type == 'array') {
-            return $this->fromArray($data);
+            $this->fromArray($data);
         } else {
-            return $this->fromArray(Doctrine_Parser::load($data, $type));
+            $this->fromArray(Doctrine_Parser::load($data, $type));
         }
     }
 
@@ -871,8 +871,8 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Compares two records. To be used on _snapshot diffs using array_udiff
      *
-     * @param Doctrine_Record $a 
-     * @param Doctrine_Record $b 
+     * @param Doctrine_Record $a
+     * @param Doctrine_Record $b
      * @return integer
      */
     protected function compareRecords($a, $b)
@@ -880,12 +880,12 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         if ($a->getOid() == $b->getOid()) {
             return 0;
         }
-        
+
         return ($a->getOid() > $b->getOid()) ? 1 : -1;
     }
 
     /**
-     * Saves all records of this collection and processes the 
+     * Saves all records of this collection and processes the
      * difference of the last snapshot and the current data
      *
      * @param Doctrine_Connection $conn     optional connection parameter
@@ -896,7 +896,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         if ($conn == null) {
             $conn = $this->_table->getConnection();
         }
-        
+
         try {
             $conn->beginInternalTransaction();
 
@@ -920,7 +920,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     }
 
     /**
-     * Replaces all records of this collection and processes the 
+     * Replaces all records of this collection and processes the
      * difference of the last snapshot and the current data
      *
      * @param Doctrine_Connection $conn     optional connection parameter
@@ -964,7 +964,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         if ($conn == null) {
             $conn = $this->_table->getConnection();
         }
-        
+
         try {
             $conn->beginInternalTransaction();
             $conn->transaction->addCollection($this);
@@ -978,14 +978,14 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
             $conn->rollback();
             throw $e;
         }
-        
+
         if ($clearColl) {
             $this->clear();
         }
-        
+
         return $this;
     }
-    
+
     /**
      * Clears the collection.
      *
@@ -1039,7 +1039,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     {
         return Doctrine_Lib::getCollectionAsString($this);
     }
-    
+
     /**
      * Returns the relation object
      *
@@ -1050,21 +1050,21 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         return $this->relation;
     }
 
-    /** 
-     * checks if one of the containing records is modified 
-     * returns true if modified, false otherwise 
-     *  
-     * @return boolean  
-     */ 
-    final public function isModified() { 
-        $dirty = (count($this->getInsertDiff()) > 0 || count($this->getDeleteDiff()) > 0); 
-        if ( ! $dirty) {  
-            foreach($this as $record) { 
+    /**
+     * checks if one of the containing records is modified
+     * returns true if modified, false otherwise
+     *
+     * @return boolean
+     */
+    final public function isModified() {
+        $dirty = (count($this->getInsertDiff()) > 0 || count($this->getDeleteDiff()) > 0);
+        if ( ! $dirty) {
+            foreach($this as $record) {
                 if ($dirty = $record->isModified()) {
                     break;
-                } 
-            } 
-        } 
-        return $dirty; 
+                }
+            }
+        }
+        return $dirty;
     }
 }

--- a/lib/Doctrine/Column.php
+++ b/lib/Doctrine/Column.php
@@ -52,7 +52,7 @@ class Doctrine_Column extends Doctrine_Access implements IteratorAggregate, Coun
     /**
      * Returns the definition of the column.
      *
-     * Keys can be: 
+     * Keys can be:
      *     string type,
      *     integer length,
      *     array values (only for enum fields, maps integer indexes to mixed values),
@@ -68,7 +68,7 @@ class Doctrine_Column extends Doctrine_Access implements IteratorAggregate, Coun
      *
      * @return boolean
      */
-    public function contains($name) 
+    public function contains($name)
     {
         return isset($this->_definition[$name]);
     }
@@ -84,7 +84,7 @@ class Doctrine_Column extends Doctrine_Access implements IteratorAggregate, Coun
         if ( ! isset($this->_definition[$name])) {
             return null;
         }
-        
+
         return $this->_definition[$name];
     }
 
@@ -116,7 +116,7 @@ class Doctrine_Column extends Doctrine_Access implements IteratorAggregate, Coun
      * Retrieves an enum value.
      *
      * @param integer $index
-     * @return string       integer ($index) if not present
+     * @return string|false       integer ($index) if not present
      */
     public function enumValue($index)
     {
@@ -156,7 +156,7 @@ class Doctrine_Column extends Doctrine_Access implements IteratorAggregate, Coun
      *
      * @return ArrayIterator
      */
-    public function getIterator() 
+    public function getIterator()
     {
         return new ArrayIterator($this->_definition);
     }

--- a/lib/Doctrine/Compiler.php
+++ b/lib/Doctrine/Compiler.php
@@ -39,16 +39,16 @@ class Doctrine_Compiler
      * cases dozens of files) can improve performance by an order of magnitude
      *
      * @throws Doctrine_Compiler_Exception      if something went wrong during the compile operation
-     * @return $target Path the compiled file was written to
+     * @return string $target Path the compiled file was written to
      */
     public static function compile($target = null, $includedDrivers = array())
     {
         if ( ! is_array($includedDrivers)) {
             $includedDrivers = array($includedDrivers);
         }
-        
+
         $excludedDrivers = array();
-        
+
         // If we have an array of specified drivers then lets determine which drivers we should exclude
         if ( ! empty($includedDrivers)) {
             $drivers = array('db2',
@@ -57,17 +57,17 @@ class Doctrine_Compiler
                              'oracle',
                              'pgsql',
                              'sqlite');
-            
+
             $excludedDrivers = array_diff($drivers, $includedDrivers);
         }
-        
+
         $path = Doctrine_Core::getPath();
         $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path . '/Doctrine'), RecursiveIteratorIterator::LEAVES_ONLY);
 
         foreach ($it as $file) {
             $e = explode('.', $file->getFileName());
-            
-            //@todo what is a versioning file? do we have these anymore? None 
+
+            //@todo what is a versioning file? do we have these anymore? None
             //exists in my version of doctrine from svn.
             // we don't want to require versioning files
             if (end($e) === 'php' && strpos($file->getFileName(), '.inc') === false
@@ -86,21 +86,21 @@ class Doctrine_Compiler
             if ($e[0] !== 'Doctrine') {
                 continue;
             }
-            
+
             // Exclude drivers
             if ( ! empty($excludedDrivers)) {
                 foreach ($excludedDrivers as $excludedDriver) {
                     $excludedDriver = ucfirst($excludedDriver);
-                    
+
                     if (in_array($excludedDriver, $e)) {
                         continue(2);
                     }
                 }
             }
-            
+
             $refl  = new ReflectionClass($class);
             $file  = $refl->getFileName();
-            
+
             $lines = file($file);
 
             $start = $refl->getStartLine() - 1;
@@ -120,7 +120,7 @@ class Doctrine_Compiler
         if ($fp === false) {
             throw new Doctrine_Compiler_Exception("Couldn't write compiled data. Failed to open $target");
         }
-        
+
         fwrite($fp, "<?php ". implode('', $ret));
         fclose($fp);
 
@@ -129,7 +129,7 @@ class Doctrine_Compiler
         if ($fp === false) {
             throw new Doctrine_Compiler_Exception("Couldn't write compiled data. Failed to open $file");
         }
-        
+
         fwrite($fp, $stripped);
         fclose($fp);
 

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -52,6 +52,26 @@
  * @version     $Revision: 7490 $
  * @author      Konsta Vesterinen <kvesteri@cc.hut.fi>
  * @author      Lukas Smith <smith@pooteeweet.org> (MDB2 library)
+ *
+ * From $modules array
+ * @property Doctrine_Formatter $formatter
+ * @property Doctrine_Connection_UnitOfWork $unitOfWork
+ * @property Doctrine_Transaction $transaction
+ * @property Doctrine_Expression_Driver $expression
+ * @property Doctrine_DataDict $dataDict
+ * @property Doctrine_Export $export
+ * @property Doctrine_Import $import
+ * @property Doctrine_Sequence $sequence
+ * @property Doctrine_Util $util
+ *
+ * From $properties array
+ * @property array $identifier_quoting
+ * @property int $max_identifier_length
+ * @property array $sql_comments
+ * @property string $sql_file_delimiter
+ * @property array $string_quoting
+ * @property int $varchar_max_length
+ * @property array $wildcards
  */
 abstract class Doctrine_Connection extends Doctrine_Configurable implements Countable, IteratorAggregate, Serializable
 {
@@ -249,7 +269,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      * Retrieves option
      *
      * @param string $option
-     * @return void
+     * @return mixed
      */
     public function getOption($option)
     {
@@ -376,7 +396,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * Gets the name of the instance driver
      *
-     * @return void
+     * @return string
      */
     public function getDriverName()
     {
@@ -394,7 +414,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      * @see Doctrine_Connection::$modules       all availible modules
      * @param string $name                      the name of the module to get
      * @throws Doctrine_Connection_Exception    if trying to get an unknown module
-     * @return Doctrine_Connection_Module       connection module
+     * @return mixed       connection module
      */
     public function __get($name)
     {
@@ -1490,7 +1510,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      * This value is set in the Doctrine_Export_{DRIVER} classes if required
      *
      * @param string $info
-     * @return void
+     * @return Doctrine_Connection
      */
     public function getTmpConnection($info)
     {

--- a/lib/Doctrine/Connection/Mock.php
+++ b/lib/Doctrine/Connection/Mock.php
@@ -42,7 +42,7 @@ class Doctrine_Connection_Mock extends Doctrine_Connection_Common
      * the constructor
      *
      * @param Doctrine_Manager $manager
-     * @param PDO|Doctrine_Adapter $adapter     database handler
+     * @param PDO|Doctrine_Adapter_Interface $adapter     database handler
      */
     public function __construct(Doctrine_Manager $manager, $adapter)
     {

--- a/lib/Doctrine/Connection/Mssql.php
+++ b/lib/Doctrine/Connection/Mssql.php
@@ -404,7 +404,11 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
      * @param string $query
      * @param array $params
      */
-    protected function replaceBoundParamsWithInlineValuesInQuery($query, array $params) {
+    protected function replaceBoundParamsWithInlineValuesInQuery($query, array $params)
+    {
+        // $value was previously undefined, this defines it for static analysis.
+        // Closure below uses it, expecting it to be set from the last iteration of the foreach below
+        $value = null;
 
         foreach($params as $key => $value) {
             $re = '/(?<=WHERE|VALUES|SET|JOIN)(.*?)(\?)/';

--- a/lib/Doctrine/Connection/Mysql.php
+++ b/lib/Doctrine/Connection/Mysql.php
@@ -42,7 +42,7 @@ class Doctrine_Connection_Mysql extends Doctrine_Connection_Common
      * the constructor
      *
      * @param Doctrine_Manager $manager
-     * @param PDO|Doctrine_Adapter $adapter     database handler
+     * @param PDO|Doctrine_Adapter_Interface $adapter     database handler
      */
     public function __construct(Doctrine_Manager $manager, $adapter)
     {
@@ -103,8 +103,8 @@ class Doctrine_Connection_Mysql extends Doctrine_Connection_Common
 
          return $connected;
      }
-    
-    
+
+
     /**
      * returns the name of the connected database
      *

--- a/lib/Doctrine/Connection/Pgsql.php
+++ b/lib/Doctrine/Connection/Pgsql.php
@@ -139,6 +139,10 @@ class Doctrine_Connection_Pgsql extends Doctrine_Connection_Common
 
             if ($isManip) {
                 $manip = preg_replace('/^(DELETE FROM|UPDATE).*$/', '\\1', $query);
+                // $match was previously undefined, setting as an empty array for static analysis
+                // as PHP implicitly makes the empty array when accessed below. Behavior here probably isn't
+                // working as originally expected
+                $match = array();
                 $from  = $match[2];
                 $where = $match[3];
                 $query = $manip . ' ' . $from . ' WHERE ctid=(SELECT ctid FROM '
@@ -210,9 +214,9 @@ class Doctrine_Connection_Pgsql extends Doctrine_Connection_Common
         $cols = array();
         // the query VALUES will contain either expresions (eg 'NOW()') or ?
         $a = array();
-        
+
         foreach ($fields as $fieldName => $value) {
-        	if ($table->isIdentifier($fieldName) 
+        	if ($table->isIdentifier($fieldName)
         	           && $table->isIdentifierAutoincrement()
         	           && $value == null) {
         		// Autoincrement fields should not be added to the insert statement
@@ -228,12 +232,12 @@ class Doctrine_Connection_Pgsql extends Doctrine_Connection_Common
                 $a[] = '?';
             }
         }
-        
+
         if (count($fields) == 0) {
-        	// Real fix #1786 and #2327 (default values when table is just 'id' as PK)        	
+        	// Real fix #1786 and #2327 (default values when table is just 'id' as PK)
             return $this->exec('INSERT INTO ' . $this->quoteIdentifier($tableName)
                               . ' '
-                              . ' VALUES (DEFAULT)');        	
+                              . ' VALUES (DEFAULT)');
         }
 
         // build the statement
@@ -242,5 +246,5 @@ class Doctrine_Connection_Pgsql extends Doctrine_Connection_Common
                 . ' VALUES (' . implode(', ', $a) . ')';
 
         return $this->exec($query, array_values($fields));
-    }    
+    }
 }

--- a/lib/Doctrine/Core.php
+++ b/lib/Doctrine/Core.php
@@ -180,7 +180,7 @@ class Doctrine_Core
     const ATTR_NAME_PREFIX                  = 121;
     const ATTR_CREATE_TABLES                = 122;
     const ATTR_COLL_LIMIT                   = 123;
-                                        
+
     const ATTR_CACHE                        = 150;
     const ATTR_RESULT_CACHE                 = 150;
     const ATTR_CACHE_LIFESPAN               = 151;
@@ -347,12 +347,12 @@ class Doctrine_Core
      * HYDRATE_NONE
      */
     const HYDRATE_NONE              = 4;
-    
+
     /**
      * HYDRATE_SCALAR
      */
     const HYDRATE_SCALAR            = 5;
-    
+
     /**
      * HYDRATE_SINGLE_SCALAR
      */
@@ -362,14 +362,14 @@ class Doctrine_Core
      * HYDRATE_ON_DEMAND
      */
     const HYDRATE_ON_DEMAND         = 7;
-    
+
     /**
-     * HYDRATE_ARRAY_HIERARCHY     
+     * HYDRATE_ARRAY_HIERARCHY
      */
     const HYDRATE_ARRAY_HIERARCHY   = 8;
-    
+
     /**
-     * HYDRATE_RECORD_HIERARCHY     
+     * HYDRATE_RECORD_HIERARCHY
      */
     const HYDRATE_RECORD_HIERARCHY  = 9;
 
@@ -403,9 +403,9 @@ class Doctrine_Core
      */
     const VALIDATE_ALL              = 7;
 
-    /** 
+    /**
      * VALIDATE_USER
-     */ 
+     */
     const VALIDATE_USER             = 8;
 
     /**
@@ -457,7 +457,7 @@ class Doctrine_Core
      * MODEL_LOADING_PEAR
      *
      * Constant for pear model loading
-     * Will simply store the path passed to Doctrine_Core::loadModels() 
+     * Will simply store the path passed to Doctrine_Core::loadModels()
      * and Doctrine_Core::autoload() will check there
      */
     const MODEL_LOADING_PEAR = 3;
@@ -529,7 +529,7 @@ class Doctrine_Core
      * Turn on/off the debugging setting
      *
      * @param string $bool
-     * @return void
+     * @return bool
      */
     public static function debug($bool = null)
     {
@@ -568,7 +568,7 @@ class Doctrine_Core
     /**
      * Set the path to autoload extension classes from
      *
-     * @param string $extensionsPath 
+     * @param string $extensionsPath
      * @return void
      */
     public static function setExtensionsPath($extensionsPath)
@@ -600,7 +600,7 @@ class Doctrine_Core
      * Set the directory where your models are located for PEAR style
      * naming convention autoloading.
      *
-     * @param string $directory 
+     * @param string $directory
      * @return void
      */
     public static function setModelsDirectory($directory)
@@ -612,7 +612,7 @@ class Doctrine_Core
      * Get the directory where your models are located for PEAR style naming
      * convention autoloading
      *
-     * @return void
+     * @return string
      * @author Jonathan Wage
      */
     public static function getModelsDirectory()
@@ -646,10 +646,10 @@ class Doctrine_Core
 
                 $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir),
                                                         RecursiveIteratorIterator::LEAVES_ONLY);
-                                                        
+
                 foreach ($it as $file) {
                     $e = explode('.', $file->getFileName());
-                    
+
                     if (end($e) === 'php' && strpos($file->getFileName(), '.inc') === false) {
                         if ($modelLoading == Doctrine_Core::MODEL_LOADING_PEAR) {
                             $className = str_replace($dir . DIRECTORY_SEPARATOR, null, $file->getPathName());
@@ -672,10 +672,10 @@ class Doctrine_Core
                                 $declaredBefore = get_declared_classes();
                                 require_once($file->getPathName());
                                 $declaredAfter = get_declared_classes();
-                                
+
                                 // Using array_slice because array_diff is broken is some PHP versions
                                 $foundClasses = array_slice($declaredAfter, count($declaredBefore));
-                                
+
                                 if ($foundClasses) {
                                     foreach ($foundClasses as $className) {
                                         if (self::isValidModelClass($className)) {
@@ -685,7 +685,7 @@ class Doctrine_Core
                                         }
                                     }
                                 }
-                                
+
                                 $previouslyLoaded = array_keys(self::$_loadedModelFiles, $file->getPathName());
 
                                 if ( ! empty($previouslyLoaded)) {
@@ -700,9 +700,9 @@ class Doctrine_Core
                 }
             }
         }
-        
+
         asort($loadedModels);
-        
+
         return $loadedModels;
     }
 
@@ -1038,7 +1038,7 @@ class Doctrine_Core
      * Generate a set of migration classes from an existing database
      *
      * @param string $migrationsPath
-     * @return void
+     * @return bool
      * @throws new Doctrine_Migration_Exception
      */
     public static function generateMigrationsFromDb($migrationsPath)
@@ -1098,7 +1098,7 @@ class Doctrine_Core
      * @param string $target
      * @param array  $includedDrivers
      * @throws Doctrine_Exception
-     * @return void
+     * @return string
      */
     public static function compile($target = null, $includedDrivers = array())
     {

--- a/lib/Doctrine/Data.php
+++ b/lib/Doctrine/Data.php
@@ -21,7 +21,7 @@
 
 /**
  * Doctrine_Data
- * 
+ *
  * Base Doctrine_Data class for dumping and loading data to and from fixtures files.
  * Support formats are based on what formats are available in Doctrine_Parser such as yaml, xml, json, etc.
  *
@@ -40,13 +40,13 @@ class Doctrine_Data
      *
      * array of formats data can be in
      *
-     * @var string
+     * @var array
      */
     protected $_formats = array('csv', 'yml', 'xml');
 
     /**
      * format
-     * 
+     *
      * the default and current format we are working with
      *
      * @var string
@@ -67,7 +67,7 @@ class Doctrine_Data
      *
      * specified array of models to use
      *
-     * @var string
+     * @var array
      */
     protected $_models = array();
 
@@ -76,7 +76,7 @@ class Doctrine_Data
      *
      * whether or not to export data to individual files instead of 1
      *
-     * @var string
+     * @var bool
      */
     protected $_exportIndividualFiles = false;
 
@@ -84,8 +84,8 @@ class Doctrine_Data
      * setFormat
      *
      * Set the current format we are working with
-     * 
-     * @param string $format 
+     *
+     * @param string $format
      * @return void
      */
     public function setFormat($format)
@@ -97,8 +97,8 @@ class Doctrine_Data
      * getFormat
      *
      * Get the current format we are working with
-     * 
-     * @return void
+     *
+     * @return string
      */
     public function getFormat()
     {
@@ -106,11 +106,11 @@ class Doctrine_Data
     }
 
     /**
-     * getFormats 
+     * getFormats
      *
      * Get array of available formats
-     * 
-     * @return void
+     *
+     * @return array
      */
     public function getFormats()
     {
@@ -121,7 +121,7 @@ class Doctrine_Data
      * setDirectory
      *
      * Set the array/string of directories or yml file paths
-     * 
+     *
      * @return void
      */
     public function setDirectory($directory)
@@ -133,8 +133,8 @@ class Doctrine_Data
      * getDirectory
      *
      * Get directory for dumping/loading data from and to
-     * 
-     * @return void
+     *
+     * @return string
      */
     public function getDirectory()
     {
@@ -145,8 +145,8 @@ class Doctrine_Data
      * setModels
      *
      * Set the array of specified models to work with
-     * 
-     * @param string $models 
+     *
+     * @param array $models
      * @return void
      */
     public function setModels($models)
@@ -159,7 +159,7 @@ class Doctrine_Data
      *
      * Get the array of specified models to work with
      *
-     * @return void
+     * @return array
      */
     public function getModels()
     {
@@ -167,10 +167,10 @@ class Doctrine_Data
     }
 
     /**
-     * _exportIndividualFiles 
+     * _exportIndividualFiles
      *
      * Set/Get whether or not to export individual files
-     * 
+     *
      * @return bool $_exportIndividualFiles
      */
     public function exportIndividualFiles($bool = null)
@@ -178,7 +178,7 @@ class Doctrine_Data
         if ($bool !== null) {
             $this->_exportIndividualFiles = $bool;
         }
-        
+
         return $this->_exportIndividualFiles;
     }
 
@@ -187,10 +187,10 @@ class Doctrine_Data
      *
      * Interface for exporting data to fixtures files from Doctrine models
      *
-     * @param string $directory 
-     * @param string $format 
-     * @param string $models 
-     * @param string $_exportIndividualFiles 
+     * @param string $directory
+     * @param string $format
+     * @param string $models
+     * @param string $_exportIndividualFiles
      * @return void
      */
     public function exportData($directory, $format = 'yml', $models = array(), $_exportIndividualFiles = false)
@@ -199,7 +199,7 @@ class Doctrine_Data
         $export->setFormat($format);
         $export->setModels($models);
         $export->exportIndividualFiles($_exportIndividualFiles);
-        
+
         return $export->doExport();
     }
 
@@ -208,9 +208,9 @@ class Doctrine_Data
      *
      * Interface for importing data from fixture files to Doctrine models
      *
-     * @param string $directory 
-     * @param string $format 
-     * @param string $models 
+     * @param string $directory
+     * @param string $format
+     * @param string $models
      * @return void
      */
     public function importData($directory, $format = 'yml', $models = array(), $append = false)
@@ -218,7 +218,7 @@ class Doctrine_Data
         $import = new Doctrine_Data_Import($directory);
         $import->setFormat($format);
         $import->setModels($models);
-        
+
         return $import->doImport($append);
     }
 
@@ -226,33 +226,33 @@ class Doctrine_Data
      * isRelation
      *
      * Check if a fieldName on a Doctrine_Record is a relation, if it is we return that relationData
-     * 
-     * @param string $Doctrine_Record 
-     * @param string $fieldName 
-     * @return void
+     *
+     * @param string $Doctrine_Record
+     * @param string $fieldName
+     * @return false|array
      */
     public function isRelation(Doctrine_Record $record, $fieldName)
     {
         $relations = $record->getTable()->getRelations();
-        
+
         foreach ($relations as $relation) {
             $relationData = $relation->toArray();
-            
+
             if ($relationData['local'] === $fieldName) {
                 return $relationData;
             }
-            
+
         }
-        
+
         return false;
     }
 
     /**
      * purge
-     * 
+     *
      * Purge all data for loaded models or for the passed array of Doctrine_Records
      *
-     * @param string $models 
+     * @param string $models
      * @return void
      */
     public function purge($models = null)

--- a/lib/Doctrine/Data/Export.php
+++ b/lib/Doctrine/Data/Export.php
@@ -35,7 +35,7 @@ class Doctrine_Data_Export extends Doctrine_Data
     /**
      * constructor
      *
-     * @param string $directory 
+     * @param string $directory
      * @return void
      */
     public function __construct($directory)
@@ -46,13 +46,13 @@ class Doctrine_Data_Export extends Doctrine_Data
     /**
      * doExport
      *
-     * FIXME: This function has ugly hacks in it for temporarily disabling INDEXBY query parts of tables 
+     * FIXME: This function has ugly hacks in it for temporarily disabling INDEXBY query parts of tables
      * to export.
      *
      * Update from jwage: I am not sure if their is any other better solution for this. It may be the correct
-     * solution to disable the indexBy settings for tables when exporting data fixtures. Maybe a better idea 
-     * would be to extract this functionality to a pair of functions to enable/disable the index by settings 
-     * so simply turn them on and off when they need to query for the translations standalone and don't need 
+     * solution to disable the indexBy settings for tables when exporting data fixtures. Maybe a better idea
+     * would be to extract this functionality to a pair of functions to enable/disable the index by settings
+     * so simply turn them on and off when they need to query for the translations standalone and don't need
      * it to be indexed by the lang.
      *
      * @return void
@@ -108,8 +108,8 @@ class Doctrine_Data_Export extends Doctrine_Data
      *
      * Dump the prepared data to the fixtures files
      *
-     * @param string $array 
-     * @return void
+     * @param string $array
+     * @return int|false|string
      */
     public function dumpData(array $data)
     {
@@ -144,7 +144,7 @@ class Doctrine_Data_Export extends Doctrine_Data
      *
      * Prepare the raw data to be exported with the parser
      *
-     * @param string $data 
+     * @param string $data
      * @return array
      */
     public function prepareData($data)
@@ -201,13 +201,13 @@ class Doctrine_Data_Export extends Doctrine_Data
                         $relationValue = $relationClassName . '_' . $value;
 
                         $preparedData[$className][$recordKey][$relationAlias] = $relationValue;
-                    } else if ($record->getTable()->hasField($key)) {                        
+                    } else if ($record->getTable()->hasField($key)) {
                         $preparedData[$className][$recordKey][$key] = $value;
                     }
                 }
             }
         }
-        
+
         return $preparedData;
     }
 }

--- a/lib/Doctrine/Export.php
+++ b/lib/Doctrine/Export.php
@@ -66,7 +66,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
      * (this method is implemented by the drivers)
      *
      * @param string $name name of the database that should be dropped
-     * @return void
+     * @return string|array
      */
     public function dropDatabaseSql($database)
     {
@@ -119,7 +119,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
     public function dropIndexSql($table, $name)
     {
         $name = $this->conn->quoteIdentifier($this->conn->formatter->getIndexName($name));
-        
+
         return 'DROP INDEX ' . $name;
     }
 
@@ -129,13 +129,13 @@ class Doctrine_Export extends Doctrine_Connection_Module
      * @param string    $table        name of table that should be used in method
      * @param string    $name         name of the constraint to be dropped
      * @param string    $primary      hint if the constraint is primary
-     * @return void
+     * @return int
      */
     public function dropConstraint($table, $name, $primary = false)
     {
         $table = $this->conn->quoteIdentifier($table);
         $name  = $this->conn->quoteIdentifier($name);
-        
+
         return $this->conn->exec('ALTER TABLE ' . $table . ' DROP CONSTRAINT ' . $name);
     }
 
@@ -171,7 +171,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
      *
      * @throws Doctrine_Connection_Exception     if something fails at database level
      * @param string $sequenceName name of the sequence to be dropped
-     * @return void
+     * @return string
      */
     public function dropSequenceSql($sequenceName)
     {
@@ -254,12 +254,12 @@ class Doctrine_Export extends Doctrine_Connection_Module
                 // append only created index declarations
                 if ( ! is_null($indexDeclaration)) {
                     $queryFields .= ', '.$indexDeclaration;
-                } 
+                }
             }
         }
 
         $query = 'CREATE TABLE ' . $this->conn->quoteIdentifier($name, true) . ' (' . $queryFields;
-        
+
         $check = $this->getCheckDeclaration($fields);
 
         if ( ! empty($check)) {
@@ -376,7 +376,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
     public function createConstraint($table, $name, $definition)
     {
         $sql = $this->createConstraintSql($table, $name, $definition);
-        
+
         return $this->conn->exec($sql);
     }
 
@@ -399,7 +399,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
      *                                            'last_login' => array()
      *                                        )
      *                                    )
-     * @return void
+     * @return string
      */
     public function createConstraintSql($table, $name, $definition)
     {
@@ -472,7 +472,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
         $table  = $this->conn->quoteIdentifier($table);
         $name   = $this->conn->quoteIdentifier($name);
         $type   = '';
-        
+
         if (isset($definition['type'])) {
             switch (strtolower($definition['type'])) {
                 case 'unique':
@@ -494,7 +494,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
         $query .= ' (' . implode(', ', $fields) . ')';
 
         return $query;
-    }    
+    }
     /**
      * createForeignKeySql
      *
@@ -520,7 +520,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
     public function createForeignKey($table, array $definition)
     {
         $sql = $this->createForeignKeySql($table, $definition);
-        
+
         return $this->conn->execute($sql);
     }
 
@@ -616,7 +616,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
     public function alterTable($name, array $changes, $check = false)
     {
         $sql = $this->alterTableSql($name, $changes, $check);
-        
+
         if (is_string($sql) && $sql) {
             $this->conn->execute($sql);
         }
@@ -783,7 +783,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
 
         return $default;
     }
-    
+
 
     /**
      * getNotNullFieldDeclaration
@@ -797,7 +797,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
     {
         return (isset($definition['notnull']) && $definition['notnull']) ? ' NOT NULL' : '';
     }
-    
+
 
     /**
      * Obtain DBMS specific SQL code portion needed to set a CHECK constraint
@@ -1237,9 +1237,9 @@ class Doctrine_Export extends Doctrine_Connection_Module
     public function exportClassesSql(array $classes)
     {
         $models = Doctrine_Core::filterInvalidModels($classes);
-        
+
         $sql = array();
-        
+
         foreach ($models as $name) {
             $record = new $name();
             $table = $record->getTable();
@@ -1271,14 +1271,14 @@ class Doctrine_Export extends Doctrine_Connection_Module
             if ($table->getAttribute(Doctrine_Core::ATTR_EXPORT) & Doctrine_Core::EXPORT_PLUGINS) {
                 $sql = array_merge($sql, $this->exportGeneratorsSql($table));
             }
-            
+
             // DC-474: Remove dummy $record from repository to not pollute it during export
             $table->getRepository()->evict($record->getOid());
             unset($record);
         }
-        
+
         $sql = array_unique($sql);
-        
+
         rsort($sql);
 
         return $sql;
@@ -1296,13 +1296,13 @@ class Doctrine_Export extends Doctrine_Connection_Module
 
         foreach ($table->getGenerators() as $name => $generator) {
             if ($generator === null) {
-                continue;                     	
+                continue;
             }
 
             $generators[] = $generator;
 
             $generatorTable = $generator->getTable();
-            
+
             if ($generatorTable instanceof Doctrine_Table) {
                 $generators = array_merge($generators, $this->getAllGenerators($generatorTable));
             }
@@ -1324,7 +1324,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
 
         foreach ($this->getAllGenerators($table) as $name => $generator) {
             $table = $generator->getTable();
-            
+
             // Make sure plugin has a valid table
             if ($table instanceof Doctrine_Table) {
                 $data = $table->getExportableFormat();
@@ -1360,7 +1360,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
         } else {
             $models = Doctrine_Core::getLoadedModels();
         }
-        
+
         return $this->exportSortedClassesSql($models, false);
     }
 

--- a/lib/Doctrine/Export/Mssql.php
+++ b/lib/Doctrine/Export/Mssql.php
@@ -74,7 +74,7 @@ class Doctrine_Export_Mssql extends Doctrine_Export
     public function getTemporaryTableQuery()
     {
         return '';
-    }  
+    }
 
     public function dropIndexSql($table, $name)
     {
@@ -228,7 +228,7 @@ class Doctrine_Export_Mssql extends Doctrine_Export
 
             $dropped = array();
             foreach ($changes['remove'] as $fieldName => $field) {
-                
+
                 $fieldName = $this->conn->quoteIdentifier($fieldName, true);
                 $dropped[] = $fieldName;
             }
@@ -368,7 +368,7 @@ class Doctrine_Export_Mssql extends Doctrine_Export
      * This function drops an existing sequence
      *
      * @param string $seqName      name of the sequence to be dropped
-     * @return void
+     * @return string
      */
     public function dropSequenceSql($seqName)
     {
@@ -439,7 +439,7 @@ class Doctrine_Export_Mssql extends Doctrine_Export
         }
 
         $query = 'CREATE TABLE ' . $this->conn->quoteIdentifier($name, true) . ' (' . $queryFields;
-        
+
         $check = $this->getCheckDeclaration($fields);
 
         if ( ! empty($check)) {
@@ -449,7 +449,7 @@ class Doctrine_Export_Mssql extends Doctrine_Export
         $query .= ')';
 
         $sql[] = $query;
-        
+
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach($options['indexes'] as $index => $definition) {
                 if (is_array($definition)) {
@@ -457,7 +457,7 @@ class Doctrine_Export_Mssql extends Doctrine_Export
                 }
             }
         }
-        
+
         if (isset($options['foreignKeys'])) {
             foreach ((array) $options['foreignKeys'] as $k => $definition) {
                 if (is_array($definition)) {
@@ -480,7 +480,7 @@ class Doctrine_Export_Mssql extends Doctrine_Export
     public function getNotNullFieldDeclaration(array $definition)
     {
         return (
-            (isset($definition['notnull']) && $definition['notnull']) || 
+            (isset($definition['notnull']) && $definition['notnull']) ||
             (isset($definition['primary']) && $definition['primary'])
         ) ? ' NOT NULL' : ' NULL';
     }
@@ -518,7 +518,7 @@ class Doctrine_Export_Mssql extends Doctrine_Export
                 ? 'NULL'
                 : $this->conn->quote($field['default'], $field['type']));
         }
-        
+
         return $default;
     }
 }

--- a/lib/Doctrine/Export/Mysql.php
+++ b/lib/Doctrine/Export/Mysql.php
@@ -57,7 +57,7 @@ class Doctrine_Export_Mysql extends Doctrine_Export
     /**
      * createDatabaseSql
      *
-     * @param string $name 
+     * @param string $name
      * @return void
      */
     public function createDatabaseSql($name)
@@ -69,7 +69,7 @@ class Doctrine_Export_Mysql extends Doctrine_Export
      * drop an existing database
      *
      * @param string $name name of the database that should be dropped
-     * @return string
+     * @return array
      */
     public function dropDatabaseSql($name)
     {
@@ -114,7 +114,7 @@ class Doctrine_Export_Mysql extends Doctrine_Export
      *
      * @return void
      */
-    public function createTableSql($name, array $fields, array $options = array()) 
+    public function createTableSql($name, array $fields, array $options = array())
     {
         if ( ! $name)
             throw new Doctrine_Export_Exception('no valid table name specified');
@@ -132,8 +132,8 @@ class Doctrine_Export_Mysql extends Doctrine_Export
                 if (isset($options['indexes'])) {
                     foreach ($options['indexes'] as $definition) {
                         if (is_string($definition['fields'])) {
-                            // Check if index already exists on the column                            
-                            $found = $found || ($local == $definition['fields']);                    
+                            // Check if index already exists on the column
+                            $found = $found || ($local == $definition['fields']);
                         } else if (in_array($local, $definition['fields']) && count($definition['fields']) === 1) {
                             // Index already exists on the column
                             $found = true;
@@ -145,14 +145,14 @@ class Doctrine_Export_Mysql extends Doctrine_Export
                     // field is part of the PK and therefore already indexed
                     $found = true;
                 }
-                
+
                 if ( ! $found) {
                     if (is_array($local)) {
                       foreach($local as $localidx) {
                         $options['indexes'][$localidx] = array('fields' => array($localidx => array()));
                       }
                     } else {
-                      $options['indexes'][$local] = array('fields' => array($local => array()));                      
+                      $options['indexes'][$local] = array('fields' => array($local => array()));
                     }
                 }
             }
@@ -288,8 +288,8 @@ class Doctrine_Export_Mysql extends Doctrine_Export
             } else {
                 $dec = $this->conn->dataDict->getNativeDeclaration($field);
             }
-    
-            return $this->conn->quoteIdentifier($name, true) 
+
+            return $this->conn->quoteIdentifier($name, true)
                  . ' ' . $dec . $charset . $default . $notnull . $comment . $unique . $check . $collation;
         } catch (Exception $e) {
             throw new Doctrine_Exception('Around field ' . $name . ': ' . $e->getMessage() . "\n\n" . $e->getTraceAsString() . "\n\n");
@@ -450,7 +450,7 @@ class Doctrine_Export_Mysql extends Doctrine_Export
                     $oldFieldName = $fieldName;
                 }
                 $oldFieldName = $this->conn->quoteIdentifier($oldFieldName, true);
-                $query .= 'CHANGE ' . $oldFieldName . ' ' 
+                $query .= 'CHANGE ' . $oldFieldName . ' '
                         . $this->getDeclaration($fieldName, $field['definition']);
             }
         }
@@ -472,7 +472,7 @@ class Doctrine_Export_Mysql extends Doctrine_Export
         }
 
         $name = $this->conn->quoteIdentifier($name, true);
-        
+
         return 'ALTER TABLE ' . $name . ' ' . $query;
     }
 
@@ -612,7 +612,7 @@ class Doctrine_Export_Mysql extends Doctrine_Export
         return $query;
     }
 
-    /** 
+    /**
      * getDefaultDeclaration
      * Obtain DBMS specific SQL code portion needed to set a default value
      * declaration to be used in statements like CREATE TABLE.
@@ -634,25 +634,25 @@ class Doctrine_Export_Mysql extends Doctrine_Export
                     $field['default'] = ' ';
                 }
             }
-    
+
             // Proposed patch:
             if ($field['type'] == 'enum' && $this->conn->getAttribute(Doctrine_Core::ATTR_USE_NATIVE_ENUM)) {
                 $fieldType = 'varchar';
             } else {
                 $fieldType = $field['type'];
             }
-            
+
             $default = ' DEFAULT ' . (is_null($field['default'])
-                ? 'NULL' 
+                ? 'NULL'
                 : $this->conn->quote($field['default'], $fieldType));
             //$default = ' DEFAULT ' . $this->conn->quote($field['default'], $field['type']);
         }
-        
+
         return $default;
     }
 
     /**
-     * Obtain DBMS specific SQL code portion needed to set an index 
+     * Obtain DBMS specific SQL code portion needed to set an index
      * declaration to be used in statements like CREATE TABLE.
      *
      * @param string $charset       name of the index
@@ -675,7 +675,7 @@ class Doctrine_Export_Mysql extends Doctrine_Export
                     );
             }
         }
-        
+
         if ( ! isset($definition['fields'])) {
             throw new Doctrine_Export_Exception('No columns given for index ' . $name);
         }
@@ -686,7 +686,7 @@ class Doctrine_Export_Mysql extends Doctrine_Export
         $query = $type . 'INDEX ' . $this->conn->quoteIdentifier($name);
 
         $query .= ' (' . $this->getIndexFieldDeclarationList($definition['fields']) . ')';
-        
+
         return $query;
     }
 

--- a/lib/Doctrine/Export/Oracle.php
+++ b/lib/Doctrine/Export/Oracle.php
@@ -76,10 +76,10 @@ class Doctrine_Export_Oracle extends Doctrine_Export
 BEGIN
   -- user_tables contains also materialized views
   FOR I IN (SELECT table_name FROM user_tables WHERE table_name NOT IN (SELECT mview_name FROM user_mviews))
-  LOOP 
+  LOOP
     EXECUTE IMMEDIATE 'DROP TABLE "'||I.table_name||'" CASCADE CONSTRAINTS';
   END LOOP;
-  
+
   FOR I IN (SELECT SEQUENCE_NAME FROM USER_SEQUENCES)
   LOOP
     EXECUTE IMMEDIATE 'DROP SEQUENCE "'||I.SEQUENCE_NAME||'"';
@@ -117,7 +117,7 @@ SQL;
             'primary' => true,
             'fields' => array($name => true),
         );
-		
+
         $sql[] = 'DECLARE
   constraints_Count NUMBER;
 BEGIN
@@ -125,8 +125,8 @@ BEGIN
   IF constraints_Count = 0 THEN
     EXECUTE IMMEDIATE \''.$this->createConstraintSql($table, $indexName, $definition).'\';
   END IF;
-END;';   
-		
+END;';
+
         if (is_null($start)) {
             $query = 'SELECT MAX(' . $this->conn->quoteIdentifier($name, true) . ') FROM ' . $this->conn->quoteIdentifier($table, true);
             $start = $this->conn->fetchOne($query);
@@ -305,7 +305,7 @@ END;';
      *                        );
      * @param array $options  An associative array of table options:
      *
-     * @return void
+     * @return array
      */
     public function createTableSql($name, array $fields, array $options = array())
     {
@@ -321,25 +321,25 @@ END;';
             }
 
             if (isset($field['autoincrement']) && $field['autoincrement'] ||
-               (isset($field['autoinc']) && $fields['autoinc'])) {           
+               (isset($field['autoinc']) && $fields['autoinc'])) {
                 $sql = array_merge($sql, $this->_makeAutoincrement($fieldName, $name));
             }
 
             if (isset($field['comment']) && ! empty($field['comment'])){
-                $sql[] = $this->_createColumnCommentSql($name,$fieldName,$field['comment']); 
+                $sql[] = $this->_createColumnCommentSql($name,$fieldName,$field['comment']);
             }
         }
-        
+
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $indexName => $definition) {
                 // create nonunique indexes, as they are a part od CREATE TABLE DDL
-                if ( ! isset($definition['type']) || 
+                if ( ! isset($definition['type']) ||
                     (isset($definition['type']) && strtolower($definition['type']) != 'unique')) {
                     $sql[] = $this->createIndexSql($name, $indexName, $definition);
                 }
             }
         }
-        
+
         return $sql;
     }
 
@@ -379,10 +379,9 @@ END;';
     public function dropTable($name)
     {
         //$this->conn->beginNestedTransaction();
-        $result = $this->dropAutoincrement($name);
-        $result = parent::dropTable($name);
+        $this->dropAutoincrement($name);
+        parent::dropTable($name);
         //$this->conn->completeNestedTransaction();
-        return $result;
     }
 
     /**
@@ -498,7 +497,7 @@ END;';
         if ( ! empty($changes['add']) && is_array($changes['add'])) {
             $fields = array();
             foreach ($changes['add'] as $fieldName => $field) {
-                $fields[] = $this->getDeclaration($fieldName, $field); 
+                $fields[] = $this->getDeclaration($fieldName, $field);
             }
             $result = $this->conn->exec('ALTER TABLE ' . $name . ' ADD (' . implode(', ', $fields) . ')');
         }
@@ -571,16 +570,16 @@ END;';
     /**
      * return Oracle's SQL code portion needed to set an index
      * declaration to be unsed in statements like CREATE TABLE.
-     * 
+     *
      * @param string $name      name of the index
      * @param array $definition index definition
-     * @return string           Oracle's SQL code portion needed to set an index  
-     */    
+     * @return string           Oracle's SQL code portion needed to set an index
+     */
     public function getIndexDeclaration($name, array $definition)
     {
         $name = $this->conn->quoteIdentifier($name);
         $type = '';
-        
+
         if ( isset($definition['type']))
         {
             if (strtolower($definition['type']) == 'unique') {
@@ -594,13 +593,13 @@ END;';
             // only unique indexes should be defined in create table statement
             return null;
         }
-        
+
         if ( !isset($definition['fields']) || !is_array($definition['fields'])) {
             throw new Doctrine_Export_Exception('No columns given for index '.$name);
         }
-        
+
         $query = 'CONSTRAINT '.$name.' '.$type.' ('.$this->getIndexFieldDeclarationList($definition['fields']).')';
-        
+
         return $query;
     }
 }

--- a/lib/Doctrine/Export/Pgsql.php
+++ b/lib/Doctrine/Export/Pgsql.php
@@ -38,13 +38,13 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
     /**
      * createDatabaseSql
      *
-     * @param string $name 
+     * @param string $name
      * @return void
      */
     public function createDatabaseSql($name)
     {
         $query  = 'CREATE DATABASE ' . $this->conn->quoteIdentifier($name);
-        
+
         return $query;
     }
 
@@ -54,11 +54,12 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
      * @param string $name name of the database that should be dropped
      * @throws PDOException
      * @access public
+     * @return string
      */
     public function dropDatabaseSql($name)
     {
         $query  = 'DROP DATABASE ' . $this->conn->quoteIdentifier($name);
-        
+
         return $query;
     }
 
@@ -125,7 +126,7 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
         if ($check) {
             return true;
         }
-        
+
         $sql = array();
 
         if (isset($changes['add']) && is_array($changes['add'])) {
@@ -178,10 +179,10 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
             $changeName = $this->conn->quoteIdentifier($changes['name'], true);
             $sql[] = 'ALTER TABLE ' . $this->conn->quoteIdentifier($name, true) . ' RENAME TO ' . $changeName;
         }
-        
+
         return $sql;
     }
-    
+
     /**
      * alter an existing table
      *
@@ -277,7 +278,7 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
         foreach ($sql as $query) {
             $this->conn->exec($query);
         }
-        return true;    
+        return true;
     }
 
     /**
@@ -305,6 +306,7 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
      * drop existing sequence
      *
      * @param string $sequenceName name of the sequence to be dropped
+     * @return string
      */
     public function dropSequenceSql($sequenceName)
     {
@@ -315,17 +317,17 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
     /**
      * Creates a table.
      *
-     * @param unknown_type $name
+     * @param string $name
      * @param array $fields
      * @param array $options
-     * @return unknown
+     * @return array
      */
     public function createTableSql($name, array $fields, array $options = array())
     {
         if ( ! $name) {
             throw new Doctrine_Export_Exception('no valid table name specified');
         }
-        
+
         if (empty($fields)) {
             throw new Doctrine_Export_Exception('no fields specified for table ' . $name);
         }
@@ -358,7 +360,7 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
                 $sql[] = $this->createIndexSql($name, $index, $definition);
             }
         }
-        
+
         if (isset($options['foreignKeys'])) {
 
             foreach ((array) $options['foreignKeys'] as $k => $definition) {
@@ -375,7 +377,7 @@ class Doctrine_Export_Pgsql extends Doctrine_Export
 
      /**
      * Get the stucture of a field into an array.
-     * 
+     *
      * @param string    $table         name of the table on which the index is to be created
      * @param string    $name          name of the index to be created
      * @param array     $definition    associative array that defines properties of the index to be created.

--- a/lib/Doctrine/Export/Schema.php
+++ b/lib/Doctrine/Export/Schema.php
@@ -21,7 +21,7 @@
 
 /**
  * Doctrine_Export_Schema
- * 
+ *
  * Used for exporting a schema to a yaml file
  *
  * @package     Doctrine
@@ -33,16 +33,16 @@
  * @author      Jonathan H. Wage <jwage@mac.com>
  */
 class Doctrine_Export_Schema
-{    
+{
     /**
      * buildSchema
-     * 
+     *
      * Build schema array that can be dumped to file
      *
      * @param string $directory  The directory of models to build the schema from
      * @param array $models      The array of model names to build the schema for
      * @param integer $modelLoading The model loading strategy to use to load the models from the passed directory
-     * @return void
+     * @return array
      */
     public function buildSchema($directory = null, $models = array(), $modelLoading = null)
     {
@@ -51,9 +51,9 @@ class Doctrine_Export_Schema
         } else {
             $loadedModels = Doctrine_Core::getLoadedModels();
         }
-        
+
         $array = array();
-        
+
         $parent = new ReflectionClass('Doctrine_Record');
 
         $sql = array();
@@ -67,9 +67,9 @@ class Doctrine_Export_Schema
             }
 
             $recordTable = Doctrine_Core::getTable($className);
-            
+
             $data = $recordTable->getExportableFormat();
-            
+
             $table = array();
             $table['connection'] = $recordTable->getConnection()->getName();
             $remove = array('ptype', 'ntype', 'alltypes');
@@ -88,7 +88,7 @@ class Doctrine_Export_Schema
                         unset($data['columns'][$name][$value]);
                     }
                 }
-                
+
                 // If type is the only property of the column then lets abbreviate the syntax
                 // columns: { name: string(255) }
                 if (count($data['columns'][$name]) === 1 && isset($data['columns'][$name]['type'])) {
@@ -99,24 +99,24 @@ class Doctrine_Export_Schema
             }
             $table['tableName'] = $data['tableName'];
             $table['columns'] = $data['columns'];
-            
+
             $relations = $recordTable->getRelations();
             foreach ($relations as $key => $relation) {
                 $relationData = $relation->toArray();
-                
+
                 $relationKey = $relationData['alias'];
-                
+
                 if (isset($relationData['refTable']) && $relationData['refTable']) {
                     $table['relations'][$relationKey]['refClass'] = $relationData['refTable']->getComponentName();
                 }
-                
+
                 if (isset($relationData['class']) && $relationData['class'] && $relation['class'] != $relationKey) {
                     $table['relations'][$relationKey]['class'] = $relationData['class'];
                 }
- 
+
                 $table['relations'][$relationKey]['local'] = $relationData['local'];
                 $table['relations'][$relationKey]['foreign'] = $relationData['foreign'];
-                
+
                 if ($relationData['type'] === Doctrine_Relation::ONE) {
                     $table['relations'][$relationKey]['type'] = 'one';
                 } else if ($relationData['type'] === Doctrine_Relation::MANY) {
@@ -125,18 +125,18 @@ class Doctrine_Export_Schema
                     $table['relations'][$relationKey]['type'] = 'one';
                 }
             }
-            
+
             $array[$className] = $table;
         }
-        
+
         return $array;
     }
 
     /**
      * exportSchema
      *
-     * @param  string $schema 
-     * @param  string $directory 
+     * @param  string $schema
+     * @param  string $directory
      * @param string $string of data in the specified format
      * @param integer $modelLoading The model loading strategy to use to load the models from the passed directory
      * @return void
@@ -144,11 +144,11 @@ class Doctrine_Export_Schema
     public function exportSchema($schema, $format = 'yml', $directory = null, $models = array(), $modelLoading = null)
     {
         $array = $this->buildSchema($directory, $models, $modelLoading);
-        
+
         if (is_dir($schema)) {
           $schema = $schema . DIRECTORY_SEPARATOR . 'schema.' . $format;
         }
-        
+
         return Doctrine_Parser::dump($array, $format, $schema);
     }
 }

--- a/lib/Doctrine/Export/Sqlite.php
+++ b/lib/Doctrine/Export/Sqlite.php
@@ -98,7 +98,7 @@ class Doctrine_Export_Sqlite extends Doctrine_Export
      *                                        )
      *                                    )
      * @throws PDOException
-     * @return void
+     * @return string
      */
     public function createIndexSql($table, $name, array $definition)
     {
@@ -129,7 +129,7 @@ class Doctrine_Export_Sqlite extends Doctrine_Export
      * Obtain DBMS specific SQL code portion needed to set an index
      * declaration to be used in statements like CREATE TABLE.
      *
-     * @return string   
+     * @return string
      */
     public function getIndexFieldDeclarationList(array $fields)
     {
@@ -191,15 +191,15 @@ class Doctrine_Export_Sqlite extends Doctrine_Export
         if ( ! $name) {
             throw new Doctrine_Export_Exception('no valid table name specified');
         }
-        
+
         if (empty($fields)) {
             throw new Doctrine_Export_Exception('no fields specified for table '.$name);
         }
         $queryFields = $this->getFieldDeclarationList($fields);
-        
+
         $autoinc = false;
         foreach($fields as $field) {
-            if (isset($field['autoincrement']) && $field['autoincrement'] || 
+            if (isset($field['autoincrement']) && $field['autoincrement'] ||
               (isset($field['autoinc']) && $field['autoinc'])) {
                 $autoinc = true;
                 break;
@@ -299,10 +299,10 @@ class Doctrine_Export_Sqlite extends Doctrine_Export
             $this->conn->exec('INSERT INTO ' . $sequenceName . ' (' . $seqcolName . ') VALUES (' . ($start-1) . ')');
             return true;
         } catch(Doctrine_Connection_Exception $e) {
-            // Handle error    
+            // Handle error
 
             try {
-                $result = $db->exec('DROP TABLE ' . $sequenceName);
+                $result = $this->conn->exec('DROP TABLE ' . $sequenceName);
             } catch(Doctrine_Connection_Exception $e) {
                 throw new Doctrine_Export_Exception('could not drop inconsistent sequence table');
             }
@@ -322,7 +322,7 @@ class Doctrine_Export_Sqlite extends Doctrine_Export
 
         return 'DROP TABLE ' . $sequenceName;
     }
-    
+
     public function alterTableSql($name, array $changes, $check = false)
     {
         if ( ! $name) {
@@ -378,7 +378,7 @@ class Doctrine_Export_Sqlite extends Doctrine_Export
                     $oldFieldName = $fieldName;
                 }
                 $oldFieldName = $this->conn->quoteIdentifier($oldFieldName, true);
-                $query .= 'CHANGE ' . $oldFieldName . ' ' 
+                $query .= 'CHANGE ' . $oldFieldName . ' '
                         . $this->getDeclaration($fieldName, $field['definition']);
             }
         }
@@ -400,7 +400,7 @@ class Doctrine_Export_Sqlite extends Doctrine_Export
         }
 
         $name = $this->conn->quoteIdentifier($name, true);
-        
+
         return 'ALTER TABLE ' . $name . ' ' . $query;
     }
 

--- a/lib/Doctrine/Expression/Pgsql.php
+++ b/lib/Doctrine/Expression/Pgsql.php
@@ -163,7 +163,7 @@ class Doctrine_Expression_Pgsql extends Doctrine_Expression_Driver
     /**
      * return string to call a function to get random value inside an SQL statement
      *
-     * @return return string to generate float between 0 and 1
+     * @return string string to generate float between 0 and 1
      * @access public
      */
     public function random()
@@ -242,7 +242,7 @@ class Doctrine_Expression_Pgsql extends Doctrine_Expression_Driver
     {
         return $this->position($substr, $str);
     }
-    
+
     /**
      * position
      *
@@ -254,7 +254,7 @@ class Doctrine_Expression_Pgsql extends Doctrine_Expression_Driver
     {
         $substr = $this->getIdentifier($substr);
         $str = $this->getIdentifier($str);
-        
+
         return sprintf('POSITION(%s IN %s)', $substr, $str);
     }
 }

--- a/lib/Doctrine/Hook/Integer.php
+++ b/lib/Doctrine/Hook/Integer.php
@@ -42,7 +42,7 @@ class Doctrine_Hook_Integer extends Doctrine_Hook_Parser_Complex
      * @param string $alias     component alias
      * @param string $field     the field name
      * @param mixed $value      the value of the field
-     * @return void
+     * @return string
      */
     public function parseSingle($alias, $field, $value)
     {

--- a/lib/Doctrine/Hook/Parser/Complex.php
+++ b/lib/Doctrine/Hook/Parser/Complex.php
@@ -33,7 +33,7 @@
 abstract class Doctrine_Hook_Parser_Complex extends Doctrine_Hook_Parser
 {
     protected $_tokenizer;
-    
+
     /**
      * Constructor.
      */
@@ -41,7 +41,7 @@ abstract class Doctrine_Hook_Parser_Complex extends Doctrine_Hook_Parser
     {
         $this->_tokenizer = new Doctrine_Query_Tokenizer();
     }
-    
+
     /**
      * parse
      * Parses given field and field value to DQL condition
@@ -65,7 +65,7 @@ abstract class Doctrine_Hook_Parser_Complex extends Doctrine_Hook_Parser
      * @param string $alias     component alias
      * @param string $field     the field name
      * @param mixed $value      the value of the field
-     * @return void
+     * @return string
      */
     public function parseClause($alias, $field, $value)
     {
@@ -101,7 +101,7 @@ abstract class Doctrine_Hook_Parser_Complex extends Doctrine_Hook_Parser
      * @param string $alias     component alias
      * @param string $field     the field name
      * @param mixed $value      the value of the field
-     * @return void
+     * @return string
      */
     abstract public function parseSingle($alias, $field, $value);
 }

--- a/lib/Doctrine/Hook/WordLike.php
+++ b/lib/Doctrine/Hook/WordLike.php
@@ -42,19 +42,19 @@ class Doctrine_Hook_WordLike extends Doctrine_Hook_Parser_Complex
      * @param string $alias     component alias
      * @param string $field     the field name
      * @param mixed $value      the value of the field
-     * @return void
+     * @return string
      */
     public function parseSingle($alias, $field, $value)
     {
         if (strpos($value, "'") !== false) {
             $value = $this->_tokenizer->bracketTrim($value, "'", "'");
-        
+
             $a[]   = $alias . '.' . $field . ' LIKE ?';
             $this->params[] = '%' . $value . '%';
 
         } else {
             $e2 = explode(' ',$value);
-    
+
             foreach ($e2 as $v) {
                 $v = trim($v);
                 $a[] = $alias . '.' . $field . ' LIKE ?';

--- a/lib/Doctrine/Hydrator/RecordDriver.php
+++ b/lib/Doctrine/Hydrator/RecordDriver.php
@@ -44,7 +44,7 @@ class Doctrine_Hydrator_RecordDriver extends Doctrine_Hydrator_Graph
 
         return $coll;
     }
-    
+
     public function initRelated(&$record, $name, $keyColumn = null)
     {
         if ( ! isset($this->_initializedRelations[$record->getOid()][$name])) {
@@ -56,20 +56,20 @@ class Doctrine_Hydrator_RecordDriver extends Doctrine_Hydrator_Graph
         }
         return true;
     }
-    
+
     public function registerCollection($coll)
     {
         $this->_collections[] = $coll;
     }
-    
-    public function getNullPointer() 
+
+    public function getNullPointer()
     {
         return self::$_null;
     }
-    
+
     public function getElement(array $data, $component)
     {
-        $component = $this->_getClassNameToReturn($data, $component);
+        $component = $this->_getClassnameToReturn($data, $component);
 
         $this->_tables[$component]->setData($data);
         $record = $this->_tables[$component]->getRecord();
@@ -77,10 +77,10 @@ class Doctrine_Hydrator_RecordDriver extends Doctrine_Hydrator_Graph
         return $record;
     }
 
-    public function getLastKey(&$coll) 
+    public function getLastKey(&$coll)
     {
         $coll->end();
-        
+
         return $coll->key();
     }
 
@@ -105,7 +105,7 @@ class Doctrine_Hydrator_RecordDriver extends Doctrine_Hydrator_Graph
             $prev[$dqlAlias] = $coll[$index];
             return;
         }
-        
+
         if (count($coll) > 0) {
             $prev[$dqlAlias] = $coll->getLast();
         }

--- a/lib/Doctrine/Import/Builder.php
+++ b/lib/Doctrine/Import/Builder.php
@@ -129,11 +129,11 @@ class Doctrine_Import_Builder extends Doctrine_Builder
      */
     protected $_classPrefix = null;
 
-    /** 
-     * Whether to use the class prefix for the filenames too 
-     * 
-     * @var boolean 
-     **/ 
+    /**
+     * Whether to use the class prefix for the filenames too
+     *
+     * @var boolean
+     **/
     protected $_classPrefixFiles = true;
 
     /**
@@ -425,11 +425,11 @@ class Doctrine_Import_Builder extends Doctrine_Builder
                 if (isset($relation['refClass'])) {
                     $a[] = '\'refClass\' => ' . $this->varExport($relation['refClass']);
                 }
-                
+
                 if (isset($relation['refClassRelationAlias'])) {
                     $a[] = '\'refClassRelationAlias\' => ' . $this->varExport($relation['refClassRelationAlias']);
                 }
-                
+
                 if (isset($relation['deferred']) && $relation['deferred']) {
                     $a[] = '\'default\' => ' . $this->varExport($relation['deferred']);
                 }
@@ -520,8 +520,8 @@ class Doctrine_Import_Builder extends Doctrine_Builder
     /**
      * buildColumns
      *
-     * @param string $array
-     * @return void
+     * @param array $array
+     * @return string|null
      */
     public function buildColumns(array $columns)
     {
@@ -536,12 +536,12 @@ class Doctrine_Import_Builder extends Doctrine_Builder
                     sprintf('When using a column alias you cannot pass it via column name and column alias definition (column: %s).', $column['name'])
                 );
             }
-            
+
             // Update column name if an alias is provided
             if (isset($column['alias']) && !isset($column['name'])) {
                 $column['name'] = $name . ' as ' . $column['alias'];
             }
-          
+
             $columnName = isset($column['name']) ? $column['name']:$name;
             if ($manager->getAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE)) {
                 $e = explode(' as ', $columnName);
@@ -798,17 +798,17 @@ class Doctrine_Import_Builder extends Doctrine_Builder
                         } else {
                             $leftActAs[$name] = $options[$name];
                         }
-                    } 
+                    }
 
                     $optionPHP = $this->varExport($realOptions);
-                    $build .= $this->emitAssign($level, $template, $optionPHP); 
+                    $build .= $this->emitAssign($level, $template, $optionPHP);
                     if ($level == 0) {
                         $emittedActAs[] = $this->emitActAs($level, $template);
                     } else {
                         $build .= $this->emitAddChild($level, $currentParent, $template);
                     }
                     // descend for the remainings actAs
-                    $parent = $template;            
+                    $parent = $template;
                     $build .= $this->innerBuildActAs($leftActAs, $level, $template, $emittedActAs);
                 } else {
                     $build .= $this->emitAssign($level, $template, null);
@@ -817,7 +817,7 @@ class Doctrine_Import_Builder extends Doctrine_Builder
                     } else {
                         $build .= $this->emitAddChild($level, $currentParent, $template);
                     }
-                    $parent = $template;            
+                    $parent = $template;
                 }
             }
         } else {
@@ -835,20 +835,20 @@ class Doctrine_Import_Builder extends Doctrine_Builder
     /**
      * Build php code for adding record listeners
      *
-     * @param string $listeners 
+     * @param string $listeners
      * @return string $build
      */
     public function buildListeners($listeners)
     {
         $build = '';
-        
+
         foreach($listeners as $name => $options) {
             if ( ! is_array($options) && $options !== null) {
                 $name = $options;
                 $options = null;
             }
 
-            $useOptions = ( ! empty($options) && isset($options['useOptions']) && $options['useOptions'] == true) 
+            $useOptions = ( ! empty($options) && isset($options['useOptions']) && $options['useOptions'] == true)
                 ? '$this->getTable()->getOptions()' : 'array()';
             $class = ( ! empty($options) && isset($options['class'])) ? $options['class'] : $name;
 
@@ -861,14 +861,14 @@ class Doctrine_Import_Builder extends Doctrine_Builder
     /**
      * buildAttributes
      *
-     * @param string $array
-     * @return void
+     * @param array $array
+     * @return string
      */
     public function buildAttributes(array $attributes)
     {
         $build = PHP_EOL;
         foreach ($attributes as $key => $value) {
-    
+
             $values = array();
             if (is_bool($value))
             {
@@ -877,7 +877,7 @@ class Doctrine_Import_Builder extends Doctrine_Builder
                 if ( ! is_array($value)) {
                     $value = array($value);
                 }
-    
+
                 foreach ($value as $attr) {
                     $const = "Doctrine_Core::" . strtoupper($key) . "_" . strtoupper($attr);
                     if (defined($const)) {
@@ -887,19 +887,19 @@ class Doctrine_Import_Builder extends Doctrine_Builder
                     }
                 }
             }
-    
+
             $string = implode(' ^ ', $values);
             $build .= "        \$this->setAttribute(Doctrine_Core::ATTR_" . strtoupper($key) . ", " . $string . ");" . PHP_EOL;
         }
-    
+
         return $build;
     }
 
     /**
      * buildTableOptions
      *
-     * @param string $array
-     * @return void
+     * @param array $array
+     * @return string
      */
     public function buildOptions(array $options)
     {
@@ -914,8 +914,8 @@ class Doctrine_Import_Builder extends Doctrine_Builder
     /**
      * buildIndexes
      *
-     * @param string $array
-     * @return void
+     * @param array $array
+     * @return string
      */
     public function buildIndexes(array $indexes)
     {
@@ -977,7 +977,7 @@ class Doctrine_Import_Builder extends Doctrine_Builder
         }
 
         $setUpCode.= $this->buildToString($definition);
-        
+
         $docs = PHP_EOL . $this->buildPhpDocs($definition);
 
         $content = sprintf(self::$_tpl, $docs, $abstract,
@@ -1127,7 +1127,7 @@ class Doctrine_Import_Builder extends Doctrine_Builder
         if ($prefix = $this->_classPrefix) {
             $className = $prefix . $definition['tableClassName'];
             if ($this->_classPrefixFiles) {
-                $fileName = $className . $this->_suffix;               
+                $fileName = $className . $this->_suffix;
             } else {
                 $fileName = $definition['tableClassName'] . $this->_suffix;
             }

--- a/lib/Doctrine/Import/Schema.php
+++ b/lib/Doctrine/Import/Schema.php
@@ -154,7 +154,7 @@ class Doctrine_Import_Schema
 
     /**
      * Returns an array of definition keys that can be applied at the global level.
-     * 
+     *
      * @return array
      */
     public static function getGlobalDefinitionKeys()
@@ -165,7 +165,7 @@ class Doctrine_Import_Schema
     /**
      * getOption
      *
-     * @param string $name 
+     * @param string $name
      * @return void
      */
     public function getOption($name)
@@ -178,7 +178,7 @@ class Doctrine_Import_Schema
     /**
      * getOptions
      *
-     * @return void
+     * @return array
      */
     public function getOptions()
     {
@@ -188,8 +188,8 @@ class Doctrine_Import_Schema
     /**
      * setOption
      *
-     * @param string $name 
-     * @param string $value 
+     * @param string $name
+     * @param string $value
      * @return void
      */
     public function setOption($name, $value)
@@ -198,11 +198,11 @@ class Doctrine_Import_Schema
             $this->_options[$name] = $value;
         }
     }
-    
+
     /**
      * setOptions
      *
-     * @param string $options 
+     * @param string $options
      * @return void
      */
     public function setOptions($options)
@@ -230,7 +230,7 @@ class Doctrine_Import_Schema
                 $e = explode('.', $s);
                 if (end($e) === $format) {
                     $array = array_merge($array, $this->parseSchema($s, $format));
-                }          
+                }
             } else if (is_dir($s)) {
                 $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($s),
                                                       RecursiveIteratorIterator::LEAVES_ONLY);
@@ -270,20 +270,20 @@ class Doctrine_Import_Schema
         $builder = new Doctrine_Import_Builder();
         $builder->setTargetPath($directory);
         $builder->setOptions($this->getOptions());
-        
+
         $array = $this->buildSchema($schema, $format);
 
-        if (count($array) == 0) { 
+        if (count($array) == 0) {
             throw new Doctrine_Import_Exception(
                 sprintf('No ' . $format . ' schema found in ' . implode(", ", $schema))
-            ); 
+            );
         }
 
         foreach ($array as $name => $definition) {
             if ( ! empty($models) && !in_array($definition['className'], $models)) {
                 continue;
             }
-            
+
             $builder->buildRecord($definition);
         }
     }
@@ -313,7 +313,7 @@ class Doctrine_Import_Schema
                           'package'             =>  null,
                           'inheritance'         =>  array(),
                           'detect_relations'    =>  false);
-        
+
         $array = Doctrine_Parser::load($schema, $type);
 
         // Loop over and build up all the global values and remove them from the array
@@ -431,14 +431,14 @@ class Doctrine_Import_Schema
                     $build[$className][$key] = isset($build[$className][$key]) ? $build[$className][$key]:$defaultValue;
                 }
             }
-            
+
             $build[$className]['className'] = $className;
             $build[$className]['tableName'] = $tableName;
             $build[$className]['columns'] = $columns;
-            
+
             // Make sure that anything else that is specified in the schema makes it to the final array
             $build[$className] = Doctrine_Lib::arrayDeepMerge($table, $build[$className]);
-            
+
             // We need to keep track of the className for the connection
             $build[$className]['connectionClassName'] = $build[$className]['className'];
         }
@@ -448,12 +448,12 @@ class Doctrine_Import_Schema
 
     /**
      * _processInheritance
-     * 
+     *
      * Perform some processing on inheritance.
      * Sets the default type and sets some default values for certain types
      *
-     * @param string $array 
-     * @return void
+     * @param array $array
+     * @return array
      */
     protected function _processInheritance($array)
     {
@@ -472,9 +472,9 @@ class Doctrine_Import_Schema
                 if ($array[$className]['inheritance']['type'] == 'column_aggregation') {
                     // Set the keyField to 'type' by default
                     if ( ! isset($array[$className]['inheritance']['keyField'])) {
-                        $array[$className]['inheritance']['keyField'] = 'type';                        
+                        $array[$className]['inheritance']['keyField'] = 'type';
                     }
-                    
+
                     // Set the keyValue to the name of the child class if it does not exist
                     if ( ! isset($array[$className]['inheritance']['keyValue'])) {
                         $array[$className]['inheritance']['keyValue'] = $className;
@@ -510,22 +510,22 @@ class Doctrine_Import_Schema
 
                 // Populate the parents subclasses
                 if ($definition['inheritance']['type'] == 'column_aggregation') {
-                    // Fix for 2015: loop through superclasses' inheritance to the base-superclass to  
-                    // make sure we collect all keyFields needed (and not only the first) 
-                    $inheritanceFields = array($definition['inheritance']['keyField'] => $definition['inheritance']['keyValue']); 
+                    // Fix for 2015: loop through superclasses' inheritance to the base-superclass to
+                    // make sure we collect all keyFields needed (and not only the first)
+                    $inheritanceFields = array($definition['inheritance']['keyField'] => $definition['inheritance']['keyValue']);
 
-                    $superClass = $definition['inheritance']['extends']; 
-                    $multiInheritanceDef = $array[$superClass]; 
+                    $superClass = $definition['inheritance']['extends'];
+                    $multiInheritanceDef = $array[$superClass];
 
-                    while (count($multiInheritanceDef['inheritance']) > 0 && array_key_exists('extends', $multiInheritanceDef['inheritance']) && $multiInheritanceDef['inheritance']['type'] == 'column_aggregation') { 
+                    while (count($multiInheritanceDef['inheritance']) > 0 && array_key_exists('extends', $multiInheritanceDef['inheritance']) && $multiInheritanceDef['inheritance']['type'] == 'column_aggregation') {
                         $superClass = $multiInheritanceDef['inheritance']['extends'];
-                        
+
                         // keep original keyField with it's keyValue
-                        if ( ! isset($inheritanceFields[$multiInheritanceDef['inheritance']['keyField']])) { 
+                        if ( ! isset($inheritanceFields[$multiInheritanceDef['inheritance']['keyField']])) {
                             $inheritanceFields[$multiInheritanceDef['inheritance']['keyField']] = $multiInheritanceDef['inheritance']['keyValue'];
-                        } 
-                        $multiInheritanceDef = $array[$superClass]; 
-                    } 
+                        }
+                        $multiInheritanceDef = $array[$superClass];
+                    }
 
                     $array[$parent]['inheritance']['subclasses'][$definition['className']] = $inheritanceFields;
                 }
@@ -555,11 +555,11 @@ class Doctrine_Import_Schema
      * buildRelationships
      *
      * Loop through an array of schema information and build all the necessary relationship information
-     * Will attempt to auto complete relationships and simplify the amount of information required 
+     * Will attempt to auto complete relationships and simplify the amount of information required
      * for defining a relationship
      *
-     * @param  string $array 
-     * @return void
+     * @param  array $array
+     * @return array
      */
     protected function _buildRelationships($array)
     {
@@ -591,10 +591,10 @@ class Doctrine_Import_Schema
             if ( ! isset($properties['relations'])) {
                 continue;
             }
-            
+
             $className = $properties['className'];
             $relations = $properties['relations'];
-            
+
             foreach ($relations as $alias => $relation) {
                 $class = isset($relation['class']) ? $relation['class']:$alias;
                 if ( ! isset($array[$class])) {
@@ -602,7 +602,7 @@ class Doctrine_Import_Schema
                 }
                 $relation['class'] = $class;
                 $relation['alias'] = isset($relation['alias']) ? $relation['alias'] : $alias;
-                
+
                 // Attempt to guess the local and foreign
                 if (isset($relation['refClass'])) {
                     $relation['local'] = isset($relation['local']) ? $relation['local']:Doctrine_Inflector::tableize($name) . '_id';
@@ -611,11 +611,11 @@ class Doctrine_Import_Schema
                     $relation['local'] = isset($relation['local']) ? $relation['local']:Doctrine_Inflector::tableize($relation['class']) . '_id';
                     $relation['foreign'] = isset($relation['foreign']) ? $relation['foreign']:'id';
                 }
-                
+
                 if (isset($relation['refClass'])) {
                     $relation['type'] = 'many';
                 }
-                
+
                 if (isset($relation['type']) && $relation['type']) {
                     $relation['type'] = $relation['type'] === 'one' ? Doctrine_Relation::ONE:Doctrine_Relation::MANY;
                 } else {
@@ -625,18 +625,18 @@ class Doctrine_Import_Schema
                 if (isset($relation['foreignType']) && $relation['foreignType']) {
                     $relation['foreignType'] = $relation['foreignType'] === 'one' ? Doctrine_Relation::ONE:Doctrine_Relation::MANY;
                 }
-                
+
                 $relation['key'] = $this->_buildUniqueRelationKey($relation);
-                
+
                 $this->_validateSchemaElement('relation', array_keys($relation), $className . '->relation->' . $relation['alias']);
-                
+
                 $this->_relations[$className][$alias] = $relation;
             }
         }
-        
+
         // Now we auto-complete opposite ends of relationships
         $this->_autoCompleteOppositeRelations();
-        
+
         // Make sure we do not have any duplicate relations
         $this->_fixDuplicateRelations();
 
@@ -644,7 +644,7 @@ class Doctrine_Import_Schema
         foreach ($this->_relations as $className => $relations) {
             $array[$className]['relations'] = $relations;
         }
-        
+
         return $array;
     }
 
@@ -663,22 +663,22 @@ class Doctrine_Import_Schema
                 if ((isset($relation['equal']) && $relation['equal']) || (isset($relation['autoComplete']) && $relation['autoComplete'] === false)) {
                     continue;
                 }
-                
+
                 $newRelation = array();
                 $newRelation['foreign'] = $relation['local'];
                 $newRelation['local'] = $relation['foreign'];
                 $newRelation['class'] = isset($relation['foreignClass']) ? $relation['foreignClass']:$className;
                 $newRelation['alias'] = isset($relation['foreignAlias']) ? $relation['foreignAlias']:$className;
                 $newRelation['foreignAlias'] = $alias;
-                
+
                 // this is so that we know that this relation was autogenerated and
                 // that we do not need to include it if it is explicitly declared in the schema by the users.
-                $newRelation['autogenerated'] = true; 
-                
+                $newRelation['autogenerated'] = true;
+
                 if (isset($relation['refClass'])) {
                     $newRelation['refClass'] = $relation['refClass'];
                     $newRelation['type'] = isset($relation['foreignType']) ? $relation['foreignType']:$relation['type'];
-                } else {                
+                } else {
                     if (isset($relation['foreignType'])) {
                         $newRelation['type'] = $relation['foreignType'];
                     } else {
@@ -720,7 +720,7 @@ class Doctrine_Import_Schema
                     }
                 }
             }
-            
+
             $this->_relations[$className] = $uniqueRelations;
         }
     }
@@ -731,8 +731,8 @@ class Doctrine_Import_Schema
      * Build a unique key to identify a relationship by
      * Md5 hash of all the relationship parameters
      *
-     * @param string $relation 
-     * @return void
+     * @param string $relation
+     * @return string
      */
     protected function _buildUniqueRelationKey($relation)
     {
@@ -742,8 +742,8 @@ class Doctrine_Import_Schema
     /**
      * _validateSchemaElement
      *
-     * @param string $name 
-     * @param string $value 
+     * @param string $name
+     * @param string $value
      * @return void
      */
     protected function _validateSchemaElement($name, $element, $path)

--- a/lib/Doctrine/Import/Sqlite.php
+++ b/lib/Doctrine/Import/Sqlite.php
@@ -203,7 +203,7 @@ class Doctrine_Import_Sqlite extends Doctrine_Import
     public function listTableViews($table)
     {
         $query = "SELECT name, sql FROM sqlite_master WHERE type='view' AND sql NOT NULL";
-        $views = $db->fetchAll($query);
+        $views = $this->conn->fetchAll($query);
 
         $result = array();
         foreach ($views as $row) {

--- a/lib/Doctrine/IntegrityMapper.php
+++ b/lib/Doctrine/IntegrityMapper.php
@@ -30,35 +30,37 @@
  * @version     $Revision$
  * @author      Konsta Vesterinen <kvesteri@cc.hut.fi>
  */
-class Doctrine_IntegrityMapper 
+class Doctrine_IntegrityMapper
 {
+    public $conn;
+
     /**
-     * processDeleteIntegrity 
-     * 
-     * @param Doctrine_Record $record 
+     * processDeleteIntegrity
+     *
+     * @param Doctrine_Record $record
      * @return void
      */
     public function processDeleteIntegrity(Doctrine_Record $record)
     {
         $coll = $this->buildIntegrityRelationQuery($record);
-        
+
         $this->invokeIntegrityActions($record);
     }
 
     /**
-     * invokeIntegrityActions 
-     * 
-     * @param Doctrine_Record $record 
+     * invokeIntegrityActions
+     *
+     * @param Doctrine_Record $record
      * @return void
      */
     public function invokeIntegrityActions(Doctrine_Record $record)
     {
         $deleteActions = Doctrine_Manager::getInstance()
                          ->getDeleteActions($record->getTable()->getComponentName());
-                         
+
         foreach ($record->getTable()->getRelations() as $relation) {
             $componentName = $relation->getTable()->getComponentName();
-            
+
             foreach($record->get($relation->getAlias()) as $coll) {
                 if ( ! ($coll instanceof Doctrine_Collection)) {
                     $coll = array($coll);
@@ -80,15 +82,15 @@ class Doctrine_IntegrityMapper
     }
 
     /**
-     * buildIntegrityRelationQuery 
-     * 
-     * @param Doctrine_Record $record 
+     * buildIntegrityRelationQuery
+     *
+     * @param Doctrine_Record $record
      * @return array The result
      */
     public function buildIntegrityRelationQuery(Doctrine_Record $record)
     {
         $q = $record->getTable()->createQuery();
-        
+
         $aliases = array();
         $indexes = array();
 
@@ -117,13 +119,13 @@ class Doctrine_IntegrityMapper
     }
 
     /**
-     * buildIntegrityRelations 
-     * 
-     * @param Doctrine_Table $table 
-     * @param mixed $aliases 
-     * @param mixed $fields 
-     * @param mixed $indexes 
-     * @param mixed $components 
+     * buildIntegrityRelations
+     *
+     * @param Doctrine_Table $table
+     * @param mixed $aliases
+     * @param mixed $fields
+     * @param mixed $indexes
+     * @param mixed $components
      * @return void
      */
     public function buildIntegrityRelations(Doctrine_Table $table, &$aliases, &$fields, &$indexes, &$components)

--- a/lib/Doctrine/Locator.php
+++ b/lib/Doctrine/Locator.php
@@ -45,7 +45,7 @@ class Doctrine_Locator implements Countable, IteratorAggregate
      */
     protected $_classPrefix = 'Doctrine_';
 
-    /** 
+    /**
      * @var array $_instances       a pool of this object's instances
      */
     protected static $_instances = array();
@@ -69,10 +69,10 @@ class Doctrine_Locator implements Countable, IteratorAggregate
         self::$_instances[] = $this;
     }
 
-    /** 
+    /**
      * instance
      *
-     * @return Sensei_Locator
+     * @return Doctrine_Locator
      */
     public static function instance()
     {
@@ -87,7 +87,7 @@ class Doctrine_Locator implements Countable, IteratorAggregate
      *
      * @param string $prefix
      */
-    public function setClassPrefix($prefix) 
+    public function setClassPrefix($prefix)
     {
         $this->_classPrefix = $prefix;
     }
@@ -119,12 +119,12 @@ class Doctrine_Locator implements Countable, IteratorAggregate
      *
      * @param string $name      the name of the resource to bind
      * @param mixed $value      the value of the resource
-     * @return Sensei_Locator   this object
+     * @return $this   this object
      */
     public function bind($name, $value)
     {
         $this->_resources[$name] = $value;
-        
+
         return $this;
     }
 
@@ -149,9 +149,9 @@ class Doctrine_Locator implements Countable, IteratorAggregate
                 $name = array_map('strtolower', $name);
                 $name = array_map('ucfirst', $name);
                 $name = implode('_', $name);
-                
+
                 $className = $this->_classPrefix . $name;
-                
+
                 if ( ! class_exists($className)) {
                     throw new Doctrine_Locator_Exception("Couldn't locate resource " . $className);
                 }
@@ -184,10 +184,10 @@ class Doctrine_Locator implements Countable, IteratorAggregate
 
     /**
      * getIterator
-     * returns an ArrayIterator that iterates through all 
+     * returns an ArrayIterator that iterates through all
      * bound resources
      *
-     * @return ArrayIterator    an iterator for iterating through 
+     * @return ArrayIterator    an iterator for iterating through
      *                          all bound resources
      */
     public function getIterator()

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -90,7 +90,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
         'oracle'   => 'Doctrine_Connection_Oracle',
         'mssql'    => 'Doctrine_Connection_Mssql',
         'dblib'    => 'Doctrine_Connection_Mssql',
-        'odbc'     => 'Doctrine_Connection_Mssql', 
+        'odbc'     => 'Doctrine_Connection_Mssql',
         'mock'     => 'Doctrine_Connection_Mock'
     );
 
@@ -120,8 +120,8 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
     /**
      * Sets default attributes values.
      *
-     * This method sets default values for all null attributes of this 
-     * instance. It is idempotent and can only be called one time. Subsequent 
+     * This method sets default values for all null attributes of this
+     * instance. It is idempotent and can only be called one time. Subsequent
      * calls does not alter the attribute values.
      *
      * @return boolean      true if inizialization was executed
@@ -162,7 +162,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
                         Doctrine_Core::ATTR_TABLE_CLASS                  => 'Doctrine_Table',
                         Doctrine_Core::ATTR_CASCADE_SAVES                => true,
                         Doctrine_Core::ATTR_TABLE_CLASS_FORMAT           => '%sTable'
-                        ); 
+                        );
             foreach ($attributes as $attribute => $value) {
                 $old = $this->getAttribute($attribute);
                 if ($old === null) {
@@ -243,7 +243,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
     public function setQueryRegistry(Doctrine_Query_Registry $registry)
     {
         $this->_queryRegistry = $registry;
-        
+
         return $this;
     }
 
@@ -345,7 +345,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
         }
         return $this->_connections[$name];
     }
-    
+
     /**
      * Parse a pdo style dsn in to an array of parts
      *
@@ -395,7 +395,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      * Build the blank dsn parts array used with parseDsn()
      *
      * @see parseDsn()
-     * @param string $dsn 
+     * @param string $dsn
      * @return array $parts
      */
     protected function _buildDsnPartsArray($dsn)
@@ -830,14 +830,14 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      */
     public function getConnectionDrivers()
     {
-        return $this->_connectionsDrivers;
+        return $this->_connectionDrivers;
     }
 
     /**
      * Register a Doctrine extension for extensionsAutoload() method
      *
-     * @param string $name 
-     * @param string $path 
+     * @param string $name
+     * @param string $path
      * @return void
      */
     public function registerExtension($name, $path = null)

--- a/lib/Doctrine/Migration/Builder.php
+++ b/lib/Doctrine/Migration/Builder.php
@@ -200,8 +200,8 @@ END;
         $down = array();
         if ( ! empty($changes['dropped_foreign_keys'])) {
             foreach ($changes['dropped_foreign_keys'] as $tableName => $droppedFks) {
-                if ( ! empty($changes['dropped_tables']) && isset($changes['dropped_tables'][$tableName])) { 
-                    continue; 
+                if ( ! empty($changes['dropped_tables']) && isset($changes['dropped_tables'][$tableName])) {
+                    continue;
                 }
 
                 foreach ($droppedFks as $name => $foreignKey) {
@@ -213,8 +213,8 @@ END;
 
         if ( ! empty($changes['dropped_indexes'])) {
             foreach ($changes['dropped_indexes'] as $tableName => $removedIndexes) {
-                if ( ! empty($changes['dropped_tables']) && isset($changes['dropped_tables'][$tableName])) { 
-                    continue; 
+                if ( ! empty($changes['dropped_tables']) && isset($changes['dropped_tables'][$tableName])) {
+                    continue;
                 }
 
                 foreach ($removedIndexes as $name => $index) {
@@ -226,8 +226,8 @@ END;
 
         if ( ! empty($changes['created_foreign_keys'])) {
             foreach ($changes['created_foreign_keys'] as $tableName => $createdFks) {
-                if ( ! empty($changes['dropped_tables']) && isset($changes['dropped_tables'][$tableName])) { 
-                    continue; 
+                if ( ! empty($changes['dropped_tables']) && isset($changes['dropped_tables'][$tableName])) {
+                    continue;
                 }
 
                 foreach ($createdFks as $name => $foreignKey) {
@@ -239,8 +239,8 @@ END;
 
         if ( ! empty($changes['created_indexes'])) {
             foreach ($changes['created_indexes'] as $tableName => $addedIndexes) {
-                if ( ! empty($changes['dropped_tables']) && isset($changes['dropped_tables'][$tableName])) { 
-                    continue; 
+                if ( ! empty($changes['dropped_tables']) && isset($changes['dropped_tables'][$tableName])) {
+                    continue;
                 }
 
                 foreach ($addedIndexes as $name => $index) {
@@ -265,7 +265,7 @@ END;
     /**
      * Generate a set of migration classes from the existing databases
      *
-     * @return void
+     * @return bool
      */
     public function generateMigrationsFromDb()
     {
@@ -348,7 +348,7 @@ END;
      */
     public function buildCreateForeignKey($tableName, $definition)
     {
-        return "        \$this->createForeignKey('" . $tableName . "', '" . $definition['name'] . "', " . $this->varExport($definition, true) . ");";
+        return "        \$this->createForeignKey('" . $tableName . "', '" . $definition['name'] . "', " . $this->varExport($definition) . ");";
     }
 
     /**
@@ -373,7 +373,7 @@ END;
     {
         $code  = "        \$this->createTable('" . $tableData['tableName'] . "', ";
 
-        $code .= $this->varExport($tableData['columns'], true) . ", ";
+        $code .= $this->varExport($tableData['columns']) . ", ";
 
         $optionsWeNeed = array('type', 'indexes', 'primary', 'collate', 'charset');
 
@@ -384,7 +384,7 @@ END;
             }
         }
 
-        $code .= $this->varExport($options, true);
+        $code .= $this->varExport($options);
 
         $code .= ");";
 
@@ -453,7 +453,7 @@ END;
      * @param string $tableName
      * @param string $indexName
      * @param string $index
-     * @return sgtring $code
+     * @return string $code
      */
     public function buildAddIndex($tableName, $indexName, $index)
     {

--- a/lib/Doctrine/Node.php
+++ b/lib/Doctrine/Node.php
@@ -55,7 +55,7 @@ class Doctrine_Node implements IteratorAggregate
     /**
      * The tree to which the node belongs.
      *
-     * @var unknown_type
+     * @var Doctrine_Tree|false
      */
     protected $_tree;
 
@@ -69,7 +69,7 @@ class Doctrine_Node implements IteratorAggregate
     {
         $this->record = $record;
         $this->options = $options;
-        
+
         // Make sure that the tree object of the root class is used in the case
         // of column aggregation inheritance (single table inheritance).
         $class = $record->getTable()->getComponentName();

--- a/lib/Doctrine/Node/NestedSet.php
+++ b/lib/Doctrine/Node/NestedSet.php
@@ -29,44 +29,44 @@
  * @since      1.0
  * @version    $Revision: 7490 $
  * @author     Joe Simms <joe.simms@websites4.com>
- * @author     Roman Borschel <roman@code-factory.org>     
+ * @author     Roman Borschel <roman@code-factory.org>
  */
 class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Interface
 {
     /**
      * test if node has previous sibling
      *
-     * @return bool            
+     * @return bool
      */
     public function hasPrevSibling()
     {
-        return $this->isValidNode($this->getPrevSibling());        
+        return $this->isValidNode($this->getPrevSibling());
     }
 
     /**
      * test if node has next sibling
      *
-     * @return bool            
-     */ 
+     * @return bool
+     */
     public function hasNextSibling()
     {
-        return $this->isValidNode($this->getNextSibling());        
+        return $this->isValidNode($this->getNextSibling());
     }
 
     /**
      * test if node has children
      *
-     * @return bool            
+     * @return bool
      */
     public function hasChildren()
     {
-        return (($this->getRightValue() - $this->getLeftValue()) > 1);        
+        return (($this->getRightValue() - $this->getLeftValue()) > 1);
     }
 
     /**
      * test if node has parent
      *
-     * @return bool            
+     * @return bool
      */
     public function hasParent()
     {
@@ -76,7 +76,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * gets record of prev sibling or empty record
      *
-     * @return Doctrine_Record            
+     * @return Doctrine_Record
      */
     public function getPrevSibling()
     {
@@ -89,20 +89,20 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         if (count($result) <= 0) {
             return false;
         }
-        
+
         if ($result instanceof Doctrine_Collection) {
             $sibling = $result->getFirst();
         } else if (is_array($result)) {
             $sibling = array_shift($result);
         }
-        
+
         return $sibling;
     }
 
     /**
      * gets record of next sibling or empty record
      *
-     * @return Doctrine_Record            
+     * @return Doctrine_Record
      */
     public function getNextSibling()
     {
@@ -115,20 +115,20 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         if (count($result) <= 0) {
             return false;
         }
-        
+
         if ($result instanceof Doctrine_Collection) {
             $sibling = $result->getFirst();
         } else if (is_array($result)) {
             $sibling = array_shift($result);
         }
-        
+
         return $sibling;
     }
 
     /**
      * gets siblings for node
      *
-     * @return array     array of sibling Doctrine_Record objects            
+     * @return array     array of sibling Doctrine_Record objects
      */
     public function getSiblings($includeNode = false)
     {
@@ -140,7 +140,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
                     continue;
                 }
                 $siblings[] = $child;
-            }        
+            }
         }
         return $siblings;
     }
@@ -148,7 +148,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * gets record of first child or empty record
      *
-     * @return Doctrine_Record            
+     * @return Doctrine_Record
      */
     public function getFirstChild()
     {
@@ -161,20 +161,20 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         if (count($result) <= 0) {
             return false;
         }
-        
+
         if ($result instanceof Doctrine_Collection) {
             $child = $result->getFirst();
         } else if (is_array($result)) {
             $child = array_shift($result);
         }
-        
-        return $child;       
+
+        return $child;
     }
 
     /**
      * gets record of last child or empty record
      *
-     * @return Doctrine_Record            
+     * @return Doctrine_Record
      */
     public function getLastChild()
     {
@@ -187,23 +187,23 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         if (count($result) <= 0) {
             return false;
         }
-        
+
         if ($result instanceof Doctrine_Collection) {
             $child = $result->getFirst();
         } else if (is_array($result)) {
             $child = array_shift($result);
         }
-        
-        return $child;      
+
+        return $child;
     }
 
     /**
      * gets children for node (direct descendants only)
      *
-     * @return mixed  The children of the node or FALSE if the node has no children.               
+     * @return mixed  The children of the node or FALSE if the node has no children.
      */
     public function getChildren()
-    { 
+    {
         return $this->getDescendants(1);
     }
 
@@ -217,17 +217,17 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         $baseAlias = $this->_tree->getBaseAlias();
         $q = $this->_tree->getBaseQuery();
         $params = array($this->record->get('lft'), $this->record->get('rgt'));
-        
+
         if ($includeNode) {
             $q->addWhere("$baseAlias.lft >= ? AND $baseAlias.rgt <= ?", $params)->addOrderBy("$baseAlias.lft asc");
         } else {
             $q->addWhere("$baseAlias.lft > ? AND $baseAlias.rgt < ?", $params)->addOrderBy("$baseAlias.lft asc");
         }
-        
+
         if ($depth !== null) {
             $q->addWhere("$baseAlias.level <= ?", $this->record['level'] + $depth);
         }
-        
+
         $q = $this->_tree->returnQueryWithRootId($q, $this->getRootValue());
         $result = $q->execute();
 
@@ -241,7 +241,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * gets record of parent or empty record
      *
-     * @return Doctrine_Record            
+     * @return Doctrine_Record
      */
     public function getParent()
     {
@@ -252,17 +252,17 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
           ->addOrderBy("$baseAlias.rgt asc");
         $q = $this->_tree->returnQueryWithRootId($q, $this->getRootValue());
         $result = $q->execute();
-        
+
         if (count($result) <= 0) {
             return false;
         }
-               
+
         if ($result instanceof Doctrine_Collection) {
             $parent = $result->getFirst();
         } else if (is_array($result)) {
             $parent = array_shift($result);
         }
-        
+
         return $parent;
     }
 
@@ -270,8 +270,8 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * gets ancestors for node
      *
      * @param integer $deth  The depth 'upstairs'.
-     * @return mixed  The ancestors of the node or FALSE if the node has no ancestors (this 
-     *                basically means it's a root node).                
+     * @return mixed  The ancestors of the node or FALSE if the node has no ancestors (this
+     *                basically means it's a root node).
      */
     public function getAncestors($depth = null)
     {
@@ -295,8 +295,8 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      *
      * @param string     $seperator     path seperator
      * @param bool     $includeNode     whether or not to include node at end of path
-     * @return string     string representation of path                
-     */     
+     * @return string     string representation of path
+     */
     public function getPath($seperator = ' > ', $includeRecord = false)
     {
         $path = array();
@@ -309,15 +309,15 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         if ($includeRecord) {
             $path[] = $this->getRecord()->__toString();
         }
-            
+
         return implode($seperator, $path);
     }
 
     /**
      * gets number of children (direct descendants)
      *
-     * @return int            
-     */     
+     * @return int
+     */
     public function getNumberChildren()
     {
         $children = $this->getChildren();
@@ -327,7 +327,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * gets number of descendants (children and their children)
      *
-     * @return int            
+     * @return int
      */
     public function getNumberDescendants()
     {
@@ -338,7 +338,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * inserts node as parent of dest record
      *
      * @return bool
-     * @todo Wrap in transaction          
+     * @todo Wrap in transaction
      */
     public function insertAsParentOf(Doctrine_Record $dest)
     {
@@ -350,7 +350,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         if ($dest->getNode()->isRoot()) {
             return false;
         }
-        
+
         // cannot insert as parent of itself
         if (
 		    $dest === $this->record ||
@@ -365,16 +365,16 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         $newRight = $dest->getNode()->getRightValue() + 2;
         $newRoot  = $dest->getNode()->getRootValue();
 		$newLevel = $dest->getNode()->getLevel();
-		
+
 		$conn = $this->record->getTable()->getConnection();
 		try {
 		    $conn->beginInternalTransaction();
-		    
+
 		    // Make space for new node
-            $this->shiftRLValues($dest->getNode()->getRightValue() + 1, 2, $newRoot);
+            $this->shiftRlValues($dest->getNode()->getRightValue() + 1, 2, $newRoot);
 
             // Slide child nodes over one and down one to allow new parent to wrap them
-    		$componentName = $this->_tree->getBaseComponent();		
+    		$componentName = $this->_tree->getBaseComponent();
             $q = Doctrine_Core::getTable($componentName)
                 ->createQuery()
                 ->update();
@@ -387,13 +387,13 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
 
             $this->record['level'] = $newLevel;
     		$this->insertNode($newLeft, $newRight, $newRoot);
-    		
+
     		$conn->commit();
 		} catch (Exception $e) {
 		    $conn->rollback();
 		    throw $e;
 		}
-        
+
         return true;
     }
 
@@ -401,7 +401,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * inserts node as previous sibling of dest record
      *
      * @return bool
-     * @todo Wrap in transaction       
+     * @todo Wrap in transaction
      */
     public function insertAsPrevSiblingOf(Doctrine_Record $dest)
     {
@@ -422,24 +422,24 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         $newLeft = $dest->getNode()->getLeftValue();
         $newRight = $dest->getNode()->getLeftValue() + 1;
         $newRoot = $dest->getNode()->getRootValue();
-        
+
         $conn = $this->record->getTable()->getConnection();
         try {
             $conn->beginInternalTransaction();
-            
-            $this->shiftRLValues($newLeft, 2, $newRoot);
+
+            $this->shiftRlValues($newLeft, 2, $newRoot);
             $this->record['level'] = $dest['level'];
             $this->insertNode($newLeft, $newRight, $newRoot);
             // update destination left/right values to prevent a refresh
             // $dest->getNode()->setLeftValue($dest->getNode()->getLeftValue() + 2);
             // $dest->getNode()->setRightValue($dest->getNode()->getRightValue() + 2);
-            
+
             $conn->commit();
         } catch (Exception $e) {
             $conn->rollback();
             throw $e;
         }
-                        
+
         return true;
     }
 
@@ -447,8 +447,8 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * inserts node as next sibling of dest record
      *
      * @return bool
-     * @todo Wrap in transaction           
-     */    
+     * @todo Wrap in transaction
+     */
     public function insertAsNextSiblingOf(Doctrine_Record $dest)
     {
         // cannot insert a node that has already has a place within the tree
@@ -472,13 +472,13 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         $conn = $this->record->getTable()->getConnection();
         try {
             $conn->beginInternalTransaction();
-            
-            $this->shiftRLValues($newLeft, 2, $newRoot);
+
+            $this->shiftRlValues($newLeft, 2, $newRoot);
             $this->record['level'] = $dest['level'];
             $this->insertNode($newLeft, $newRight, $newRoot);
             // update destination left/right values to prevent a refresh
             // no need, node not affected
-            
+
             $conn->commit();
         } catch (Exception $e) {
             $conn->rollback();
@@ -492,7 +492,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * inserts node as first child of dest record
      *
      * @return bool
-     * @todo Wrap in transaction         
+     * @todo Wrap in transaction
      */
     public function insertAsFirstChildOf(Doctrine_Record $dest)
     {
@@ -517,14 +517,14 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         $conn = $this->record->getTable()->getConnection();
         try {
             $conn->beginInternalTransaction();
-            
-            $this->shiftRLValues($newLeft, 2, $newRoot);
+
+            $this->shiftRlValues($newLeft, 2, $newRoot);
             $this->record['level'] = $dest['level'] + 1;
             $this->insertNode($newLeft, $newRight, $newRoot);
-            
+
             // update destination left/right values to prevent a refresh
             // $dest->getNode()->setRightValue($dest->getNode()->getRightValue() + 2);
-            
+
             $conn->commit();
         } catch (Exception $e) {
             $conn->rollback();
@@ -538,7 +538,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * inserts node as last child of dest record
      *
      * @return bool
-     * @todo Wrap in transaction            
+     * @todo Wrap in transaction
      */
     public function insertAsLastChildOf(Doctrine_Record $dest)
     {
@@ -563,20 +563,20 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         $conn = $this->record->getTable()->getConnection();
         try {
             $conn->beginInternalTransaction();
-            
-            $this->shiftRLValues($newLeft, 2, $newRoot);
+
+            $this->shiftRlValues($newLeft, 2, $newRoot);
             $this->record['level'] = $dest['level'] + 1;
             $this->insertNode($newLeft, $newRight, $newRoot);
 
             // update destination left/right values to prevent a refresh
             // $dest->getNode()->setRightValue($dest->getNode()->getRightValue() + 2);
-            
+
             $conn->commit();
         } catch (Exception $e) {
             $conn->rollback();
             throw $e;
         }
-        
+
         return true;
     }
 
@@ -585,14 +585,14 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * Used by the move* methods if the root values of the two nodes are different.
      *
      * @param Doctrine_Record $dest
-     * @param unknown_type $newLeftValue
-     * @param unknown_type $moveType
+     * @param int $newLeftValue
+     * @param string $moveType
      * @todo Better exception handling/wrapping
      */
     private function _moveBetweenTrees(Doctrine_Record $dest, $newLeftValue, $moveType)
     {
         $conn = $this->record->getTable()->getConnection();
-            
+
         try {
             $conn->beginInternalTransaction();
 
@@ -658,23 +658,23 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
             // Close gap in old tree
             $first = $oldRgt + 1;
             $delta = $oldLft - $oldRgt - 1;
-            $this->shiftRLValues($first, $delta, $oldRoot);
+            $this->shiftRlValues($first, $delta, $oldRoot);
 
             $conn->commit();
-     
+
 	        return true;
         } catch (Exception $e) {
             $conn->rollback();
             throw $e;
         }
-        
+
         return false;
     }
 
     /**
      * moves node as prev sibling of dest record
-     * 
-     */     
+     *
+     */
     public function moveAsPrevSiblingOf(Doctrine_Record $dest)
     {
         if (
@@ -695,13 +695,13 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
             $this->record['level'] = $dest['level'];
             $this->updateNode($dest->getNode()->getLeftValue(), $this->record['level'] - $oldLevel);
         }
-        
+
         return true;
     }
 
     /**
      * moves node as next sibling of dest record
-     *        
+     *
      */
     public function moveAsNextSiblingOf(Doctrine_Record $dest)
     {
@@ -710,7 +710,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
 			($dest->exists() && $this->record->exists() && $dest->identifier() === $this->record->identifier())
 		) {
             throw new Doctrine_Tree_Exception("Cannot move node as next sibling of itself");
-            
+
             return false;
         }
 
@@ -723,13 +723,13 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
             $this->record['level'] = $dest['level'];
             $this->updateNode($dest->getNode()->getRightValue() + 1, $this->record['level'] - $oldLevel);
         }
-        
+
         return true;
     }
 
     /**
      * moves node as first child of dest record
-     *            
+     *
      */
     public function moveAsFirstChildOf(Doctrine_Record $dest)
     {
@@ -757,7 +757,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
 
     /**
      * moves node as last child of dest record
-     *        
+     *
      */
     public function moveAsLastChildOf(Doctrine_Record $dest)
     {
@@ -779,7 +779,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
             $this->record['level'] = $dest['level'] + 1;
             $this->updateNode($dest->getNode()->getRightValue(), $this->record['level'] - $oldLevel);
         }
-        
+
         return true;
     }
 
@@ -794,16 +794,16 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         if ($this->getLeftValue() == 1 || ! $this->_tree->getAttribute('hasManyRoots')) {
             return false;
         }
-        
+
         $oldRgt = $this->getRightValue();
         $oldLft = $this->getLeftValue();
         $oldRoot = $this->getRootValue();
         $oldLevel = $this->record['level'];
-        
+
         $conn = $this->record->getTable()->getConnection();
         try {
             $conn->beginInternalTransaction();
-            
+
             // Update descendants lft/rgt/root/level values
             $diff = 1 - $oldLft;
             $newRoot = $newRootId;
@@ -819,34 +819,34 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
                 ->where($componentName . '.lft > ? AND ' . $componentName . '.rgt < ?', array($oldLft, $oldRgt));
             $q = $this->_tree->returnQueryWithRootId($q, $oldRoot);
             $q->execute();
-            
+
             // Detach from old tree (close gap in old tree)
             $first = $oldRgt + 1;
             $delta = $oldLft - $oldRgt - 1;
-            $this->shiftRLValues($first, $delta, $this->getRootValue());
-            
+            $this->shiftRlValues($first, $delta, $this->getRootValue());
+
             // Set new lft/rgt/root/level values for root node
             $this->setLeftValue(1);
             $this->setRightValue($oldRgt - $oldLft + 1);
             $this->setRootValue($newRootId);
             $this->record['level'] = 0;
-            
+
             $this->record->save();
-            
+
             $conn->commit();
-            
+
             return true;
         } catch (Exception $e) {
             $conn->rollback();
             throw $e;
         }
-        
+
         return false;
     }
 
     /**
      * adds node as last child of record
-     *        
+     *
      */
     public function addChild(Doctrine_Record $record)
     {
@@ -856,7 +856,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * determines if node is leaf
      *
-     * @return bool            
+     * @return bool
      */
     public function isLeaf()
     {
@@ -866,7 +866,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * determines if node is root
      *
-     * @return bool            
+     * @return bool
      */
     public function isRoot()
     {
@@ -876,12 +876,12 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * determines if node is equal to subject node
      *
-     * @return bool            
-     */    
+     * @return bool
+     */
     public function isEqualTo(Doctrine_Record $subj)
     {
         return (($this->getLeftValue() == $subj->getNode()->getLeftValue()) &&
-                ($this->getRightValue() == $subj->getNode()->getRightValue()) && 
+                ($this->getRightValue() == $subj->getNode()->getRightValue()) &&
                 ($this->getRootValue() == $subj->getNode()->getRootValue())
                 );
     }
@@ -901,7 +901,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * determines if node is child of or sibling to subject node
      *
-     * @return bool            
+     * @return bool
      */
     public function isDescendantOfOrEqualTo(Doctrine_Record $subj)
     {
@@ -913,7 +913,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * determines if node is ancestor of subject node
      *
-     * @return bool            
+     * @return bool
      */
     public function isAncestorOf(Doctrine_Record $subj)
     {
@@ -937,7 +937,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
             return false;
         }
     }
-    
+
     /**
      * Detaches the node from the tree by invalidating it's lft & rgt values
      * (they're set to 0).
@@ -950,14 +950,14 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
 
     /**
      * deletes node and it's descendants
-     * @todo Delete more efficiently. Wrap in transaction if needed.      
+     * @todo Delete more efficiently. Wrap in transaction if needed.
      */
     public function delete()
     {
         $conn = $this->record->getTable()->getConnection();
         try {
             $conn->beginInternalTransaction();
-            
+
             // TODO: add the setting whether or not to delete descendants or relocate children
             $oldRoot = $this->getRootValue();
             $q = $this->_tree->getBaseQuery();
@@ -975,15 +975,15 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
 
             $first = $this->getRightValue() + 1;
             $delta = $this->getLeftValue() - $this->getRightValue() - 1;
-            $this->shiftRLValues($first, $delta, $oldRoot);
-            
+            $this->shiftRlValues($first, $delta, $oldRoot);
+
             $conn->commit();
         } catch (Exception $e) {
             $conn->rollback();
             throw $e;
         }
-        
-        return true; 
+
+        return true;
     }
 
     /**
@@ -991,13 +991,13 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      *
      * @param int     $destLeft     node left value
      * @param int        $destRight    node right value
-     */    
+     */
     private function insertNode($destLeft = 0, $destRight = 0, $destRoot = 1)
     {
         $this->setLeftValue($destLeft);
         $this->setRightValue($destRight);
         $this->setRootValue($destRoot);
-        $this->record->save();    
+        $this->record->save();
     }
 
     /**
@@ -1007,7 +1007,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * @todo Wrap in transaction
      */
     private function updateNode($destLeft, $levelDiff)
-    { 
+    {
         $componentName = $this->_tree->getBaseComponent();
         $left = $this->getLeftValue();
         $right = $this->getRightValue();
@@ -1018,9 +1018,9 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         $conn = $this->record->getTable()->getConnection();
         try {
             $conn->beginInternalTransaction();
-            
+
             // Make room in the new branch
-            $this->shiftRLValues($destLeft, $treeSize, $rootId);
+            $this->shiftRlValues($destLeft, $treeSize, $rootId);
 
             if ($left >= $destLeft) { // src was shifted too?
                 $left += $treeSize;
@@ -1037,20 +1037,20 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
             $q->execute();
 
             // now there's enough room next to target to move the subtree
-            $this->shiftRLRange($left, $right, $destLeft - $left, $rootId);
+            $this->shiftRlRange($left, $right, $destLeft - $left, $rootId);
 
             // correct values after source (close gap in old tree)
-            $this->shiftRLValues($right + 1, -$treeSize, $rootId);
+            $this->shiftRlValues($right + 1, -$treeSize, $rootId);
 
             $this->record->save();
             $this->record->refresh();
-            
+
             $conn->commit();
         } catch (Exception $e) {
             $conn->rollback();
             throw $e;
         }
-        
+
         return true;
     }
 
@@ -1062,7 +1062,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      *
      * @param int $first         First node to be shifted
      * @param int $delta         Value to be shifted by, can be negative
-     */    
+     */
     private function shiftRlValues($first, $delta, $rootId = 1)
     {
         // shift left columns
@@ -1092,7 +1092,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     }
 
     /**
-     * adds '$delta' to all Left and Right values that are >= '$first' and <= '$last'. 
+     * adds '$delta' to all Left and Right values that are >= '$first' and <= '$last'.
      * '$delta' can also be negative.
      *
      * Note: This method does wrap its database queries in a transaction. This should be done
@@ -1101,7 +1101,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
      * @param int $first     First node to be shifted (L value)
      * @param int $last     Last node to be shifted (L value)
      * @param int $delta         Value to be shifted by, can be negative
-     */ 
+     */
     private function shiftRlRange($first, $last, $delta, $rootId = 1)
     {
         $componentName = $this->_tree->getBaseComponent();
@@ -1117,11 +1117,11 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
         // shift left column values
         $qLeft = $qLeft->set($componentName . '.lft', $componentName.'.lft + ?', $delta)
                        ->where($componentName . '.lft >= ? AND ' . $componentName . '.lft <= ?', array($first, $last));
-        
+
         $qLeft = $this->_tree->returnQueryWithRootId($qLeft, $rootId);
 
         $resultLeft = $qLeft->execute();
-        
+
         // shift right column values
         $qRight = $qRight->set($componentName . '.rgt', $componentName.'.rgt + ?', $delta)
                         ->where($componentName . '.rgt >= ? AND ' . $componentName . '.rgt <= ?', array($first, $last));
@@ -1134,8 +1134,8 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * gets record's left value
      *
-     * @return int            
-     */     
+     * @return int
+     */
     public function getLeftValue()
     {
         return $this->record->get('lft');
@@ -1144,38 +1144,38 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * sets record's left value
      *
-     * @param int            
-     */     
+     * @param int
+     */
     public function setLeftValue($lft)
     {
-        $this->record->set('lft', $lft);        
+        $this->record->set('lft', $lft);
     }
 
     /**
      * gets record's right value
      *
-     * @return int            
-     */     
+     * @return int
+     */
     public function getRightValue()
     {
-        return $this->record->get('rgt');        
+        return $this->record->get('rgt');
     }
 
     /**
      * sets record's right value
      *
-     * @param int            
-     */    
+     * @param int
+     */
     public function setRightValue($rgt)
     {
-        $this->record->set('rgt', $rgt);         
+        $this->record->set('rgt', $rgt);
     }
 
     /**
      * gets level (depth) of node in the tree
      *
-     * @return int            
-     */    
+     * @return int
+     */
     public function getLevel()
     {
         if ( ! isset($this->record['level'])) {
@@ -1185,7 +1185,7 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
             $q = $q->addWhere("$baseAlias.lft < ? AND $baseAlias.rgt > ?", array($this->getLeftValue(), $this->getRightValue()));
 
             $q = $this->_tree->returnQueryWithRootId($q, $this->getRootValue());
-            
+
             $coll = $q->execute();
 
             $this->record['level'] = count($coll) ? count($coll) : 0;
@@ -1195,8 +1195,8 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
 
     /**
      * get records root id value
-     *            
-     */     
+     *
+     */
     public function getRootValue()
     {
         if ($this->_tree->getAttribute('hasManyRoots')) {
@@ -1208,12 +1208,12 @@ class Doctrine_Node_NestedSet extends Doctrine_Node implements Doctrine_Node_Int
     /**
      * sets records root id value
      *
-     * @param int            
+     * @param int
      */
     public function setRootValue($value)
     {
         if ($this->_tree->getAttribute('hasManyRoots')) {
-            $this->record->set($this->_tree->getAttribute('rootColumnName'), $value);   
-        }    
+            $this->record->set($this->_tree->getAttribute('rootColumnName'), $value);
+        }
     }
 }

--- a/lib/Doctrine/Node/NestedSet/PreOrderIterator.php
+++ b/lib/Doctrine/Node/NestedSet/PreOrderIterator.php
@@ -67,6 +67,12 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      */
     protected $count;
 
+    // These were undefined, added for static analysis and set to public so api isn't changed
+    public $level;
+    public $maxLevel;
+    public $options;
+    public $prevLeft;
+
     public function __construct($record, $opts)
     {
         $componentName = $record->getTable()->getComponentName();
@@ -79,7 +85,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
         } else {
             $query = $q->where("$componentName.lft > ? AND $componentName.rgt < ?", $params)->orderBy("$componentName.lft asc");
         }
-        
+
         $query = $record->getTable()->getTree()->returnQueryWithRootId($query, $record->getNode()->getRootValue());
 
         $this->maxLevel   = isset($opts['depth']) ? ($opts['depth'] + $record->getNode()->getLevel()) : 0;

--- a/lib/Doctrine/Pager.php
+++ b/lib/Doctrine/Pager.php
@@ -142,7 +142,7 @@ class Doctrine_Pager
      *
      * Returns the check if Pager was already executed at least once
      *
-     * @return boolen        Pager was executed
+     * @return bool        Pager was executed
      */
     public function getExecuted()
     {

--- a/lib/Doctrine/Pager/Layout.php
+++ b/lib/Doctrine/Pager/Layout.php
@@ -62,9 +62,9 @@ class Doctrine_Pager_Layout
      * @var string $_urlMask      URL to be assigned for each page. Masks are used as: {%var_name}
      */
     private $_urlMask;
-    
+
     /**
-     * @var array $_maskReplacements      Stores references of masks and their correspondent 
+     * @var array $_maskReplacements      Stores references of masks and their correspondent
      *                                    (replaces defined masks with new masks or values)
      */
     private $_maskReplacements = array();
@@ -195,7 +195,7 @@ class Doctrine_Pager_Layout
     /**
      * setTemplate
      *
-     * Defines the Template to be applied for inactive pages 
+     * Defines the Template to be applied for inactive pages
      * (also active page if selected template not defined)
      *
      * @param $template       Template to be applied for inactive pages
@@ -250,7 +250,7 @@ class Doctrine_Pager_Layout
      *
      * @param $separatorTemplate       Separator template, applied between each page
      * @return void
-     */ 
+     */
     public function setSeparatorTemplate($separatorTemplate)
     {
         $this->_separatorTemplate = $separatorTemplate;
@@ -268,7 +268,7 @@ class Doctrine_Pager_Layout
      *                       changes the bahavior of replacement mask to replacement
      *                       value
      * @return void
-     */ 
+     */
     public function addMaskReplacement($oldMask, $newMask, $asValue = false)
     {
         if (($oldMask = trim($oldMask)) != 'page_number') {
@@ -286,7 +286,7 @@ class Doctrine_Pager_Layout
      *
      * @param $oldMask       Replacement Mask to be removed
      * @return void
-     */ 
+     */
     public function removeMaskReplacement($oldMask)
     {
         if (isset($this->_maskReplacements[$oldMask])) {
@@ -294,15 +294,15 @@ class Doctrine_Pager_Layout
             unset($this->_maskReplacements[$oldMask]);
         }
     }
-    
-    
+
+
     /**
      * cleanMaskReplacements
      *
      * Remove all mask replacements
      *
      * @return void
-     */ 
+     */
     public function cleanMaskReplacements()
     {
         $this->_maskReplacements = null;
@@ -314,11 +314,11 @@ class Doctrine_Pager_Layout
      *
      * Displays the pager on screen based on templates and options defined
      *
-     * @param $options    Optional parameters to be applied in template and url mask
-     * @param $return     Optional parameter if you want to capture the output of this method call 
+     * @param array $options    Optional parameters to be applied in template and url mask
+     * @param bool $return     Optional parameter if you want to capture the output of this method call
      *                    (Default value is false), instead of printing it
-     * @return void       If you would like to capture the output of Doctrine_Pager_Layout::display(),
-     *                    use the $return  parameter. If this parameter is set to TRUE, this method 
+     * @return void|string       If you would like to capture the output of Doctrine_Pager_Layout::display(),
+     *                    use the $return  parameter. If this parameter is set to TRUE, this method
      *                    will return its output, instead of printing it (which it does by default)
      */
     public function display($options = array(), $return = false)
@@ -390,7 +390,7 @@ class Doctrine_Pager_Layout
      * Parse the template of a given page and return the processed template
      *
      * @param array    Optional parameters to be applied in template and url mask
-     * @return string  
+     * @return string
      */
     protected function _parseTemplate($options = array())
     {
@@ -475,7 +475,7 @@ class Doctrine_Pager_Layout
      * Parse the mask replacements, changing from to-be replaced mask with new masks/values
      *
      * @param $str    String to have masks replaced
-     * @return string  
+     * @return string
      */
     protected function _parseMaskReplacements($str)
     {

--- a/lib/Doctrine/Parser.php
+++ b/lib/Doctrine/Parser.php
@@ -37,7 +37,7 @@ abstract class Doctrine_Parser
      *
      * Override in the parser driver
      *
-     * @param string $array 
+     * @param string $array
      * @return void
      * @author Jonathan H. Wage
      */
@@ -48,8 +48,8 @@ abstract class Doctrine_Parser
      *
      * Override in the parser driver
      *
-     * @param string $array 
-     * @param string $path 
+     * @param string $array
+     * @param string $path
      * @param string $charset The charset of the data being dumped
      * @return void
      * @author Jonathan H. Wage
@@ -61,8 +61,8 @@ abstract class Doctrine_Parser
      *
      * Get instance of the specified parser
      *
-     * @param string $type 
-     * @return void
+     * @param string $type
+     * @return Doctrine_Parser
      * @author Jonathan H. Wage
      */
     static public function getParser($type)
@@ -77,9 +77,9 @@ abstract class Doctrine_Parser
      *
      * Interface for loading and parsing data from a file
      *
-     * @param string $path 
-     * @param string $type 
-     * @return void
+     * @param string $path
+     * @param string $type
+     * @return array
      * @author Jonathan H. Wage
      */
     static public function load($path, $type = 'xml')
@@ -94,11 +94,11 @@ abstract class Doctrine_Parser
      *
      * Interface for pulling and dumping data to a file
      *
-     * @param string $array 
-     * @param string $path 
-     * @param string $type 
+     * @param string $array
+     * @param string $path
+     * @param string $type
      * @param string $charset The charset of the data being dumped
-     * @return void
+     * @return int|false|string
      * @author Jonathan H. Wage
      */
     static public function dump($array, $type = 'xml', $path = null, $charset = null)
@@ -114,8 +114,8 @@ abstract class Doctrine_Parser
      * Get contents whether it is the path to a file file or a string of txt.
      * Either should allow php code in it.
      *
-     * @param string $path 
-     * @return void
+     * @param string $path
+     * @return string
      */
     public function doLoad($path)
     {
@@ -128,7 +128,7 @@ abstract class Doctrine_Parser
         }
 
         include($path);
-        
+
         // Fix #1569. Need to check if it's still all valid
         $contents = ob_get_clean(); //iconv("UTF-8", "UTF-8", ob_get_clean());
 
@@ -138,9 +138,9 @@ abstract class Doctrine_Parser
     /**
      * doDump
      *
-     * @param string $data 
-     * @param string $path 
-     * @return void
+     * @param string $data
+     * @param string $path
+     * @return int|false|string
      */
     public function doDump($data, $path = null)
     {

--- a/lib/Doctrine/Parser/Json.php
+++ b/lib/Doctrine/Parser/Json.php
@@ -36,17 +36,17 @@ class Doctrine_Parser_Json extends Doctrine_Parser
      * dumpData
      *
      * Dump an array of data to a specified path or return
-     * 
+     *
      * @param string $array Array of data to dump to json
      * @param string $path  Path to dump json data to
      * @param string $charset The charset of the data being dumped
      * @return string $json
-     * @return void
+     * @return int|false|string
      */
     public function dumpData($array, $path = null, $charset = null)
     {
         $data = json_encode($array);
-        
+
         return $this->doDump($data, $path);
     }
 
@@ -54,16 +54,16 @@ class Doctrine_Parser_Json extends Doctrine_Parser
      * loadData
      *
      * Load and unserialize data from a file or from passed data
-     * 
+     *
      * @param  string $path   Path to dump data to
      * @return array  $json   Array of json objects
      */
     public function loadData($path)
     {
         $contents = $this->doLoad($path);
-        
+
         $json = json_decode($contents);
-        
+
         return $json;
     }
 }

--- a/lib/Doctrine/Parser/Xml.php
+++ b/lib/Doctrine/Parser/Xml.php
@@ -34,7 +34,7 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
 {
     /**
      * dumpData
-     * 
+     *
      * Convert array to xml and dump to specified path or return the xml
      *
      * @param  string $array Array of data to convert to xml
@@ -46,14 +46,14 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
     public function dumpData($array, $path = null, $charset = null)
     {
         $data = self::arrayToXml($array, 'data', null, $charset);
-        
+
         return $this->doDump($data, $path);
     }
 
     /**
      * arrayToXml
      *
-     * @param  string $array        Array to convert to xml    
+     * @param  string $array        Array to convert to xml
      * @param  string $rootNodeName Name of the root node
      * @param  string $xml          SimpleXmlElement
      * @return string $asXml        String of xml built from array
@@ -61,7 +61,7 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
     public static function arrayToXml($array, $rootNodeName = 'data', $xml = null, $charset = null)
     {
         if ($xml === null) {
-            $xml = new SimpleXmlElement("<?xml version=\"1.0\" encoding=\"utf-8\"?><$rootNodeName/>");
+            $xml = new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?><$rootNodeName/>");
         }
 
         foreach($array as $key => $value)
@@ -79,7 +79,7 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
                 }
 
                 self::arrayToXml($value, $rootNodeName, $node, $charset);
-            } else if (is_int($key)) {               
+            } else if (is_int($key)) {
                 $xml->addChild($value, 'true');
             } else {
                 $charset = $charset ? $charset : 'utf-8';
@@ -105,9 +105,9 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
     public function loadData($path)
     {
         $contents = $this->doLoad($path);
-        
+
         $simpleXml = simplexml_load_string($contents);
-        
+
         return $this->prepareData($simpleXml);
     }
 
@@ -116,7 +116,7 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
      *
      * Prepare simple xml to array for return
      *
-     * @param  string $simpleXml 
+     * @param  string $simpleXml
      * @return array  $return
      */
     public function prepareData($simpleXml)

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -223,7 +223,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      * createSubquery
      * creates a subquery
      *
-     * @return Doctrine_Hydrate
+     * @return Doctrine_Query
      */
     public function createSubquery()
     {
@@ -1103,7 +1103,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      * handling.
      *
      * @param string $alias Component Alias
-     * @return Processed pending conditions
+     * @return string Processed pending conditions
      */
     protected function _processPendingJoinConditions($alias)
     {

--- a/lib/Doctrine/Query/Check.php
+++ b/lib/Doctrine/Query/Check.php
@@ -38,11 +38,11 @@ class Doctrine_Query_Check
     protected $table;
 
     /**
-     * @var string $sql                     database specific sql CHECK constraint definition 
+     * @var string $sql                     database specific sql CHECK constraint definition
      *                                      parsed from the given dql CHECK definition
      */
     protected $sql;
-    
+
     protected $_tokenizer;
 
     /**
@@ -87,7 +87,7 @@ class Doctrine_Query_Check
      * @param string $alias     component alias
      * @param string $field     the field name
      * @param mixed $value      the value of the field
-     * @return void
+     * @return string
      */
     public function parseClause($dql)
     {
@@ -116,11 +116,11 @@ class Doctrine_Query_Check
         }
         return '(' . $r . ')';
     }
-    
+
     public function parseSingle($part)
     {
         $e = explode(' ', $part);
-        
+
         $e[0] = $this->parseFunction($e[0]);
 
         switch ($e[1]) {
@@ -138,18 +138,18 @@ class Doctrine_Query_Check
         return implode(' ', $e);
     }
 
-    public function parseFunction($dql) 
+    public function parseFunction($dql)
     {
         if (($pos = strpos($dql, '(')) !== false) {
             $func  = substr($dql, 0, $pos);
             $value = substr($dql, ($pos + 1), -1);
-            
+
             $expr  = $this->table->getConnection()->expression;
 
             if ( ! method_exists($expr, $func)) {
                 throw new Doctrine_Query_Exception('Unknown function ' . $func);
             }
-            
+
             $func  = $expr->$func($value);
         }
         return $func;

--- a/lib/Doctrine/Query/Tokenizer.php
+++ b/lib/Doctrine/Query/Tokenizer.php
@@ -78,7 +78,7 @@ class Doctrine_Query_Tokenizer
                     //$parts[$token] = array();
                     $parts[$token] = '';
                 break;
-            
+
                 case 'order':
                 case 'group':
                     $i = ($index + 1);
@@ -91,10 +91,10 @@ class Doctrine_Query_Tokenizer
                         //$parts[$p][] = $token;
                     }
                 break;
-            
+
                 case 'by':
                     continue;
-            
+
                 default:
                     if ( ! isset($p)) {
                         throw new Doctrine_Query_Tokenizer_Exception(
@@ -345,7 +345,7 @@ class Doctrine_Query_Tokenizer
      * @param $e1
      * @param $e2
      *
-     * @return unknown_type
+     * @return array
      */
     private function clauseExplodeCountBrackets($str, $regexp, $e1 = '(', $e2 = ')')
     {
@@ -387,7 +387,7 @@ class Doctrine_Query_Tokenizer
                 $i += sizeof($subterms);
             }
         }
-        
+
         return $terms;
     }
 
@@ -442,9 +442,9 @@ class Doctrine_Query_Tokenizer
 
     /**
      * This expects input from clauseExplodeNonQuoted.
-     * It will go through the result and merges any bracket terms with 
+     * It will go through the result and merges any bracket terms with
      * unbalanced bracket count.
-     * Note that only the third parameter in each term is used to get the 
+     * Note that only the third parameter in each term is used to get the
      * bracket overhang. This is needed to be able to handle quoted strings
      * wich contain brackets
      *
@@ -478,7 +478,7 @@ class Doctrine_Query_Tokenizer
             if ( ! isset($res[$i])) {
                 $res[$i] = array($val[0], $val[1], $val[2]);
             } else {
-                $res[$i][0] .= $res[$i][1] . $val[0]; 
+                $res[$i][0] .= $res[$i][1] . $val[0];
                 $res[$i][1] = $val[1];
                 $res[$i][2] += $val[2];
             }

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -1960,7 +1960,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
             $array = $data;
         }
 
-        return $this->fromArray($array, $deep);
+        $this->fromArray($array, $deep);
     }
 
     /**
@@ -2093,9 +2093,9 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     public function importFrom($type, $data, $deep = true)
     {
         if ($type == 'array') {
-            return $this->fromArray($data, $deep);
+            $this->fromArray($data, $deep);
         } else {
-            return $this->fromArray(Doctrine_Parser::load($data, $type), $deep);
+            $this->fromArray(Doctrine_Parser::load($data, $type), $deep);
         }
     }
 

--- a/lib/Doctrine/Record/Generator.php
+++ b/lib/Doctrine/Record/Generator.php
@@ -74,7 +74,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
      *
      * @param string $option
      */
-    public function __isset($option) 
+    public function __isset($option)
     {
         return isset($this->_options[$option]);
     }
@@ -90,7 +90,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
         if ( ! isset($this->_options[$name])) {
             throw new Doctrine_Exception('Unknown option ' . $name);
         }
-        
+
         return $this->_options[$name];
     }
 
@@ -99,19 +99,19 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
      *
      * @param $option       the name of the option to be changed
      * @param $value        the value of the option
-     * @return Doctrine_Plugin  this object
+     * @return $this  this object
      */
     public function setOption($name, $value)
     {
         $this->_options[$name] = $value;
-        
+
         return $this;
     }
 
     /**
-     * Add child record generator 
+     * Add child record generator
      *
-     * @param  Doctrine_Record_Generator $generator 
+     * @param  Doctrine_Record_Generator $generator
      * @return void
      */
     public function addChild($generator)
@@ -133,7 +133,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
      * Initialize the plugin. Call in Doctrine_Template setTableDefinition() in order to initiate a generator in a template
      *
      * @see Doctrine_Template_I18n
-     * @param  Doctrine_Table $table 
+     * @param  Doctrine_Table $table
      * @return void
      */
     public function initialize(Doctrine_Table $table)
@@ -141,7 +141,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
       	if ($this->_initialized) {
       	    return false;
       	}
-        
+
         $this->_initialized = true;
 
         $this->initOptions();
@@ -192,7 +192,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
      */
     public function buildTable()
     {
-        // Bind model 
+        // Bind model
         $conn = $this->_options['table']->getConnection();
         $bindConnName = $conn->getManager()->getConnectionForComponent($this->_options['table']->getComponentName())->getName();
         if ($bindConnName) {
@@ -203,7 +203,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
 
         // Create table
         $tableClass = $conn->getAttribute(Doctrine_Core::ATTR_TABLE_CLASS);
-        $this->_table = new $tableClass($this->_options['className'], $conn);        
+        $this->_table = new $tableClass($this->_options['className'], $conn);
         $this->_table->setGenerator($this);
 
         // If custom table name set then lets use it
@@ -227,7 +227,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
         $conn->addTable($this->_table);
     }
 
-    /** 
+    /**
      * Empty template method for providing the concrete plugins the ability
      * to initialize options before the actual definition is being built
      *
@@ -235,7 +235,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
      */
     public function initOptions()
     {
-        
+
     }
 
     /**
@@ -296,7 +296,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
     }
 
     /**
-     * Build the local relationship on the generated model for this generator 
+     * Build the local relationship on the generated model for this generator
      * instance which points to the invoking table in $this->_options['table']
      *
      * @param string $alias Alias of the foreign relation
@@ -327,8 +327,8 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
     /**
      * Add a Doctrine_Relation::MANY relationship to the generator owner table
      *
-     * @param string $name 
-     * @param array $options 
+     * @param string $name
+     * @param array $options
      * @return void
      */
     public function ownerHasMany($name, $options)
@@ -339,8 +339,8 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
     /**
      * Add a Doctrine_Relation::ONE relationship to the generator owner table
      *
-     * @param string $name 
-     * @param array $options 
+     * @param string $name
+     * @param array $options
      * @return void
      */
     public function ownerHasOne($name, $options)
@@ -402,12 +402,12 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
                 return $column;
             }
         }
-        
+
         return $identifier;
     }
 
     /**
-     * This method can be used for generating the relation from the plugin 
+     * This method can be used for generating the relation from the plugin
      * table to the owner table. By default buildForeignRelation() and buildLocalRelation() are called
      * Those methods can be overridden or this entire method can be overridden
      *
@@ -432,7 +432,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
         $definition['tableName'] = $table->getTableName();
         $definition['actAs'] = $table->getTemplates();
 
-        return $this->generateClass($definition);
+        $this->generateClass($definition);
     }
 
     /**

--- a/lib/Doctrine/Search.php
+++ b/lib/Doctrine/Search.php
@@ -51,15 +51,15 @@ class Doctrine_Search extends Doctrine_Record_Generator
                                 'cascadeDelete'    => true,
                                 'appLevelDelete'   => false);
     /**
-     * __construct 
-     * 
-     * @param array $options 
+     * __construct
+     *
+     * @param array $options
      * @return void
      */
     public function __construct(array $options)
     {
         $this->_options = Doctrine_Lib::arrayDeepMerge($this->_options, $options);
-        
+
         if ( ! isset($this->_options['analyzer'])) {
             $this->_options['analyzer'] = 'Doctrine_Search_Analyzer_Standard';
         }
@@ -71,22 +71,23 @@ class Doctrine_Search extends Doctrine_Record_Generator
         $this->_options['analyzer'] = new $this->_options['analyzer']($this->_options['analyzer_options']);
     }
 
+    /**
+     * @return void
+     */
     public function buildTable()
     {
-        $result = parent::buildTable();
+        parent::buildTable();
 
         if ( ! isset($this->_options['connection'])) {
             $manager = Doctrine_Manager::getInstance();
             $this->_options['connection'] = $manager->getConnectionForComponent($this->_options['table']->getComponentName());
             $manager->bindComponent($this->_options['className'], $this->_options['connection']->getName());
         }
-
-        return $result;
     }
 
     /**
      * Searchable keyword search
-     * 
+     *
      * @param string $string Keyword string to search for
      * @param Doctrine_Query $query Query object to alter. Adds where condition to limit the results using the search index
      * @return array    ids and relevancy
@@ -112,13 +113,13 @@ class Doctrine_Search extends Doctrine_Record_Generator
             return $this->_options['connection']->fetchAll($q->getSqlQuery(), $q->getParams());
         }
     }
-    
+
     /**
      * analyze a text in the encoding format
-     * 
-     * @param string $text 
+     *
+     * @param string $text
      * @param string $encoding
-     * @return void
+     * @return array
      */
     public function analyze($text, $encoding = null)
     {
@@ -151,7 +152,7 @@ class Doctrine_Search extends Doctrine_Record_Generator
         $q->execute();
 
         if ($this->_options['batchUpdates'] === true) {
-            $index = new $class(); 
+            $index = new $class();
 
             foreach ((array) $this->_options['table']->getIdentifier() as $id) {
                 $index->$id = $data[$id];
@@ -183,10 +184,10 @@ class Doctrine_Search extends Doctrine_Record_Generator
     }
 
     /**
-     * readTableData 
-     * 
-     * @param mixed $limit 
-     * @param mixed $offset 
+     * readTableData
+     *
+     * @param mixed $limit
+     * @param mixed $offset
      * @return Doctrine_Collection The collection of results
      */
     public function readTableData($limit = null, $offset = null)
@@ -212,10 +213,10 @@ class Doctrine_Search extends Doctrine_Record_Generator
     }
 
     /**
-     * batchUpdateIndex 
-     * 
-     * @param mixed $limit 
-     * @param mixed $offset 
+     * batchUpdateIndex
+     *
+     * @param mixed $limit
+     * @param mixed $offset
      * @return void
      */
     public function batchUpdateIndex($limit = null, $offset = null, $encoding = null)
@@ -228,7 +229,7 @@ class Doctrine_Search extends Doctrine_Record_Generator
         $class     = $this->_options['className'];
         $fields    = $this->_options['fields'];
         $conn      = $this->_options['table']->getConnection();
-        
+
         for ($i = 0; $i < count($fields); $i++) {
             $fields[$i] = $table->getColumnName($fields[$i], $fields[$i]);
         }
@@ -270,20 +271,20 @@ class Doctrine_Search extends Doctrine_Record_Generator
             try {
                 foreach ($fields as $field) {
                     $data  = $row[$field];
-        
+
                     $terms = $this->analyze($data, $encoding);
-        
+
                     foreach ($terms as $pos => $term) {
                         $index = new $class();
-        
+
                         $index->keyword = $term;
                         $index->position = $pos;
                         $index->field = $field;
-                        
+
                         foreach ((array) $table->getIdentifier() as $identifier) {
                             $index->$identifier = $row[$table->getColumnName($identifier, $identifier)];
                         }
-    
+
                         $index->save();
                         $index->free(true);
                     }
@@ -297,8 +298,8 @@ class Doctrine_Search extends Doctrine_Record_Generator
     }
 
     /**
-     * buildDefinition 
-     * 
+     * buildDefinition
+     *
      * @return void
      */
     public function setTableDefinition()

--- a/lib/Doctrine/Search/Analyzer/Standard.php
+++ b/lib/Doctrine/Search/Analyzer/Standard.php
@@ -261,6 +261,9 @@ class Doctrine_Search_Analyzer_Standard extends Doctrine_Search_Analyzer impleme
                             'yours'
                             );
 
+    /**
+     * @return array
+     */
     public function analyze($text, $encoding = null)
     {
         $text = preg_replace('/[\'`´"]/', '', $text);
@@ -269,7 +272,7 @@ class Doctrine_Search_Analyzer_Standard extends Doctrine_Search_Analyzer impleme
         $text = str_replace('  ', ' ', $text);
 
         $terms = explode(' ', $text);
-        
+
         $ret = array();
         if ( ! empty($terms)) {
             foreach ($terms as $i => $term) {

--- a/lib/Doctrine/Search/Analyzer/Utf8.php
+++ b/lib/Doctrine/Search/Analyzer/Utf8.php
@@ -22,7 +22,7 @@
 /**
  * Doctrine_Search_Analyzer_Utf8
  *
- * This class is used to analyze (ie tokenize) an input $text in 
+ * This class is used to analyze (ie tokenize) an input $text in
  * $encoding encoding, and return an array of words to be indexed.
  *
  * @package     Doctrine
@@ -35,6 +35,9 @@
  */
 class Doctrine_Search_Analyzer_Utf8 extends Doctrine_Search_Analyzer_Standard
 {
+    /**
+     * @return array
+     */
     public function analyze($text, $encoding = null)
     {
         if (is_null($encoding)) {
@@ -50,7 +53,7 @@ class Doctrine_Search_Analyzer_Utf8 extends Doctrine_Search_Analyzer_Standard
         $text = str_replace('  ', ' ', $text);
 
         $terms = explode(' ', $text);
-        
+
         $ret = array();
         if ( ! empty($terms)) {
             foreach ($terms as $i => $term) {

--- a/lib/Doctrine/Sequence/Db2.php
+++ b/lib/Doctrine/Sequence/Db2.php
@@ -36,19 +36,19 @@ class Doctrine_Sequence_Db2 extends Doctrine_Sequence
      * Returns the next free id of a sequence
      *
      * @param string $seqName   name of the sequence
-     * @param bool              when true missing sequences are automatic created
+     * @param bool   $onDemand  when true missing sequences are automatic created
      *
      * @return integer          next id in the given sequence
      * @throws Doctrine_Sequence_Exception
      */
-    public function nextId($seqName, $ondemand = true)
+    public function nextId($seqName, $onDemand = true)
     {
         $sequenceName = $this->conn->quoteIdentifier($this->conn->formatter->getSequenceName($seqName), true);
         $query = 'SELECT NEXTVAL FOR ' . $sequenceName . ' AS VAL FROM SYSIBM.SYSDUMMY1';
-        
+
         try {
             $result = $this->conn->fetchOne($query);
-            $result = ($result) ? $result['VAL'] : null; 
+            $result = ($result) ? $result['VAL'] : null;
         } catch(Doctrine_Connection_Exception $e) {
             if ($onDemand && $e->getPortableCode() == Doctrine_Core::ERR_NOSUCHTABLE) {
                 try {
@@ -56,7 +56,7 @@ class Doctrine_Sequence_Db2 extends Doctrine_Sequence
                 } catch(Doctrine_Exception $e) {
                     throw new Doctrine_Sequence_Exception('on demand sequence ' . $seqName . ' could not be created');
                 }
-                
+
                 return $this->nextId($seqName, false);
             } else {
                 throw new Doctrine_Sequence_Exception('sequence ' .$seqName . ' does not exist');
@@ -64,7 +64,7 @@ class Doctrine_Sequence_Db2 extends Doctrine_Sequence
         }
         return $result;
     }
-    
+
     /**
      * Return the most recent value from the specified sequence in the database.
      * This is supported only on RDBMS brands that support sequences
@@ -77,10 +77,10 @@ class Doctrine_Sequence_Db2 extends Doctrine_Sequence
     public function currId($sequenceName)
     {
         $sql = 'SELECT PREVVAL FOR '
-             . $this->quoteIdentifier($this->conn->formatter->getSequenceName($sequenceName))
+             . $this->conn->quoteIdentifier($this->conn->formatter->getSequenceName($sequenceName))
              . ' AS VAL FROM SYSIBM.SYSDUMMY1';
 
-        $stmt   = $this->query($sql);
+        $stmt   = $this->conn->query($sql);
         $result = $stmt->fetchAll(Doctrine_Core::FETCH_ASSOC);
         if ($result) {
             return $result[0]['VAL'];
@@ -121,7 +121,7 @@ class Doctrine_Sequence_Db2 extends Doctrine_Sequence
         }
 
         $sql = 'SELECT IDENTITY_VAL_LOCAL() AS VAL FROM SYSIBM.SYSDUMMY1';
-        $stmt = $this->query($sql);
+        $stmt = $this->conn->query($sql);
         $result = $stmt->fetchAll(Doctrine_Core::FETCH_ASSOC);
         if ($result) {
             return $result[0]['VAL'];

--- a/lib/Doctrine/Sequence/Oracle.php
+++ b/lib/Doctrine/Sequence/Oracle.php
@@ -55,7 +55,7 @@ class Doctrine_Sequence_Oracle extends Doctrine_Sequence
                     throw new Doctrine_Sequence_Exception('on demand sequence ' . $seqName . ' could not be created');
                 }
 
-                return $this->nextId($seqName, false);
+                return $this->nextID($seqName, false);
             } else {
                 throw new Doctrine_Sequence_Exception('sequence ' .$seqName . ' does not exist');
             }

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1374,7 +1374,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
 
         $options['type'] = $type;
         $options['length'] = $length;
-        
+
         if (strtolower($fieldName) != $name) {
             $options['alias'] = $fieldName;
         }
@@ -2740,10 +2740,10 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
         $fieldsFound = $matches[1];
         $operatorFound = array_map('strtoupper', $matches[2]);
 
-        // Check if $fieldName has unidentified parts left 
+        // Check if $fieldName has unidentified parts left
         if (strlen(implode('', $fieldsFound) . implode('', $operatorFound)) !== strlen($fieldName)) {
             $expression = preg_replace('/(' . implode('|', $fields) . ')(Or|And)?/', '($1)$2', $fieldName);
-            throw new Doctrine_Table_Exception('Invalid expression found: ' . $expression);    
+            throw new Doctrine_Table_Exception('Invalid expression found: ' . $expression);
         }
 
         // Build result
@@ -2768,7 +2768,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
             }
 
             $where .= ' ' . strtoupper($operatorFound[$index]) . ' ';
-            
+
             $lastOperator = $operatorFound[$index];
         }
 
@@ -2805,7 +2805,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
      * findByColumnName, findByRelationAlias
      * findById, findByContactId, etc.
      *
-     * @return the result of the finder
+     * @return mixed the result of the finder
      */
     public function __call($method, $arguments)
     {

--- a/lib/Doctrine/Task.php
+++ b/lib/Doctrine/Task.php
@@ -21,7 +21,7 @@
 
 /**
  * Doctrine_Task
- * 
+ *
  * Abstract class used for writing Doctrine Tasks
  *
  * @package     Doctrine
@@ -69,12 +69,12 @@ abstract class Doctrine_Task
 
     /**
      * Returns the name of the task the specified class _would_ implement
-     * 
+     *
      * N.B. This method does not check if the specified class is actually a Doctrine Task
-     * 
+     *
      * This is public so we can easily test its reactions to fully-qualified class names, without having to add
      * PHP 5.3-specific test code
-     * 
+     *
      * @param string $className
      * @return string|bool
      */
@@ -94,14 +94,14 @@ abstract class Doctrine_Task
     /**
      * notify
      *
-     * @param string $notification 
+     * @param string $notification
      * @return void
      */
     public function notify($notification = null)
     {
         if (is_object($this->dispatcher) && method_exists($this->dispatcher, 'notify')) {
             $args = func_get_args();
-            
+
             return call_user_func_array(array($this->dispatcher, 'notify'), $args);
         } else if ( $notification !== null ) {
             return $notification;
@@ -113,16 +113,16 @@ abstract class Doctrine_Task
     /**
      * ask
      *
-     * @return void
+     * @return string
      */
     public function ask()
     {
         $args = func_get_args();
-        
+
         call_user_func_array(array($this, 'notify'), $args);
-        
+
         $answer = strtolower(trim(fgets(STDIN)));
-        
+
         return $answer;
     }
 
@@ -146,21 +146,21 @@ abstract class Doctrine_Task
     public function validate()
     {
         $requiredArguments = $this->getRequiredArguments();
-        
+
         foreach ($requiredArguments as $arg) {
             if ( ! isset($this->arguments[$arg])) {
                 return false;
             }
         }
-        
+
         return true;
     }
 
     /**
      * addArgument
      *
-     * @param string $name 
-     * @param string $value 
+     * @param string $name
+     * @param string $value
      * @return void
      */
     public function addArgument($name, $value)
@@ -171,8 +171,8 @@ abstract class Doctrine_Task
     /**
      * getArgument
      *
-     * @param string $name 
-     * @param string $default 
+     * @param string $name
+     * @param string $default
      * @return mixed
      */
     public function getArgument($name, $default = null)
@@ -197,7 +197,7 @@ abstract class Doctrine_Task
     /**
      * setArguments
      *
-     * @param array $args 
+     * @param array $args
      * @return void
      */
     public function setArguments(array $args)
@@ -207,7 +207,7 @@ abstract class Doctrine_Task
 
     /**
      * Returns TRUE if the specified task name is valid, or FALSE otherwise
-     * 
+     *
      * @param string $taskName
      * @return bool
      */

--- a/lib/Doctrine/Task/BuildAll.php
+++ b/lib/Doctrine/Task/BuildAll.php
@@ -35,30 +35,33 @@ class Doctrine_Task_BuildAll extends Doctrine_Task
     public $description          =   'Calls generate-models-from-yaml, create-db, and create-tables',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();
-    
+
     protected $models,
               $tables;
-    
+
+    // This was undefined, added for static analysis and set to public so api isn't changed
+    public $createDb;
+
     public function __construct($dispatcher = null)
     {
         parent::__construct($dispatcher);
-        
+
         $this->models = new Doctrine_Task_GenerateModelsYaml($this->dispatcher);
         $this->createDb = new Doctrine_Task_CreateDb($this->dispatcher);
         $this->tables = new Doctrine_Task_CreateTables($this->dispatcher);
-        
+
         $this->requiredArguments = array_merge($this->requiredArguments, $this->models->requiredArguments, $this->createDb->requiredArguments, $this->tables->requiredArguments);
         $this->optionalArguments = array_merge($this->optionalArguments, $this->models->optionalArguments, $this->createDb->optionalArguments, $this->tables->optionalArguments);
     }
-    
+
     public function execute()
     {
         $this->models->setArguments($this->getArguments());
         $this->models->execute();
-        
+
         $this->createDb->setArguments($this->getArguments());
         $this->createDb->execute();
-        
+
         $this->tables->setArguments($this->getArguments());
         $this->tables->execute();
     }

--- a/lib/Doctrine/Task/BuildAllLoad.php
+++ b/lib/Doctrine/Task/BuildAllLoad.php
@@ -35,23 +35,27 @@ class Doctrine_Task_BuildAllLoad extends Doctrine_Task
     public $description          =   'Calls build-all, and load-data',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();
-    
+
+    // These were undefined, added for static analysis and set to public so api isn't changed
+    public $buildAll;
+    public $loadData;
+
     public function __construct($dispatcher = null)
     {
         parent::__construct($dispatcher);
 
         $this->buildAll = new Doctrine_Task_BuildAll($this->dispatcher);
         $this->loadData = new Doctrine_Task_LoadData($this->dispatcher);
-        
+
         $this->requiredArguments = array_merge($this->requiredArguments, $this->buildAll->requiredArguments, $this->loadData->requiredArguments);
         $this->optionalArguments = array_merge($this->optionalArguments, $this->buildAll->optionalArguments, $this->loadData->optionalArguments);
     }
-    
+
     public function execute()
     {
         $this->buildAll->setArguments($this->getArguments());
         $this->buildAll->execute();
-        
+
         $this->loadData->setArguments($this->getArguments());
         $this->loadData->execute();
     }

--- a/lib/Doctrine/Task/BuildAllReload.php
+++ b/lib/Doctrine/Task/BuildAllReload.php
@@ -35,23 +35,27 @@ class Doctrine_Task_BuildAllReload extends Doctrine_Task
     public $description          =   'Calls rebuild-db and load-data',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();
-    
+
+    // These were undefined, added for static analysis and set to public so api isn't changed
+    public $loadData;
+    public $rebuildDb;
+
     public function __construct($dispatcher = null)
     {
         parent::__construct($dispatcher);
 
         $this->rebuildDb = new Doctrine_Task_RebuildDb($this->dispatcher);
         $this->loadData = new Doctrine_Task_LoadData($this->dispatcher);
-        
+
         $this->requiredArguments = array_merge($this->requiredArguments, $this->rebuildDb->requiredArguments, $this->loadData->requiredArguments);
         $this->optionalArguments = array_merge($this->optionalArguments, $this->rebuildDb->optionalArguments, $this->loadData->optionalArguments);
     }
-    
+
     public function execute()
     {
         $this->rebuildDb->setArguments($this->getArguments());
         $this->rebuildDb->execute();
-        
+
         $this->loadData->setArguments($this->getArguments());
         $this->loadData->execute();
     }

--- a/lib/Doctrine/Task/RebuildDb.php
+++ b/lib/Doctrine/Task/RebuildDb.php
@@ -35,11 +35,16 @@ class Doctrine_Task_RebuildDb extends Doctrine_Task
     public $description          =   'Drops and re-creates databases',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();
-    
+
+    // These were undefined, added for static analysis and set to public so api isn't changed
+    public $createDb;
+    public $createTables;
+    public $dropDb;
+
     public function __construct($dispatcher = null)
     {
         parent::__construct($dispatcher);
-        
+
         $this->dropDb = new Doctrine_Task_DropDb($this->dispatcher);
         $this->createDb = new Doctrine_Task_CreateDb($this->dispatcher);
         $this->createTables = new Doctrine_Task_CreateTables($this->dispatcher);

--- a/lib/Doctrine/Template/Geographical.php
+++ b/lib/Doctrine/Template/Geographical.php
@@ -20,7 +20,7 @@
  */
 
 /**
- * Easily add longitude and latitude columns to your records and use inherited functionality for 
+ * Easily add longitude and latitude columns to your records and use inherited functionality for
  * calculating distances
  *
  * @package     Doctrine
@@ -60,7 +60,7 @@ class Doctrine_Template_Geographical extends Doctrine_Template
     }
 
     /**
-     * Initiate and get a distance query with the select parts for the number of kilometers and miles 
+     * Initiate and get a distance query with the select parts for the number of kilometers and miles
      * between this record and other zipcode records in the database
      *
      * @return Doctrine_Query $query
@@ -90,14 +90,14 @@ class Doctrine_Template_Geographical extends Doctrine_Template
     /**
      * Get distance between this record and another
      *
-     * @param string $Doctrine_Record 
-     * @param string $kilometers 
+     * @param string $Doctrine_Record
+     * @param string $kilometers
      * @return integer
      */
     public function getDistance(Doctrine_Record $record, $kilometers = false)
     {
-        $query = $this->getDistanceQuery($kilometers);
-        
+        $query = $this->getDistanceQuery();
+
         $conditions = array();
         $values = array();
         foreach ((array) $record->getTable()->getIdentifier() as $id) {
@@ -112,7 +112,7 @@ class Doctrine_Template_Geographical extends Doctrine_Template
         $query->limit(1);
 
         $result = $query->execute()->getFirst();
-        
+
         if (isset($result['kilometers']) && $result['miles']) {
             return $kilometers ? $result->get('kilometers'):$result->get('miles');
         } else {

--- a/lib/Doctrine/Template/Listener/Timestampable.php
+++ b/lib/Doctrine/Template/Listener/Timestampable.php
@@ -43,7 +43,7 @@ class Doctrine_Template_Listener_Timestampable extends Doctrine_Record_Listener
     /**
      * __construct
      *
-     * @param string $options 
+     * @param string $options
      * @return void
      */
     public function __construct(array $options)
@@ -116,8 +116,8 @@ class Doctrine_Template_Listener_Timestampable extends Doctrine_Record_Listener
     /**
      * Gets the timestamp in the correct format based on the way the behavior is configured
      *
-     * @param string $type 
-     * @return void
+     * @param string $type
+     * @return int|string|Doctrine_Expression
      */
     public function getTimestamp($type, $conn = null)
     {

--- a/lib/Doctrine/Transaction.php
+++ b/lib/Doctrine/Transaction.php
@@ -55,7 +55,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
      *                                  transaction.
      */
     protected $_nestingLevel = 0;
-    
+
     /**
      * @var integer $_internalNestingLevel  The current internal nesting level of this transaction.
      *                                      "Internal" means transactions started by Doctrine itself.
@@ -143,7 +143,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
     * Return the invalid records
     *
     * @return array An array of invalid records
-    */ 
+    */
     public function getInvalid()
     {
         return $this->invalid;
@@ -159,7 +159,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
     {
         return $this->_nestingLevel;
     }
-    
+
     public function getInternalTransactionLevel()
     {
         return $this->_internalNestingLevel;
@@ -178,13 +178,13 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
      * Listeners: onPreTransactionBegin, onTransactionBegin
      *
      * @param string $savepoint                 name of a savepoint to set
-     * @throws Doctrine_Transaction_Exception   if the transaction fails at database level     
+     * @throws Doctrine_Transaction_Exception   if the transaction fails at database level
      * @return integer                          current transaction nesting level
      */
     public function beginTransaction($savepoint = null)
     {
         $this->conn->connect();
-        
+
         $listener = $this->conn->getAttribute(Doctrine_Core::ATTR_LISTENER);
 
         if ( ! is_null($savepoint)) {
@@ -238,7 +238,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
         if ($this->_nestingLevel == 0) {
             throw new Doctrine_Transaction_Exception("Commit failed. There is no active transaction.");
         }
-        
+
         $this->conn->connect();
 
         $listener = $this->conn->getAttribute(Doctrine_Core::ATTR_LISTENER);
@@ -256,7 +256,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
 
             $listener->postSavepointCommit($event);
         } else {
-                 
+
             if ($this->_nestingLevel == 1 || $this->_internalNestingLevel == 1) {
                 if ( ! empty($this->invalid)) {
                     if ($this->_internalNestingLevel == 1) {
@@ -281,13 +281,13 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
                     $listener->postTransactionCommit($event);
                 }
             }
-            
+
             if ($this->_nestingLevel > 0) {
                 $this->_nestingLevel--;
-            }            
+            }
             if ($this->_internalNestingLevel > 0) {
                 $this->_internalNestingLevel--;
-            } 
+            }
         }
 
         return true;
@@ -303,7 +303,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
      * this method can be listened with onPreTransactionRollback and onTransactionRollback
      * eventlistener methods
      *
-     * @param string $savepoint                 name of a savepoint to rollback to   
+     * @param string $savepoint                 name of a savepoint to rollback to
      * @throws Doctrine_Transaction_Exception   if the rollback operation fails at database level
      * @return boolean                          false if rollback couldn't be performed, true otherwise
      * @todo Shouldnt this method only commit a rollback if the transactionLevel is 1
@@ -318,7 +318,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
         if ($this->_nestingLevel == 0) {
             throw new Doctrine_Transaction_Exception("Rollback failed. There is no active transaction.");
         }
-        
+
         $this->conn->connect();
 
         if ($this->_internalNestingLevel >= 1 && $this->_nestingLevel > 1) {
@@ -338,7 +338,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
             $event = new Doctrine_Event($this, Doctrine_Event::SAVEPOINT_ROLLBACK);
 
             $listener->preSavepointRollback($event);
-            
+
             if ( ! $event->skipOperation) {
                 $this->rollbackSavePoint($savepoint);
             }
@@ -346,9 +346,9 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
             $listener->postSavepointRollback($event);
         } else {
             $event = new Doctrine_Event($this, Doctrine_Event::TX_ROLLBACK);
-    
+
             $listener->preTransactionRollback($event);
-            
+
             if ( ! $event->skipOperation) {
                 $this->_nestingLevel = 0;
                 $this->_internalNestingLevel = 0;
@@ -400,7 +400,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
     {
         throw new Doctrine_Transaction_Exception('Savepoints not supported by this driver.');
     }
-    
+
     /**
      * Performs the rollback.
      */
@@ -408,7 +408,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
     {
         $this->conn->getDbh()->rollback();
     }
-    
+
     /**
      * Performs the commit.
      */
@@ -416,7 +416,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
     {
         $this->conn->getDbh()->commit();
     }
-    
+
     /**
      * Begins a database transaction.
      */
@@ -430,7 +430,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
      * removes a savepoint from the internal savePoints array of this transaction object
      * and all its children savepoints
      *
-     * @param sring $savepoint      name of the savepoint to remove
+     * @param string $savepoint      name of the savepoint to remove
      * @return integer              removed savepoints
      */
     private function removeSavePoints($savepoint)
@@ -498,7 +498,7 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
     {
         throw new Doctrine_Transaction_Exception('Fetching transaction isolation level not supported by this driver.');
     }
-    
+
     /**
      * Initiates a transaction.
      *
@@ -510,5 +510,5 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
         $this->_internalNestingLevel++;
         return $this->beginTransaction($savepoint);
     }
-    
+
 }

--- a/lib/Doctrine/Tree/NestedSet.php
+++ b/lib/Doctrine/Tree/NestedSet.php
@@ -94,14 +94,14 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
                         . " be created as a root node. Automatic assignment of a root id on"
                         . " transient/new records is no longer supported.");
             }
-            
+
             if ($record->exists() && ! $record->getNode()->getRootValue()) {
                 // Default: root_id = id
                 $identifier = $record->getTable()->getIdentifier();
                 $record->getNode()->setRootValue($record->get($identifier));
             }
         }
-        
+
         if ( ! $record) {
             $record = $this->table->create();
         }
@@ -173,8 +173,8 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
             $q->addOrderBy($this->_baseAlias . ".lft ASC");
         }
 
-        if ( ! is_null($depth)) { 
-            $q->addWhere($this->_baseAlias . ".level BETWEEN ? AND ?", array(0, $depth)); 
+        if ( ! is_null($depth)) {
+            $q->addWhere($this->_baseAlias . ".level BETWEEN ? AND ?", array(0, $depth));
         }
 
         $q = $this->returnQueryWithRootId($q, $rootId);
@@ -212,8 +212,8 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
         $q->addWhere($this->_baseAlias . ".lft >= ? AND " . $this->_baseAlias . ".rgt <= ?", $params)
                 ->addOrderBy($this->_baseAlias . ".lft asc");
 
-        if ( ! is_null($depth)) { 
-            $q->addWhere($this->_baseAlias . ".level BETWEEN ? AND ?", array($record->get('level'), $record->get('level')+$depth)); 
+        if ( ! is_null($depth)) {
+            $q->addWhere($this->_baseAlias . ".level BETWEEN ? AND ?", array($record->get('level'), $record->get('level')+$depth));
         }
 
         $q = $this->returnQueryWithRootId($q, $record->getNode()->getRootValue());
@@ -259,7 +259,7 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
      * Enter description here...
      *
      * @param array $options
-     * @return unknown
+     * @return Doctrine_Query
      */
     public function getBaseQuery()
     {

--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -38,11 +38,14 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
      */
     private static $validators = array();
 
+    // This was undefined, added for static analysis and set to public so api isn't changed
+    public $stack;
+
     /**
      * Get a validator instance for the passed $name
      *
      * @param  string   $name  Name of the validator or the validator class name
-     * @return Doctrine_Validator_Interface $validator
+     * @return Doctrine_Validator_Driver $validator
      */
     public static function getValidator($name)
     {

--- a/lib/Doctrine/Validator/ErrorStack.php
+++ b/lib/Doctrine/Validator/ErrorStack.php
@@ -146,7 +146,7 @@ class Doctrine_Validator_ErrorStack extends Doctrine_Access implements Countable
     /**
      * Enter description here...
      *
-     * @return unknown
+     * @return ArrayIterator
      */
     public function getIterator()
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,69 @@
+parameters:
+    ignoreErrors:
+        #########
+        # Level 0
+        #########
+        # Missing functions due to extension not installed
+        - '#Function oci_.+ not found\.#'
+        - '#Function apc_.+ not found\.#'
+        - '#Function xcache_.+ not found\.#'
+        # Memcache extension not installed
+        - '#Instantiated class Memcache not found\.#'
+        - '#Property .+ unknown class Memcache as its type\.#'
+        # These two methods don't exist (anywhere in Doctrine), this sequence adapter is probably broken
+        - '#Call to an undefined method Doctrine_Sequence_Db2::_connect\(\)\.#'
+        - '#Call to an undefined method Doctrine_Sequence_Db2::lastSequenceId\(\)\.#'
+        # This method only exists on Doctrine_Query_Condition
+        - '#Call to an undefined method Doctrine_Query_Set::parseLiteralValue\(\)\.#'
+        # These methods are defined on Doctrine_Query, and probably should be made abstract in Doctrine_Query_Abstract,
+        # but that would break anything extending Doctrine_Query_Abstract that doesn't define the method (like Doctrine_RawSql)
+        - '#Call to an undefined method Doctrine_Query_Abstract::isSubquery\(\)\.#'
+        - '#Call to an undefined method Doctrine_Query_Abstract::copy\(\)\.#'
+        # Similar to above, this is defined in all sub-classes of Doctrine_Query_Condition, but not in the abstract class
+        # itself, so should be an abstract method, but that would break any code outside of Doctrine that extends this
+        - '#Call to an undefined method Doctrine_Query_Condition::load\(\)\.#'
+        # Both Doctrine_Expression_Mysql and Doctrine_Expression_Pgsql call this, but doesn't seem to exist anywhere in
+        # the Doctrine codebase. Both methods it appears in are marked as "experimental"
+        - '#Call to an undefined method Doctrine_Expression_.+sql::patternEscapeString\(\)\.#'
+        # These two exception classes are found in the same "experimental" method as the above error
+        - '#Instantiated class Doctrine_Expression_.+sql_Exception not found\.#'
+        # This method does not exist anywhere in Doctrine
+        - '#Call to an undefined method Doctrine_Search_Indexer_Dir::indexFile\(\)\.#'
+        # Doctrine_Query_Abstract defines this with just one parameter but Doctrine_Query (which extends Doctrine_Query_Abstract)
+        # defines it with a second parameter ($limitSubQuery). Since this is called from Doctrine_Query_Abstract, the abstract
+        # signature should probably be changed, but that could break other implementations.
+        - '#Method Doctrine_Query_Abstract::getSqlQuery\(\) invoked with 2 parameters, 0-1 required\.#'
+        # In Doctrine_Column, not sure the intent here, seems like $field was to be passed to filter which enum value was sent?
+        # Either way, this method does not accept a parameter.
+        - '#Method Doctrine_Column::getEnumValues\(\) invoked with 1 parameter, 0 required\.#'
+        # In Doctrine_Cli_Formatter:81, this seems like a bug, the format probably has a type-o, but not sure what the intent was
+        # php > echo sprintf(">> %-$9s %s", 'testing', 'another test');
+        #   >> 9s another test
+        - '#Call to sprintf contains 1 placeholder, 2 values given\.#'
+        # This is probably intentional since it's a mock and doesn't want to have the same functionality as a true connection
+        - '#Doctrine_Connection_Mock::__construct\(\) does not call parent constructor from Doctrine_Connection\.#'
+        - '#Constructor of class Doctrine_Connection_Mock has an unused parameter \$.+\.#'
+        # Not really harmful or anything, none of the classes that ultimately extend Doctrine_Connection have either param
+        # in their signature. Even other extending classes shouldn't be affected if removed from signature, but just ignoring
+        - '#Constructor of class Doctrine_Connection has an unused parameter \$user\.#'
+        - '#Constructor of class Doctrine_Connection has an unused parameter \$pass\.#'
+        # These aren't implemented yet (throw an exception stating such)
+        - '#Constructor of class Doctrine_Node_MaterializedPath_.+Iterator has an unused parameter \$(node|opts)\.#'
+        # This might be a type-o, not sure. Doctrine_Connection has a __get magic method that returns various properties, most of
+        # them defined in the $modules property. There's an "export" property defined there, but not "exported"
+        - '#Access to an undefined property Doctrine_Connection::\$exported\.#'
+        # Don't really see this referenced anywhere other than being set in a few classes (These two and on a "conn" property in Doctrine_DataDict_Pgsql)
+        # Doesn't appear to be used with __get or __set either (the Sequence class or its parents don't define any of those)
+        - '#Access to an undefined property Doctrine_Sequence::\$warnings\.#'
+        - '#Access to an undefined property Doctrine_Sequence_Mssql::\$warnings\.#'
+        # This is probably supposed to be `$this->conn->string_quoting` as the Doctrine_Connection class does have that
+        # property (through __get), and does look like it contains an "escape_pattern" key
+        - '#Access to an undefined property Doctrine_Formatter::\$string_quoting\.#'
+        # This one is on Doctrine_Connection as well (through __get)
+        - '#Access to an undefined property Doctrine_Formatter::\$wildcards\.#'
+        # This one is probably supposed to be $_preQueried, not $_preQuery, which exists on Doctrine_Query_Abstract that Doctrine_RawSql extends
+        # Didn't change as I don't know what the effect would be
+        - '#Access to an undefined property Doctrine_RawSql::\$_preQuery\.#'
+        # This is defined in Doctrine_Hydrator, but not Doctrine_Hydrator_Abstract (which both Doctrine_Hydrator and Doctrine_Hydrator_Graph extend)
+        # Should probably be defined in the Abstract
+        - '#Access to an undefined property Doctrine_Hydrator_Graph::\$_rootAlias\.#'


### PR DESCRIPTION
I'm working to get doctrine1 to pass phpstan checks.  I'm trying to make as few code changes as possible and focus on the docblock changes, though I have added some property declarations and fixed some type-os here and there (I'll document the code changes inline).

This PR is just the first level of checks (level 0).

I'll follow up with more as time permits (in separate PRs).

I didn't add phpstan to the dev dependencies since it's not compatible with PHP 5.6 (so our travis build for that version would break).  Once 5.6 support is removed (end of this year no?) we can add to composer and have it run in travis (we could add a phar download of phpstan to travis and just run in php >= 7.0 though).