### PR TITLE
Removing include-path, fixing docblock, adding classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,10 @@
             "Doctrine_": "lib/",
             "sfYaml": "lib/Doctrine/Parser/sfYaml/"
         },
-        "files": [
+        "classmap": [
             "lib/Doctrine.php"
         ]
     },
-    "include-path": [
-        "lib/"
-    ],
     "replace": {
         "doctrine/doctrine1": "*"
     },

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -251,17 +251,17 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      * Open a new connection. If the adapter parameter is set this method acts as
      * a short cut for Doctrine_Manager::getInstance()->openConnection($adapter, $name);
      *
-     * if the adapter paramater is not set this method acts as
+     * if the adapter parameter is not set this method acts as
      * a short cut for Doctrine_Manager::getInstance()->getCurrentConnection()
      *
-     * @param PDO|Doctrine_Adapter_Interface $adapter   database driver
-     * @param string $name                              name of the connection, if empty numeric key is used
-     * @throws Doctrine_Manager_Exception               if trying to bind a connection with an existing name
+     * @param PDO|Doctrine_Adapter_Interface|array|string|null $adapter database driver, DSN or array of connection options
+     * @param string $name                                         name of the connection, if empty numeric key is used
+     * @throws Doctrine_Manager_Exception                          if trying to bind a connection with an existing name
      * @return Doctrine_Connection
      */
     public static function connection($adapter = null, $name = null)
     {
-        if ($adapter == null) {
+        if ($adapter === null) {
             return Doctrine_Manager::getInstance()->getCurrentConnection();
         } else {
             return Doctrine_Manager::getInstance()->openConnection($adapter, $name);
@@ -271,10 +271,10 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
     /**
      * Opens a new connection and saves it to Doctrine_Manager->connections
      *
-     * @param PDO|Doctrine_Adapter_Interface|array|string $adapter   database driver, DSN or array of connection options
-     * @param string $name                              name of the connection, if empty numeric key is used
-     * @throws Doctrine_Manager_Exception               if trying to bind a connection with an existing name
-     * @throws Doctrine_Manager_Exception               if trying to open connection for unknown driver
+     * @param PDO|Doctrine_Adapter_Interface|array|string $adapter database driver, DSN or array of connection options
+     * @param string $name                                         name of the connection, if empty numeric key is used
+     * @throws Doctrine_Manager_Exception                          if trying to bind a connection with an existing name
+     * @throws Doctrine_Manager_Exception                          if trying to open connection for unknown driver
      * @return Doctrine_Connection
      */
     public function openConnection($adapter, $name = null, $setCurrent = true)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -425,8 +425,6 @@ parameters:
         - '#Parameter \#1 \$alias of method Doctrine_Query::_processPendingJoinConditions\(\) expects string, string\|null given\.#'
         # Same with this one, default for $alias should probably be an empty string, Doctrine_Table:1120
         - '#Parameter \#1 \$alias of method Doctrine_Table::processOrderBy\(\) expects string, string\|null given\.#'
-        # This one has a check for null that will prevent null being passed further, Doctrine_Manager:267
-        - '#Parameter \#1 \$adapter of method Doctrine_Manager::openConnection\(\) expects array\|Doctrine_Adapter_Interface\|PDO\|string, Doctrine_Adapter_Interface\|PDO\|null given\.#'
         # Should change to empty string as default, Doctrine_Import_Schema:271
         - '#Parameter \#1 \$path of method Doctrine_Import_Builder::setTargetPath\(\) expects string, string\|null given\.#'
         # In Doctrine_Query_Abstract:1616, $from really shouldn't be allowed to be "null" since once it's passed to the _addDqlQueryPart method an


### PR DESCRIPTION
The include-path change was added here https://github.com/diablomedia/doctrine1/commit/c5f38eebebe3360aa9abb9ab08dac3068ad81f87 so that the `Doctrine.php` file could be loaded, but this isn't necessary with the autoloading strategy we have (I've moved the file to a classmap autoloader which should prevent it from being loaded every time and only when required).