### PR TITLE
Level 1 phpstan fixes

### DIFF
--- a/lib/Doctrine/AuditLog.php
+++ b/lib/Doctrine/AuditLog.php
@@ -128,6 +128,7 @@ class Doctrine_AuditLog extends Doctrine_Record_Generator
             ->createQuery();
 
         $values = array();
+        $conditions = array();
         foreach ((array) $this->_options['table']->getIdentifier() as $id) {
             $conditions[] = $className . '.' . $id . ' = ?';
             $values[] = $record->get($id);
@@ -152,6 +153,8 @@ class Doctrine_AuditLog extends Doctrine_Record_Generator
     {
         $className = $this->_options['className'];
         $select = 'MAX(' . $className . '.' . $this->_options['version']['name'] . ') max_version';
+        $conditions = array();
+        $values = array();
 
         foreach ((array) $this->_options['table']->getIdentifier() as $id) {
             $conditions[] = $className . '.' . $id . ' = ?';

--- a/lib/Doctrine/AuditLog/Listener.php
+++ b/lib/Doctrine/AuditLog/Listener.php
@@ -42,10 +42,10 @@ class Doctrine_AuditLog_Listener extends Doctrine_Record_Listener
     /**
      * Instantiate AuditLog listener and set the Doctrine_AuditLog instance to the class
      *
-     * @param   Doctrine_AuditLog $auditLog 
+     * @param   Doctrine_AuditLog $auditLog
      * @return  void
      */
-    public function __construct(Doctrine_AuditLog $auditLog) 
+    public function __construct(Doctrine_AuditLog $auditLog)
     {
         $this->_auditLog = $auditLog;
     }
@@ -69,10 +69,10 @@ class Doctrine_AuditLog_Listener extends Doctrine_Record_Listener
      * Post insert event hook which creates the new version record
      * This will only insert a version record if the auditLog is enabled
      *
-     * @param   Doctrine_Event $event 
+     * @param   Doctrine_Event $event
      * @return  void
      */
-    public function postInsert(Doctrine_Event $event) 
+    public function postInsert(Doctrine_Event $event)
     {
         if ($this->_auditLog->getOption('auditLog')) {
             $class = $this->_auditLog->getOption('className');
@@ -100,6 +100,8 @@ class Doctrine_AuditLog_Listener extends Doctrine_Record_Listener
 	        $event->getInvoker()->set($name, null);
 
             if ($this->_auditLog->getOption('deleteVersions')) {
+                $conditions = array();
+                $values = array();
     	        $q = Doctrine_Core::getTable($className)
     	            ->createQuery('obj')
     	            ->delete();
@@ -152,7 +154,7 @@ class Doctrine_AuditLog_Listener extends Doctrine_Record_Listener
     /**
      * Get the next version number for the audit log
      *
-     * @param Doctrine_Record $record 
+     * @param Doctrine_Record $record
      * @return integer $nextVersion
      */
     protected function _getNextVersion(Doctrine_Record $record)

--- a/lib/Doctrine/Compiler.php
+++ b/lib/Doctrine/Compiler.php
@@ -127,7 +127,7 @@ class Doctrine_Compiler
         $stripped = php_strip_whitespace($target);
         $fp = @fopen($target, 'w');
         if ($fp === false) {
-            throw new Doctrine_Compiler_Exception("Couldn't write compiled data. Failed to open $file");
+            throw new Doctrine_Compiler_Exception("Couldn't write compiled data. Failed to open $target");
         }
 
         fwrite($fp, $stripped);

--- a/lib/Doctrine/Connection/Mssql.php
+++ b/lib/Doctrine/Connection/Mssql.php
@@ -154,6 +154,11 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
 
         $count = intval($limit);
         $offset = intval($offset);
+        $orders = array();
+        $tables = array();
+        $columns = array();
+        $aliases = array();
+        $sorts = array();
 
         if ($offset < 0) {
             throw new Doctrine_Connection_Exception("LIMIT argument offset=$offset is not valid");

--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -338,6 +338,7 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
         $event = new Doctrine_Event($this, Doctrine_Event::STMT_FETCHALL, $this->getQuery());
         $event->fetchMode = $fetchMode;
         $event->columnIndex = $columnIndex;
+        $data = array();
 
         $this->_conn->getListener()->preFetchAll($event);
 
@@ -484,6 +485,6 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
             return $this->_stmt->setFetchMode($mode, $arg1, $arg2);
         } else {
             return $this->_stmt->setFetchMode($mode);
-        } 
+        }
     }
 }

--- a/lib/Doctrine/Connection/UnitOfWork.php
+++ b/lib/Doctrine/Connection/UnitOfWork.php
@@ -101,7 +101,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
                     foreach ($record->getPendingDeletes() as $pendingDelete) {
                         $pendingDelete->delete();
                     }
-                
+
                     foreach ($record->getPendingUnlinks() as $alias => $ids) {
                         if ($ids === false) {
                             $record->unlinkInDb($alias, array());
@@ -376,7 +376,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
 
         return $saveLater;
     }
-    
+
     /**
      * saveRelatedLocalKeys
      * saves all related (through LocalKey) records to $record
@@ -391,7 +391,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
 
         foreach ($record->getReferences() as $k => $v) {
             $rel = $record->getTable()->getRelation($k);
-            
+
             $local = $rel->getLocal();
             $foreign = $rel->getForeign();
 
@@ -408,7 +408,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
                     if ( ! empty($id)) {
                         foreach ((array) $rel->getLocal() as $k => $columnName) {
                             $field = $record->getTable()->getFieldName($columnName);
-                            
+
                             if (isset($id[$k]) && $id[$k] && $record->getTable()->hasField($field)) {
                                 $record->set($field, $id[$k]);
                             }
@@ -548,11 +548,11 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
      * Inserts a record into database.
      *
      * This method inserts a transient record in the database, and adds it
-     * to the identity map of its correspondent table. It proxies to @see 
+     * to the identity map of its correspondent table. It proxies to @see
      * processSingleInsert(), trigger insert hooks and validation of data
      * if required.
      *
-     * @param Doctrine_Record $record   
+     * @param Doctrine_Record $record
      * @return boolean                  false if record is not valid
      */
     public function insert(Doctrine_Record $record)
@@ -584,7 +584,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
     /**
      * Replaces a record into database.
      *
-     * @param Doctrine_Record $record   
+     * @param Doctrine_Record $record
      * @return boolean                  false if record is not valid
      */
     public function replace(Doctrine_Record $record)
@@ -600,7 +600,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
 
                 $table = $record->getTable();
                 $identifier = (array) $table->getIdentifier();
-                $data = $record->getPrepared();       
+                $data = $record->getPrepared();
 
                 foreach ($data as $key  => $value) {
                     if ($value instanceof Doctrine_Expression) {
@@ -625,9 +625,9 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
     /**
      * Inserts a transient record in its table.
      *
-     * This method inserts the data of a single record in its assigned table, 
+     * This method inserts the data of a single record in its assigned table,
      * assigning to it the autoincrement primary key (if any is defined).
-     * 
+     *
      * @param Doctrine_Record $record
      * @return void
      */
@@ -937,13 +937,13 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
         if (empty($seq) && !is_array($identifier) &&
             $table->getIdentifierType() != Doctrine_Core::IDENTIFIER_NATURAL) {
             $id = false;
-            if ($record->$identifier == null) { 
+            if ($record->$identifier == null) {
                 if (($driver = strtolower($this->conn->getDriverName())) == 'pgsql') {
                     $seq = $table->getTableName() . '_' . $table->getColumnName($identifier);
                 } elseif ($driver == 'oracle' || $driver == 'mssql') {
                     $seq = $table->getTableName();
                 }
-    
+
                 $id = $this->conn->sequence->lastInsertId($seq);
             } else {
                 $id = $record->$identifier;

--- a/lib/Doctrine/Export.php
+++ b/lib/Doctrine/Export.php
@@ -670,6 +670,8 @@ class Doctrine_Export extends Doctrine_Connection_Module
      */
     public function getFieldDeclarationList(array $fields)
     {
+        $queryFields = array();
+
         foreach ($fields as $fieldName => $field) {
             $query = $this->getDeclaration($fieldName, $field);
 

--- a/lib/Doctrine/Expression.php
+++ b/lib/Doctrine/Expression.php
@@ -22,7 +22,7 @@
 /**
  * Doctrine_Expression memorizes a dql expression that use a db function.
  *
- * This class manages abstractions of dql expressions like query parts 
+ * This class manages abstractions of dql expressions like query parts
  * that use CONCAT(), MIN(), SUM().
  *
  * @package     Doctrine
@@ -42,12 +42,12 @@ class Doctrine_Expression
     /**
      * Creates an expression.
      *
-     * The constructor needs the dql fragment that contains one or more dbms 
+     * The constructor needs the dql fragment that contains one or more dbms
      * functions.
      * <code>
      * $e = new Doctrine_Expression("CONCAT('some', 'one')");
      * </code>
-     * 
+     *
      * @param string $expr                  sql fragment
      * @param Doctrine_Connection $conn     the connection (optional)
      */
@@ -62,8 +62,8 @@ class Doctrine_Expression
 
     /**
      * Retrieves the connection associated to this expression at creation,
-     * or the current connection used if it was not specified. 
-     * 
+     * or the current connection used if it was not specified.
+     *
      * @return Doctrine_Connection The connection
      */
     public function getConnection()
@@ -80,7 +80,7 @@ class Doctrine_Expression
      * <code>
      * $e->setExpression("CONCAT('some', 'one')");
      * </code>
-     * 
+     *
      * @param string $clause The expression to set
      * @return void
      */
@@ -90,7 +90,7 @@ class Doctrine_Expression
     }
 
     /**
-     * Parses a single expressions and substitutes dql abstract functions 
+     * Parses a single expressions and substitutes dql abstract functions
      * with their concrete sql counterparts for the given connection.
      *
      * @param string $expr The expression to parse
@@ -107,6 +107,7 @@ class Doctrine_Expression
         // get the name of the function
         $name   = substr($expr, 0, $pos);
         $argStr = substr($expr, ($pos + 1), -1);
+        $args = [];
 
         // parse args
         foreach ($this->_tokenizer->bracketExplode($argStr, ',') as $arg) {
@@ -117,9 +118,9 @@ class Doctrine_Expression
     }
 
     /**
-     * Parses a set of expressions at once. 
+     * Parses a set of expressions at once.
      * @see parseExpression()
-     * 
+     *
      * @param string $clause    The clause. Can be complex and parenthesised.
      * @return string           The parsed clause.
      */
@@ -130,13 +131,13 @@ class Doctrine_Expression
         foreach ($e as $k => $expr) {
             $e[$k] = $this->parseExpression($expr);
         }
-        
+
         return implode(' ', $e);
     }
 
     /**
      * Gets the sql fragment represented.
-     * 
+     *
      * @return string
      */
     public function getSql()
@@ -146,9 +147,9 @@ class Doctrine_Expression
 
     /**
      * Magic method.
-     * 
+     *
      * Returns a string representation of this object. Proxies to @see getSql().
-     * 
+     *
      * @return string
      */
     public function __toString()

--- a/lib/Doctrine/Hook.php
+++ b/lib/Doctrine/Hook.php
@@ -84,9 +84,9 @@ class Doctrine_Hook
         } elseif ($query instanceof Doctrine_Query) {
             $this->query = $query;
         } else {
-            throw new Doctrine_Exception('Constructor argument should be either Doctrine_Query object or valid DQL query');          
+            throw new Doctrine_Exception('Constructor argument should be either Doctrine_Query object or valid DQL query');
         }
-        
+
         $this->query->getSqlQuery();
     }
 
@@ -106,7 +106,7 @@ class Doctrine_Hook
      * @param string $type              type name
      * @param string|object $parser     parser name or custom parser object
      */
-    public function setTypeParser($type, $parser) 
+    public function setTypeParser($type, $parser)
     {
         $this->typeParsers[$type] = $parser;
     }
@@ -157,11 +157,11 @@ class Doctrine_Hook
                     if (isset($this->typeParsers[$def[0]])) {
                         $name   = $this->typeParsers[$def[0]];
                         $parser = new $name;
+
+                        $parser->parse($alias, $column, $value);
+
+                        $this->query->addWhere($parser->getCondition(), $parser->getParams());
                     }
-
-                    $parser->parse($alias, $column, $value);
-
-                    $this->query->addWhere($parser->getCondition(), $parser->getParams());
                 }
             }
         }
@@ -199,7 +199,7 @@ class Doctrine_Hook
                 $map   = $this->query->getQueryComponent($alias);
                 $table = $map['table'];
 
-                if ($def = $table->getDefinitionOf($column)) {   
+                if ($def = $table->getDefinitionOf($column)) {
                     $this->query->addOrderBy($alias . '.' . $column . ' ' . $order);
                 }
             }
@@ -208,9 +208,9 @@ class Doctrine_Hook
     }
 
     /**
-     * set the hook limit 
-     * 
-     * @param integer $limit 
+     * set the hook limit
+     *
+     * @param integer $limit
      * @return void
      */
     public function hookLimit($limit)

--- a/lib/Doctrine/Hook/Integer.php
+++ b/lib/Doctrine/Hook/Integer.php
@@ -47,15 +47,16 @@ class Doctrine_Hook_Integer extends Doctrine_Hook_Parser_Complex
     public function parseSingle($alias, $field, $value)
     {
         $e = explode(' ', $value);
+        $a = array();
 
         foreach ($e as $v) {
-             $v = trim($v);
+            $v = trim($v);
 
-             $e2   = explode('-', $v);
+            $e2   = explode('-', $v);
 
             $name = $alias. '.' . $field;
 
-             if (count($e2) == 1) {
+            if (count($e2) == 1) {
                  // one '-' found
 
                 $a[] = $name . ' = ?';

--- a/lib/Doctrine/Hook/WordLike.php
+++ b/lib/Doctrine/Hook/WordLike.php
@@ -46,6 +46,8 @@ class Doctrine_Hook_WordLike extends Doctrine_Hook_Parser_Complex
      */
     public function parseSingle($alias, $field, $value)
     {
+        $a = array();
+
         if (strpos($value, "'") !== false) {
             $value = $this->_tokenizer->bracketTrim($value, "'", "'");
 

--- a/lib/Doctrine/IntegrityMapper.php
+++ b/lib/Doctrine/IntegrityMapper.php
@@ -93,6 +93,9 @@ class Doctrine_IntegrityMapper
 
         $aliases = array();
         $indexes = array();
+        $fields = array();
+        $cond = array();
+        $params = '';
 
         $root = $record->getTable()->getComponentName();
         $rootAlias = strtolower(substr($root, 0, 1));

--- a/lib/Doctrine/Parser/Xml.php
+++ b/lib/Doctrine/Parser/Xml.php
@@ -121,9 +121,11 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
      */
     public function prepareData($simpleXml)
     {
+        $children = array();
+        $return = array();
+
         if ($simpleXml instanceof SimpleXMLElement) {
             $children = $simpleXml->children();
-            $return = null;
         }
 
         foreach ($children as $element => $value) {

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -1014,6 +1014,9 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
                 $distinct = ($this->_sqlParts['distinct']) ? 'DISTINCT ' : '';
                 $q = 'SELECT ' . $distinct . implode(', ', $this->_sqlParts['select']) . ' FROM ';
             break;
+            default:
+                $q = '';
+            break;
         }
         return $q;
     }

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -1593,6 +1593,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
                 }
             } else {
                 $localFieldName = $this->_table->getFieldName($rel->getLocal());
+                $foreignFieldName = '';
 
                 if ($value !== self::$_null) {
                     $relatedTable = $rel->getTable();
@@ -1815,6 +1816,13 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     {
         $a = array();
 
+        /**
+         * This was previously unset (unless the if condition below is true),
+         * setting to empty array, which won't change behavior.
+         * @todo It seems like this is meant to be set to what's in $array, but not sure
+         */
+        $modifiedFields = array();
+
         if (empty($array)) {
             $modifiedFields = $this->_modified;
         }
@@ -1948,7 +1956,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @see fromArray()
      * @link http://www.doctrine-project.org/documentation/manual/1_1/en/working-with-models
-     * @param string $array  array of data to merge, see link for documentation
+     * @param array|Doctrine_Record $array  array of data to merge, see link for documentation
      * @param bool   $deep   whether or not to merge relations
      * @return void
      */
@@ -1958,6 +1966,8 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
             $array = $data->toArray($deep);
         } else if (is_array($data)) {
             $array = $data;
+        } else {
+            $array = array();
         }
 
         $this->fromArray($array, $deep);

--- a/lib/Doctrine/Record/Generator.php
+++ b/lib/Doctrine/Record/Generator.php
@@ -134,7 +134,7 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
      *
      * @see Doctrine_Template_I18n
      * @param  Doctrine_Table $table
-     * @return void
+     * @return bool
      */
     public function initialize(Doctrine_Table $table)
     {

--- a/lib/Doctrine/Relation/Association.php
+++ b/lib/Doctrine/Relation/Association.php
@@ -58,7 +58,8 @@ class Doctrine_Relation_Association extends Doctrine_Relation
     {
         $table = $this->definition['refTable'];
         $component = $this->definition['refTable']->getComponentName();
-        
+        $dql = '';
+
         switch ($context) {
             case "record":
                 $sub  = substr(str_repeat("?, ", $count),0,-2);

--- a/lib/Doctrine/Relation/Association/Self.php
+++ b/lib/Doctrine/Relation/Association/Self.php
@@ -40,11 +40,13 @@ class Doctrine_Relation_Association_Self extends Doctrine_Relation_Association
      */
     public function getRelationDql($count, $context = 'record')
     {
+        $dql = '';
+
         switch ($context) {
             case 'record':
                 $identifierColumnNames = $this->definition['table']->getIdentifierColumnNames();
                 $identifier = array_pop($identifierColumnNames);
-                $sub    = 'SELECT '.$this->definition['foreign'] 
+                $sub    = 'SELECT '.$this->definition['foreign']
                         . ' FROM '.$this->definition['refTable']->getTableName()
                         . ' WHERE '.$this->definition['local']
                         . ' = ?';
@@ -57,13 +59,13 @@ class Doctrine_Relation_Association_Self extends Doctrine_Relation_Association
                 $dql  = 'FROM ' . $this->definition['table']->getComponentName()
                       . '.' . $this->definition['refTable']->getComponentName()
                       . ' WHERE ' . $this->definition['table']->getComponentName()
-                      . '.' . $identifier 
+                      . '.' . $identifier
                       . ' IN (' . $sub . ')'
-                      . ' || ' . $this->definition['table']->getComponentName() 
+                      . ' || ' . $this->definition['table']->getComponentName()
                       . '.' . $identifier
                       . ' IN (' . $sub2 . ')';
 
-                $dql .= $this->getOrderBy($this->definition['table']->getComponentName(), false); 
+                $dql .= $this->getOrderBy($this->definition['table']->getComponentName(), false);
                 break;
             case 'collection':
                 $sub  = substr(str_repeat('?, ', $count),0,-2);

--- a/lib/Doctrine/Relation/Parser.php
+++ b/lib/Doctrine/Relation/Parser.php
@@ -31,7 +31,7 @@
  * @since       1.0
  * @todo Composite key support?
  */
-class Doctrine_Relation_Parser 
+class Doctrine_Relation_Parser
 {
     /**
      * @var Doctrine_Table $_table          the table object this parser belongs to
@@ -53,7 +53,7 @@ class Doctrine_Relation_Parser
      *
      * @param Doctrine_Table $table         the table object this parser belongs to
      */
-    public function __construct(Doctrine_Table $table) 
+    public function __construct(Doctrine_Table $table)
     {
         $this->_table = $table;
     }
@@ -73,12 +73,12 @@ class Doctrine_Relation_Parser
      *
      * @return array            an array defining a pending relation
      */
-    public function getPendingRelation($name) 
+    public function getPendingRelation($name)
     {
         if ( ! isset($this->_pending[$name])) {
             throw new Doctrine_Relation_Exception('Unknown pending relation ' . $name);
         }
-        
+
         return $this->_pending[$name];
     }
 
@@ -87,7 +87,7 @@ class Doctrine_Relation_Parser
      *
      * @return array            an array containing all the pending relations
      */
-    public function getPendingRelations() 
+    public function getPendingRelations()
     {
         return $this->_pending;
     }
@@ -98,7 +98,7 @@ class Doctrine_Relation_Parser
      *
      * @param string            relation to remove
      */
-    public function unsetPendingRelations($name) 
+    public function unsetPendingRelations($name)
     {
        unset($this->_pending[$name]);
     }
@@ -106,7 +106,7 @@ class Doctrine_Relation_Parser
     /**
      * Check if a relation alias exists
      *
-     * @param string $name 
+     * @param string $name
      * @return boolean $bool
      */
     public function hasRelation($name)
@@ -114,7 +114,7 @@ class Doctrine_Relation_Parser
         if ( ! isset($this->_pending[$name]) && ! isset($this->_relations[$name])) {
             return false;
         }
-        
+
         return true;
     }
 
@@ -362,6 +362,8 @@ class Doctrine_Relation_Parser
     public function guessColumns(array $classes, Doctrine_Table $foreignTable)
     {
         $conn = $this->_table->getConnection();
+        $found = false;
+        $columns = array();
 
         foreach ($classes as $class) {
             try {

--- a/lib/Doctrine/Search/File.php
+++ b/lib/Doctrine/Search/File.php
@@ -53,12 +53,14 @@ class Doctrine_Search_File extends Doctrine_Search
             $this->_options['fields'] = array('url', 'content');
         }
 
-        $this->initialize($table);
+        if (isset($table)) {
+            $this->initialize($table);
+        }
     }
 
     public function buildRelation()
     {
-    	
+
     }
 
     /**
@@ -71,7 +73,7 @@ class Doctrine_Search_File extends Doctrine_Search
     {
         $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir),
                                                 RecursiveIteratorIterator::LEAVES_ONLY);
-                                                
+
         foreach ($it as $file) {
             if (strpos($file, DIRECTORY_SEPARATOR . '.svn') !== false) {
                 continue;

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1823,6 +1823,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
             }
 
             $found = false;
+            $id = array();
             foreach ($identifierFieldNames as $fieldName) {
                 if ( ! isset($this->_data[$fieldName])) {
                     // primary key column not found return new record

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -67,3 +67,61 @@ parameters:
         # This is defined in Doctrine_Hydrator, but not Doctrine_Hydrator_Abstract (which both Doctrine_Hydrator and Doctrine_Hydrator_Graph extend)
         # Should probably be defined in the Abstract
         - '#Access to an undefined property Doctrine_Hydrator_Graph::\$_rootAlias\.#'
+        #########
+        # Level 1
+        #########
+        # Missing extensions
+        - '#Constant MEMCACHE_COMPRESSED not found\.#'
+        - '#Constant XC_TYPE_VAR not found\.#'
+        - '#Constant OCI_.+ not found\.#'
+        - '#Constant SQLT_CHR not found\.#'
+        # This isset check could probably be removed (Doctrine_I18n:124) because the method that is called to set `$others` already does an
+        # isset check on the value it returns and throws an exception if it's not set
+        - '#Variable \$others in isset\(\) always exists and is not nullable\.#'
+        # The block for this is a bit confusing (Doctrine_Connection_UnitOfWork:831), but $rootRecord is set on the first
+        # iteration of the foreach loop, and then referenced in each subsequent iteration. Assuming this is intentional
+        - '#Variable \$rootRecord might not be defined\.#'
+        # Not really sure what a satisfactory default value for $oci_length should be, seems that it should maybe be set to the $length parameter
+        # but not certain (Doctrine_Adapter_Statement_Oracle:175)
+        - '#Variable \$oci_length might not be defined\.#'
+        # This one would require some testing to see if it can be predefined, as it's predefined as "null" in a specific case, but undefined otherwise
+        # (though is_null will return true for undefined variables (but throws a notice), so perhaps it doesn't matter if it's set to null.
+        # Doctrine_Hydrator_Graph:131
+        - '#Variable \$activeRootIdentifier might not be defined\.#'
+        # These four are only used if the $autoincrement var is set to "true", and if it's set to "true", they get defined.
+        # In Doctrine_Migration_Base:278
+        - '#Variable \$autoincrementColumn might not be defined\.#'
+        - '#Variable \$autoincrementType might not be defined\.#'
+        - '#Variable \$autoincrementLength might not be defined\.#'
+        - '#Variable \$autoincrementOptions might not be defined\.#'
+        # These three happen several times in Doctrine_Node_NestedSet and each are structured the same way. The docblocks say something to the
+        # effect of "gets record of ... or empty record". The way the code is now, they return null (undefined variable) if the record doesn't exist,
+        # not an empty record. Could return an empty Doctrine_Record here, but not sure how that would affect behavior.
+        - '#Variable \$sibling might not be defined\.#'
+        - '#Variable \$child might not be defined\.#'
+        # (this one belongs to the previous group as well, not easy to tell phpstan to ignore specific errors in specific files)
+        # This one shows up in both Doctrine_Query and Doctrine_RawSql and is pretty much the same situation. I'm not sure what a good default
+        # for parent should be (though in this case it's probably being passed as null in all situations since it could be undefined)
+        - '#Variable \$parent might not be defined\.#'
+        # This one refers specifically to Doctrine_Connection:1040. In some cases $stmt is defined in an if block with no else, so would probably be safe
+        # to set to null in this case
+        - '#Variable \$stmt might not be defined\.#'
+        # Similar to the one above in Doctrine_Connection:1075
+        - '#Variable \$count might not be defined\.#'
+        # This, in Doctrine_RawSql:160|167|168|173, is intentional when tokenizing so that data is appended to the previous $type (during loop)
+        - '#Variable \$type might not be defined\.#'
+        # Doctrine_Relation_Parser:512, $table must always be set since nobody that has cared has complained about this, but seems like it should
+        # either be set to an initial value, or have an isset() check around it. There's a comment questioning if it should be $table or $this->table
+        - '#Variable \$table might not be defined\.#'
+        # Doctrine_Query_Check:155, this one doesn't really matter much, as it'll just return null/undefined if it doesn't get set, could initialize as null
+        # perhaps to make phpstan happy
+        - '#Variable \$func might not be defined\.#'
+        # In Doctrine_Table:506, seems to change $this->_identifier from an array to the last value of that array, intentional?  $pk won't be defined if
+        # $this->_identifier is empty
+        - '#Variable \$pk might not be defined\.#'
+        # In Doctrine_Query_Tokenizer:90, this seems to be intentional to add parts of the query to the previous type until a new token is found
+        - '#Variable \$p might not be defined\.#'
+        # Doctrine_Query:981|988|990|1195, not sure what good defaults should be (assuming blank string for most of these is what's happening now)
+        - '#Variable \$tableAlias might not be defined\.#'
+        - '#Variable \$componentAlias might not be defined\.#'
+        - '#Variable \$queryComponentsBefore might not be defined\.#'


### PR DESCRIPTION
This makes phpstan pass on the `lib` dir using level 1.

Most of the errors on this level were "Variable XXX may not be defined", so I added some defaults where possible without changing behavior.  Otherwise there were a lot of phpstan ignores added, with descriptions.

I'll document the code changes with inline comments.