### PR TITLE
Appending orderby fields to select for mysql driver as well

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -18,7 +18,8 @@ return PhpCsFixer\Config::create()
         'single_quote' => true,
         'array_syntax' => ['syntax' => 'long'],
         'concat_space' => ['spacing' => 'one'],
-        'psr0' => true
+        'psr0' => true,
+        'no_whitespace_in_blank_line' => true,
     ])
     ->setUsingCache(true)
     ->setFinder($finder);

--- a/lib/Doctrine/DataDict/Oracle.php
+++ b/lib/Doctrine/DataDict/Oracle.php
@@ -70,7 +70,7 @@ class Doctrine_DataDict_Oracle extends Doctrine_DataDict
                 $length = !empty($field['length']) ? $field['length'] : false;
 
                 $fixed = ((isset($field['fixed']) && $field['fixed']) || $field['type'] == 'char') ? true : false;
-                
+
                 $unit = $this->conn->getParam('char_unit');
                 $unit = ! is_null($unit) ? ' ' . $unit : '';
 
@@ -130,7 +130,7 @@ class Doctrine_DataDict_Oracle extends Doctrine_DataDict
         if (! isset($field['data_type'])) {
             throw new Doctrine_DataDict_Exception('Native oracle definition must have a data_type key specified');
         }
-        
+
         $dbType = strtolower($field['data_type']);
         $type   = array();
         $length = $unsigned = $fixed = null;

--- a/lib/Doctrine/File.php
+++ b/lib/Doctrine/File.php
@@ -44,7 +44,7 @@ class Doctrine_File extends Doctrine_Record
     {
         $this->actAs('Searchable', array('className' => 'Doctrine_File_Index',
                                          'fields'    => array('url', 'content')));
-        
+
         $this->index('url', array('fields' => array('url')));
     }
 

--- a/lib/Doctrine/File/Index.php
+++ b/lib/Doctrine/File/Index.php
@@ -39,13 +39,13 @@ class Doctrine_File_Index extends Doctrine_Record
     {
         $this->hasColumn('keyword', 'string', 255, array('notnull' => true,
                                                          'primary' => true));
-                                                         
+
         $this->hasColumn('field', 'string', 50, array('notnull' => true,
                                                       'primary' => true));
 
         $this->hasColumn('position', 'string', 255, array('notnull' => true,
                                                           'primary' => true));
-                                                          
+
         $this->hasColumn('file_id', 'integer', 8, array('notnull' => true,
                                                         'primary' => true));
     }

--- a/lib/Doctrine/I18n/Exception.php
+++ b/lib/Doctrine/I18n/Exception.php
@@ -18,7 +18,7 @@
  * and is licensed under the LGPL. For more information, see
  * <http://www.doctrine-project.org>.
  */
- 
+
 /**
  * Doctrine_I18n_Exception
  *

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -1436,7 +1436,10 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
         $subquery .= $this->_conn->quoteIdentifier($primaryKey);
 
         // pgsql & oracle need the order by fields to be preserved in select clause
-        if ($driverName == 'pgsql' || $driverName == 'oracle' || $driverName == 'oci' || $driverName == 'mssql' || $driverName == 'odbc') {
+        // Technically this isn't required for mysql <= 5.6, but mysql 5.7 with an sql_mode option enabled
+        // (only_full_group_by, which is enabled by default in 5.7) will throw SQL errors if this isn't done,
+        // so easier to just enable for all of mysql.
+        if ($driverName == 'mysql' || $driverName == 'pgsql' || $driverName == 'oracle' || $driverName == 'oci' || $driverName == 'mssql' || $driverName == 'odbc') {
             foreach ($this->_sqlParts['orderby'] as $part) {
                 // Remove identifier quoting if it exists
                 $e = $this->_tokenizer->bracketExplode($part, ' ');

--- a/lib/Doctrine/Record/Listener.php
+++ b/lib/Doctrine/Record/Listener.php
@@ -54,7 +54,7 @@ class Doctrine_Record_Listener implements Doctrine_Record_Listener_Interface
             $this->_options[$name] = $value;
         }
     }
-    
+
     /**
      * getOptions
      * returns all options of this template and the associated values
@@ -81,7 +81,7 @@ class Doctrine_Record_Listener implements Doctrine_Record_Listener_Interface
 
         return null;
     }
-    
+
     /**
      * @return void
      */
@@ -207,7 +207,7 @@ class Doctrine_Record_Listener implements Doctrine_Record_Listener_Interface
     public function preValidate(Doctrine_Event $event)
     {
     }
-    
+
     /**
      * @return void
      */

--- a/lib/Doctrine/Record/Listener/Interface.php
+++ b/lib/Doctrine/Record/Listener/Interface.php
@@ -61,8 +61,8 @@ interface Doctrine_Record_Listener_Interface
     public function preInsert(Doctrine_Event $event);
 
     public function postInsert(Doctrine_Event $event);
-    
+
     public function preHydrate(Doctrine_Event $event);
-    
+
     public function postHydrate(Doctrine_Event $event);
 }

--- a/lib/Doctrine/Relation/LocalKey.php
+++ b/lib/Doctrine/Relation/LocalKey.php
@@ -62,7 +62,7 @@ class Doctrine_Relation_LocalKey extends Doctrine_Relation
                             ->getConnection()
                             ->query($dql, array($id))
                             ->getFirst();
-            
+
             if (! $related || empty($related)) {
                 $related = $this->getTable()->create();
             }

--- a/lib/Doctrine/Validator/Email.php
+++ b/lib/Doctrine/Validator/Email.php
@@ -70,7 +70,7 @@ class Doctrine_Validator_Email extends Doctrine_Validator_Driver
         $subDomain     = "($domainRef|$domainLiteral)";
         $word          = "($atom|$quotedString)";
         $domain        = "$subDomain(\\x2e$subDomain)+";
-        
+
         /*
           following pseudocode to allow strict checking - ask pookey about this if you're puzzled
 
@@ -78,13 +78,13 @@ class Doctrine_Validator_Email extends Doctrine_Validator_Driver
               $domain = "$sub_domain(\\x2e$sub_domain)*";
           }
         */
-        
+
         $localPart = "$word(\\x2e$word)*";
         $addrSpec  = "$localPart\\x40$domain";
-        
+
         return (bool) preg_match("!^$addrSpec$!D", $value);
     }
-    
+
     /**
      * Check DNS Records for MX type
      *
@@ -96,9 +96,9 @@ class Doctrine_Validator_Email extends Doctrine_Validator_Driver
         // We have different behavior here depending of OS and PHP version
         if (strtolower(substr(PHP_OS, 0, 3)) == 'win' && version_compare(PHP_VERSION, '5.3.0', '<')) {
             $output = array();
-            
+
             @exec('nslookup -type=MX ' . escapeshellcmd($host) . ' 2>&1', $output);
-            
+
             if (empty($output)) {
                 throw new Doctrine_Exception('Unable to execute DNS lookup. Are you sure PHP can call exec()?');
             }
@@ -108,12 +108,12 @@ class Doctrine_Validator_Email extends Doctrine_Validator_Driver
                     return true;
                 }
             }
-            
+
             return false;
         } elseif (function_exists('checkdnsrr')) {
             return checkdnsrr($host, 'MX');
         }
-        
+
         throw new Doctrine_Exception('Could not retrieve DNS record information. Remove check_mx = true to prevent this warning');
     }
 }

--- a/lib/Doctrine/Validator/Readonly.php
+++ b/lib/Doctrine/Validator/Readonly.php
@@ -37,7 +37,7 @@ class Doctrine_Validator_Readonly extends Doctrine_Validator_Driver
     public function validate($value)
     {
         $modified = $this->invoker->getModified();
-        
+
         return array_key_exists($this->field, $modified) ? false : true;
     }
 }

--- a/lib/Doctrine/Validator/Unique.php
+++ b/lib/Doctrine/Validator/Unique.php
@@ -52,17 +52,17 @@ class Doctrine_Validator_Unique extends Doctrine_Validator_Driver
             for ($i = 0, $l = count($pks); $i < $l; $i++) {
                 $pks[$i] = $conn->quoteIdentifier($pks[$i]);
             }
-            
+
             $pks = implode(', ', $pks);
         }
 
         $sql = 'SELECT ' . $pks . ' FROM ' . $conn->quoteIdentifier($table->getTableName()) . ' WHERE ';
-        
+
         if (is_array($this->field)) {
             foreach ($this->field as $k => $v) {
                 $this->field[$k] = $conn->quoteIdentifier($table->getColumnName($v));
             }
-        
+
             $sql .= implode(' = ? AND ', $this->field) . ' = ?';
             $values = $value;
         } else {
@@ -70,7 +70,7 @@ class Doctrine_Validator_Unique extends Doctrine_Validator_Driver
             $values   = array();
             $values[] = $value;
         }
-        
+
         // If the record is not new we need to add primary key checks because its ok if the
         // unique value already exists in the database IF the record in the database is the same
         // as the one that is validated here.

--- a/tests/AccessTestCase.php
+++ b/tests/AccessTestCase.php
@@ -52,17 +52,17 @@ class Doctrine_Access_TestCase extends Doctrine_UnitTestCase
 
         $this->assertTrue(isset($user->name));
         $this->assertFalse(isset($user->unknown));
-        
+
         $this->assertTrue(isset($user['name']));
         $this->assertFalse(isset($user['unknown']));
-        
+
         $coll = new Doctrine_Collection('User');
-        
+
         $this->assertFalse(isset($coll[0]));
         // test repeated call
         $this->assertFalse(isset($coll[0]));
         $coll[0];
-        
+
         $this->assertTrue(isset($coll[0]));
         // test repeated call
         $this->assertTrue(isset($coll[0]));
@@ -95,7 +95,7 @@ class Doctrine_Access_TestCase extends Doctrine_UnitTestCase
         $user->name = 'Jack';
 
         $this->assertEqual($user->name, 'Jack');
-        
+
         $user->save();
 
         $user = $this->connection->getTable('User')->find($user->identifier());
@@ -106,7 +106,7 @@ class Doctrine_Access_TestCase extends Doctrine_UnitTestCase
         $user->name = 'zYne';
         $this->assertEqual($user->name, 'zYne');
     }
-    
+
     public function testSet()
     {
         $user = new User();

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Base_TestCase extends Doctrine_UnitTestCase
     public function testAggressiveModelLoading()
     {
         $path = realpath('ModelLoadingTest/Aggressive');
-        
+
         $models = Doctrine_Core::loadModels($path, Doctrine_Core::MODEL_LOADING_AGGRESSIVE);
 
         // Ensure the correct model names were returned
@@ -45,7 +45,7 @@ class Doctrine_Base_TestCase extends Doctrine_UnitTestCase
 
         // Make sure it does not include the base classes
         $this->assertTrue(! isset($models['BaseAggressiveModelLoadingUser']));
-        
+
         $filteredModels = Doctrine_Core::filterInvalidModels($models);
 
         // Make sure filterInvalidModels filters out base abstract classes
@@ -85,7 +85,7 @@ class Doctrine_Base_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue(in_array('AggressiveModelLoadingUser', $models));
         $this->assertTrue(in_array('ConservativeModelLoadingProfile', $models));
         $this->assertTrue(in_array('ConservativeModelLoadingContact', $models));
-        
+
         $modelFiles = Doctrine_Core::getLoadedModelFiles();
         $this->assertTrue(file_exists($modelFiles['ConservativeModelLoadingUser']));
         $this->assertTrue(file_exists($modelFiles['ConservativeModelLoadingProfile']));
@@ -106,7 +106,7 @@ class Doctrine_Base_TestCase extends Doctrine_UnitTestCase
         Doctrine_Manager::getInstance()->bindComponent('Entity', $connectionBefore->getName());
 
         $connectionAfter = Doctrine_Core::getConnectionByTableName('entity');
-        
+
         $this->assertEqual($connectionBefore->getName(), $connectionAfter->getName());
     }
 }

--- a/tests/BatchIteratorTestCase.php
+++ b/tests/BatchIteratorTestCase.php
@@ -48,18 +48,18 @@ class Doctrine_BatchIterator_TestCase extends Doctrine_UnitTestCase
             $i++;
         }
         $this->assertTrue($i == $entities->count());
-        
+
         $user = $graph->query('FROM User');
         foreach ($user[1]->Group as $group) {
             $this->assertTrue(is_string($group->name));
         }
-        
+
         $user       = new User();
         $user->name = 'tester';
-        
+
         $user->Address[0]->address = 'street 1';
         $user->Address[1]->address = 'street 2';
-        
+
         $this->assertEqual($user->name, 'tester');
         $this->assertEqual($user->Address[0]->address, 'street 1');
         $this->assertEqual($user->Address[1]->address, 'street 2');
@@ -70,12 +70,12 @@ class Doctrine_BatchIterator_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($a, array('street 1', 'street 2'));
 
         $user->save();
-        
+
         $user = $user->getTable()->find($user->id);
         $this->assertEqual($user->name, 'tester');
         $this->assertEqual($user->Address[0]->address, 'street 1');
         $this->assertEqual($user->Address[1]->address, 'street 2');
-        
+
         $user = $user->getTable()->find($user->id);
         $a    = array();
         foreach ($user->Address as $address) {

--- a/tests/Cache/ApcTestCase.php
+++ b/tests/Cache/ApcTestCase.php
@@ -37,12 +37,12 @@ class Doctrine_Cache_Apc_TestCase extends Doctrine_Cache_Abstract_TestCase
     {
         apc_clear_cache('user');
     }
-    
+
     protected function _isEnabled()
     {
         return extension_loaded('apc');
     }
-    
+
     protected function _getCacheDriver()
     {
         return new Doctrine_Cache_Apc();

--- a/tests/Cache/ArrayTestCase.php
+++ b/tests/Cache/ArrayTestCase.php
@@ -37,12 +37,12 @@ class Doctrine_Cache_Array_TestCase extends Doctrine_Cache_Abstract_TestCase
     {
         // do nothing
     }
-    
+
     protected function _isEnabled()
     {
         return true;
     }
-    
+
     protected function _getCacheDriver()
     {
         return new Doctrine_Cache_Array();

--- a/tests/Cache/QuerySqliteTestCase.php
+++ b/tests/Cache/QuerySqliteTestCase.php
@@ -22,7 +22,7 @@ class Doctrine_Cache_Query_SqliteTestCase extends Doctrine_UnitTestCase
         $this->assertEqual($this->cache->count(), 1);
 
         $this->cache->store('SELECT * FROM group', array(array('name' => 'Drinkers club')), 60);
-        
+
         $md5    = md5('SELECT * FROM user');
         $result = $this->cache->fetch($md5);
         $this->assertEqual($result, array(array('name' => 'Jack Daniels')));
@@ -32,10 +32,10 @@ class Doctrine_Cache_Query_SqliteTestCase extends Doctrine_UnitTestCase
         $this->assertEqual($result, array(array('name' => 'Drinkers club')));
 
         $this->assertEqual($this->cache->count(), 2);
-        
+
         $this->cache->delete($md5);
         $this->assertEqual($this->cache->count(), 1);
-        
+
         $this->cache->deleteAll();
         $this->assertEqual($this->cache->count(), 0);
     }

--- a/tests/CacheSqliteTestCase.php
+++ b/tests/CacheSqliteTestCase.php
@@ -22,7 +22,7 @@ class Doctrine_Cache_SqliteTestCase extends Doctrine_UnitTestCase
     {
         // does not store proxy objects
         $this->assertFalse($this->cache->store($this->objTable->getProxy(4)));
-        
+
         $this->assertTrue($this->cache->store($this->objTable->find(4)));
 
         $record = $this->cache->fetch(4);
@@ -117,7 +117,7 @@ class Doctrine_Cache_SqliteTestCase extends Doctrine_UnitTestCase
         $this->cache->fetchMultiple(array(5,6,7));
         $this->cache->fetchMultiple(array(4,5,6,7,8,9));
         $this->assertTrue($this->cache->saveStats());
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_CACHE_SIZE, 3);
         $this->assertEqual($this->cache->clean(), 3);
     }

--- a/tests/ClassTableInheritanceTestCase.php
+++ b/tests/ClassTableInheritanceTestCase.php
@@ -57,7 +57,7 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($sql[2], 'CREATE TABLE c_t_i_test_parent4 (id INTEGER, age INTEGER, PRIMARY KEY(id))');
         $this->assertEqual($sql[3], 'CREATE TABLE c_t_i_test_parent3 (id INTEGER, added INTEGER, PRIMARY KEY(id))');
         $this->assertEqual($sql[4], 'CREATE TABLE c_t_i_test_parent2 (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(200), verified INTEGER)');
-    
+
         foreach ($sql as $query) {
             $this->conn->exec($query);
         }
@@ -68,7 +68,7 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $class = new CTITest();
 
         $table = $class->getTable();
-        
+
         $columns = $table->getColumns();
 
         $this->assertEqual($columns['verified']['owner'], 'CTITestParent2');
@@ -95,7 +95,7 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $record->verified = true;
         $record->added    = time();
         $record->save();
-        
+
         // pop the commit event
         $profiler->pop();
         $this->assertEqual($profiler->pop()->getQuery(), 'INSERT INTO c_t_i_test_parent4 (age, id) VALUES (?, ?)');
@@ -107,7 +107,7 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($profiler->pop()->getQuery(), 'INSERT INTO c_t_i_test_parent2 (name, verified) VALUES (?, ?)');
         $this->conn->addListener(new Doctrine_EventListener());
     }
-    
+
     public function testParentalJoinsAreAddedAutomaticallyWithDql()
     {
         $q = new Doctrine_Query();
@@ -116,7 +116,7 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($q->getSqlQuery(), 'SELECT c.id AS c__id, c3.added AS c__added, c2.name AS c__name, c2.verified AS c__verified, c.age AS c__age FROM c_t_i_test_parent4 c LEFT JOIN c_t_i_test_parent2 c2 ON c.id = c2.id LEFT JOIN c_t_i_test_parent3 c3 ON c.id = c3.id WHERE (c.id = 1)');
 
         $record = $q->fetchOne();
-        
+
         $this->assertEqual($record->id, 1);
         $this->assertEqual($record->name, 'Jack Daniels');
         $this->assertEqual($record->verified, true);
@@ -150,7 +150,7 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $q->from('CTITestOneToManyRelated c')->leftJoin('c.CTITest c2')->where('c.id = 1')->limit(1);
 
         $record = $q->fetchOne();
-        
+
         $this->assertEqual($record->name, 'Someone');
         $this->assertEqual($record->cti_id, 1);
 
@@ -171,14 +171,14 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $this->conn->addListener($profiler);
 
         $record = $this->conn->getTable('CTITest')->find(1);
-        
+
         $record->age      = 11;
         $record->name     = 'Jack';
         $record->verified = false;
         $record->added    = 0;
-        
+
         $record->save();
-        
+
         // pop the commit event
         $profiler->pop();
         $this->assertEqual($profiler->pop()->getQuery(), 'UPDATE c_t_i_test_parent4 SET age = ? WHERE id = ?');
@@ -190,20 +190,20 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($profiler->pop()->getQuery(), 'UPDATE c_t_i_test_parent2 SET name = ?, verified = ? WHERE id = ?');
         $this->conn->addListener(new Doctrine_EventListener());
     }
-    
+
     public function testUpdateOperationIsPersistent()
     {
         $this->conn->clear();
-        
+
         $record = $this->conn->getTable('CTITest')->find(1);
-        
+
         $this->assertEqual($record->id, 1);
         $this->assertEqual($record->name, 'Jack');
         $this->assertEqual($record->verified, false);
         $this->assertEqual($record->added, 0);
         $this->assertEqual($record->age, 11);
     }
-    
+
     public function testValidationSkipsOwnerOption()
     {
         $this->conn->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
@@ -217,7 +217,7 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         }
         $this->conn->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
-    
+
     public function testDeleteIssuesQueriesOnAllJoinedTables()
     {
         $this->conn->clear();
@@ -226,11 +226,11 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $this->conn->addListener($profiler);
 
         $record = $this->conn->getTable('CTITest')->find(1);
-        
+
         $record->delete();
 
         // pop the commit event
-        
+
         // pop the prepare event
         $profiler->pop();
         $this->assertEqual($profiler->pop()->getQuery(), 'DELETE FROM c_t_i_test_parent2 WHERE id = ?');
@@ -240,14 +240,14 @@ class Doctrine_ClassTableInheritance_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($profiler->pop()->getQuery(), 'DELETE FROM c_t_i_test_parent4 WHERE id = ?');
         $this->conn->addListener(new Doctrine_EventListener());
     }
-    
+
     public function testNoIdCti()
     {
         $NoIdTestChild               = new NoIdTestChild();
         $NoIdTestChild->name         = 'test';
         $NoIdTestChild->child_column = 'test';
         $NoIdTestChild->save();
-        
+
         $NoIdTestChild = Doctrine_Core::getTable('NoIdTestChild')->find(1);
         $this->assertEqual($NoIdTestChild->myid, 1);
         $this->assertEqual($NoIdTestChild->name, 'test');
@@ -298,7 +298,7 @@ class CTITestOneToManyRelated extends Doctrine_Record
         $this->hasColumn('name', 'string');
         $this->hasColumn('cti_id', 'integer');
     }
-    
+
     public function setUp()
     {
         $this->hasMany('CTITest', array('local' => 'cti_id', 'foreign' => 'id'));

--- a/tests/CliTestCase.php
+++ b/tests/CliTestCase.php
@@ -296,7 +296,7 @@ class Doctrine_Cli_TestCase extends Doctrine_UnitTestCase
         $cli = new Doctrine_Cli_TestCase_PassiveCli();
 
         $directory = $this->getFixturesPath() . '/foo';
-    
+
         try {
             $cli->loadTasks($directory);
         } catch (InvalidArgumentException $e) {
@@ -305,7 +305,7 @@ class Doctrine_Cli_TestCase extends Doctrine_UnitTestCase
                 return;
             }
         }
-    
+
         $this->fail();
     }
 
@@ -315,9 +315,9 @@ class Doctrine_Cli_TestCase extends Doctrine_UnitTestCase
     public function testLoadtasksLoadsDoctrineStyleTasksFromTheSpecifiedDirectory()
     {
         $cli = new Doctrine_Cli_TestCase_PassiveCli();
-    
+
         $this->assertEqual(array(), $cli->getRegisteredTasks());
-    
+
         $loadedTaskName   = $cli->loadTasks($this->getFixturesPath() . '/' . __FUNCTION__);
         $expectedTaskName = array('doctrine-style-task' => 'doctrine-style-task');
         $this->assertEqual($expectedTaskName, $loadedTaskName);
@@ -351,7 +351,7 @@ class Doctrine_Cli_TestCase extends Doctrine_UnitTestCase
         $expectedTaskName = array_combine($this->doctrineTaskClassName, $this->doctrineTaskClassName);
         $this->assertEqual($expectedTaskName, array_intersect_assoc($expectedTaskName, $loadedTaskNames));
     }
-    
+
     /*
      * Exists only to ensure the method behaves the same as it did before refactoring
      */
@@ -369,11 +369,11 @@ class Doctrine_Cli_TestCase extends Doctrine_UnitTestCase
         $cli = new Doctrine_Cli_TestCase_NoisyCli();
         $cli->run(array());
         $this->pass();
-    
+
         $cli = new Doctrine_Cli_TestCase_NoisyCli(array('rethrow_exceptions' => false));
         $cli->run(array());
         $this->pass();
-    
+
         $cli = new Doctrine_Cli_TestCase_NoisyCli(array('rethrow_exceptions' => 0));
         $cli->run(array());
         $this->pass();
@@ -387,7 +387,7 @@ class Doctrine_Cli_TestCase extends Doctrine_UnitTestCase
         ob_start();
 
         $cli = new Doctrine_Cli_TestCase_NoisyCli(array('rethrow_exceptions' => 1));
-    
+
         try {
             $cli->run(array());
             //The same exception must be re-thrown...
@@ -398,7 +398,7 @@ class Doctrine_Cli_TestCase extends Doctrine_UnitTestCase
                 return;
             }
         }
-    
+
         $this->fail();
 
         ob_end_clean();

--- a/tests/Collection/SnapshotTestCase.php
+++ b/tests/Collection/SnapshotTestCase.php
@@ -41,7 +41,7 @@ class Doctrine_Collection_Snapshot_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('Entity', 'User', 'Group', 'GroupUser', 'Account', 'Album', 'Phonenumber', 'Email', 'Book');
-        
+
         parent::prepareTables();
     }
 
@@ -124,17 +124,17 @@ class Doctrine_Collection_Snapshot_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(count($user->Group->getSnapshot()), 1);
         unset($user->Group[1]);
         $this->assertEqual(count($user->Group->getSnapshot()), 1);
-        
+
         $count = count($this->conn);
         $user->save();
 
         $this->assertEqual(count($user->Group->getSnapshot()), 0);
-        
+
         $this->conn->clear();
 
         $users = Doctrine_Query::create()->from('User u LEFT JOIN u.Group g')
                  ->where('u.id = ' . $user->id)->execute();
-        
+
         $this->assertEqual(count($user->Group), 0);
     }
 }

--- a/tests/CollectionTestCase.php
+++ b/tests/CollectionTestCase.php
@@ -45,15 +45,15 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
         $coll[2]->Group[0]->name = 'Actors House 4';
         $coll[2]->Group[1]->name = 'Actors House 5';
         $coll[2]->Group[2]->name = 'Actors House 6';
-        
+
         $coll[5]->Group[0]->name = 'Actors House 7';
         $coll[5]->Group[1]->name = 'Actors House 8';
         $coll[5]->Group[2]->name = 'Actors House 9';
-        
+
         $coll->save();
-        
+
         $this->connection->clear();
-        
+
         $coll = $this->connection->query('FROM User');
 
         $this->assertEqual($coll->count(), 8);
@@ -63,7 +63,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($coll[5]->Group->count(), 3);
 
         $this->connection->clear();
-        
+
         $coll = $this->connection->query('FROM User');
 
         $this->assertEqual($coll->count(), 8);
@@ -110,7 +110,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
         $resource[1]->Type[1]->type = 'type 4';
 
         $resource->save();
-        
+
         $this->connection->clear();
 
         $resources = $this->connection->query('FROM Resource');
@@ -129,7 +129,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($resource[1]->Type[1]->type, 'type 4');
         $this->assertEqual(($count + 1), $this->connection->count());
     }
-    
+
     public function testAdd()
     {
         $coll = new Doctrine_Collection($this->objTable);
@@ -153,7 +153,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
         $q = $coll->loadRelated();
 
         $this->assertTrue($q instanceof Doctrine_Query);
-        
+
         $q->addFrom('User.Group g');
 
         $this->assertEqual($q->getSqlQuery($coll->getPrimaryKeys()), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id, e2.id AS e2__id, e2.name AS e2__name, e2.loginname AS e2__loginname, e2.password AS e2__password, e2.type AS e2__type, e2.created AS e2__created, e2.updated AS e2__updated, e2.email_id AS e2__email_id FROM entity e LEFT JOIN groupuser g ON (e.id = g.user_id) LEFT JOIN entity e2 ON e2.id = g.group_id AND e2.type = 1 WHERE (e.id IN (?, ?, ?, ?, ?, ?, ?, ?) AND (e.type = 0))');
@@ -171,7 +171,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
         $coll = $this->connection->query('FROM User');
 
         $this->assertEqual($coll->count(), 8);
-        
+
         $count = $this->connection->count();
         $coll->loadRelated('Email');
 
@@ -196,7 +196,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
     {
         $coll = $this->connection->query('FROM User');
         $this->assertEqual($coll->count(), 8);
-        
+
         $count = $this->connection->count();
         $coll->loadRelated('Phonenumber');
 
@@ -220,9 +220,9 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($coll[6]->Phonenumber[0]->phonenumber, '111 222 333');
         $this->assertEqual($coll[6]['Phonenumber'][1]->phonenumber, '222 123');
         $this->assertEqual($coll[6]['Phonenumber'][2]->phonenumber, '123 456');
-        
+
         $this->assertEqual(($count + 1), $this->connection->count());
-        
+
         $this->connection->clear();
     }
 
@@ -256,7 +256,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
     {
         $user = new User();
         $user->attribute(Doctrine_Core::ATTR_COLL_KEY, 'id');
-        
+
         $users = $user->getTable()->findAll();
         $this->assertFalse($users->contains(0));
         $this->assertEqual($users->count(), 8);
@@ -266,7 +266,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
     {
         $user = new User();
         $user->attribute(Doctrine_Core::ATTR_COLL_KEY, 'name');
-        
+
         $users = $user->getTable()->findAll();
         $this->assertFalse($users->contains(0));
         $this->assertEqual($users->count(), 8);
@@ -275,7 +275,7 @@ class Doctrine_Collection_TestCase extends Doctrine_UnitTestCase
     public function testFetchMultipleCollections()
     {
         $this->connection->clear();
-        
+
         $user = new User();
         $user->attribute(Doctrine_Core::ATTR_COLL_KEY, 'id');
         $phonenumber = new Phonenumber();

--- a/tests/ColumnAliasTestCase.php
+++ b/tests/ColumnAliasTestCase.php
@@ -37,27 +37,27 @@ class Doctrine_ColumnAlias_TestCase extends Doctrine_UnitTestCase
         $book1       = new Book();
         $book1->name = 'Das Boot';
         $book1->save();
-        
+
         $record1               = new ColumnAliasTest();
         $record1->alias1       = 'first';
         $record1->alias2       = 123;
         $record1->anotherField = 'camelCase';
         $record1->bookId       = $book1->id;
         $record1->save();
-        
+
         $record2               = new ColumnAliasTest();
         $record2->alias1       = 'one';
         $record2->alias2       = 456;
         $record2->anotherField = 'KoQ';
         $record2->save();
-        
+
         $record2->anotherField = 'foo';
     }
-    
+
     public function prepareTables()
     {
         $this->tables = array('ColumnAliasTest', 'Book');
-        
+
         parent::prepareTables();
     }
 
@@ -71,7 +71,7 @@ class Doctrine_ColumnAlias_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue(isset($result[0]->book));
         $this->assertEqual($result[0]->book->name, 'Das Boot');
     }
-    
+
     public function testAliasesAreSupportedForArrayFetching()
     {
         $q = new Doctrine_Query();
@@ -93,14 +93,14 @@ class Doctrine_ColumnAlias_TestCase extends Doctrine_UnitTestCase
         try {
             $record->alias1 = 'someone';
             $record->alias2 = 187;
-            
+
             $this->assertEqual($record->alias1, 'someone');
             $this->assertEqual($record->alias2, 187);
         } catch (Doctrine_Record_Exception $e) {
             $this->fail();
         }
     }
-    
+
     public function testAliasesAreSupportedForDqlSelectPart()
     {
         $q = new Doctrine_Query();
@@ -111,7 +111,7 @@ class Doctrine_ColumnAlias_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($coll[0]->alias2, 123);
         $this->assertEqual($coll[0]->anotherField, 'camelCase');
     }
-    
+
     public function testAliasesAreSupportedForDqlWherePart()
     {
         $q = new Doctrine_Query();
@@ -126,7 +126,7 @@ class Doctrine_ColumnAlias_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($coll[0]->alias2, 456);
         $this->assertEqual($coll[0]->anotherField, 'KoQ');
     }
-    
+
     public function testAliasesAreSupportedForDqlAggregateFunctions()
     {
         $q = new Doctrine_Query();
@@ -137,7 +137,7 @@ class Doctrine_ColumnAlias_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($coll[0]->MAX, 456);
     }
-    
+
     public function testAliasesAreSupportedForDqlHavingPart()
     {
         $q = new Doctrine_Query();
@@ -148,7 +148,7 @@ class Doctrine_ColumnAlias_TestCase extends Doctrine_UnitTestCase
           ->having('c.alias2 > 123');
 
         $coll = $q->execute();
-        
+
         $this->assertEqual($coll[0]->alias2, 456);
     }
 }

--- a/tests/CompositePrimaryKeyTestCase.php
+++ b/tests/CompositePrimaryKeyTestCase.php
@@ -11,7 +11,7 @@ class Doctrine_Composite_PrimaryKey_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'CPK_Test';
         $this->tables[] = 'CPK_Test2';
         $this->tables[] = 'CPK_Association';
-        
+
         parent::prepareTables();
     }
 }

--- a/tests/ConfigurableTestCase.php
+++ b/tests/ConfigurableTestCase.php
@@ -145,7 +145,7 @@ class Doctrine_Configurable_TestCase extends Doctrine_UnitTestCase
     public function testValidatorAttributeAcceptsBooleans()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, true);
-        
+
         $this->assertEqual($this->manager->getAttribute(Doctrine_Core::ATTR_VALIDATE), true);
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, false);
     }
@@ -185,7 +185,7 @@ class Doctrine_Configurable_TestCase extends Doctrine_UnitTestCase
         $original = $this->connection->getTable('User')->getAttribute(Doctrine_Core::ATTR_COLL_KEY);
         try {
             $this->connection->getTable('User')->setAttribute(Doctrine_Core::ATTR_COLL_KEY, 'name');
-            
+
             $this->pass();
         } catch (Exception $e) {
             $this->fail();
@@ -197,7 +197,7 @@ class Doctrine_Configurable_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $this->connection->getTable('User')->setAttribute(Doctrine_Core::ATTR_COLL_KEY, 'unknown');
-            
+
             $this->fail();
         } catch (Exception $e) {
             $this->pass();
@@ -208,7 +208,7 @@ class Doctrine_Configurable_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $this->connection->setAttribute(Doctrine_Core::ATTR_COLL_KEY, 'name');
-            
+
             $this->fail();
         } catch (Exception $e) {
             $this->pass();

--- a/tests/Connection/MssqlTestCase.php
+++ b/tests/Connection/MssqlTestCase.php
@@ -35,56 +35,56 @@ class Doctrine_Connection_Mssql_TestCase extends Doctrine_UnitTestCase
     public function testAlreadyExistsErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 2714, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ALREADY_EXISTS);
     }
 
     public function testAlreadyExistsErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1913, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ALREADY_EXISTS);
     }
 
     public function testValueCountOnRowErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 110, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_VALUE_COUNT_ON_ROW);
     }
 
     public function testNoSuchFieldErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 155, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testNoSuchFieldErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 207, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testNoSuchTableErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 208, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testNoSuchTableErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 3701, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testSyntaxErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 170, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 

--- a/tests/Connection/MysqlTestCase.php
+++ b/tests/Connection/MysqlTestCase.php
@@ -41,28 +41,28 @@ class Doctrine_Connection_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testNotLockedErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1100, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOT_LOCKED);
     }
 
     public function testNotFoundErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1091, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOT_FOUND);
     }
 
     public function testSyntaxErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1064, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 
     public function testNoSuchDbErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1049, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHDB);
     }
 
@@ -76,21 +76,21 @@ class Doctrine_Connection_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testNoSuchTableErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1051, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testNoSuchTableErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1146, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testConstraintErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1048, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
@@ -104,70 +104,70 @@ class Doctrine_Connection_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testConstraintErrorIsSupported3()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1217, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testNoDbSelectedErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1046, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NODBSELECTED);
     }
 
     public function testAccessViolationErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1142, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ACCESS_VIOLATION);
     }
 
     public function testAccessViolationErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1044, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ACCESS_VIOLATION);
     }
 
     public function testCannotDropErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1008, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CANNOT_DROP);
     }
 
     public function testCannotCreateErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1004, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CANNOT_CREATE);
     }
 
     public function testCannotCreateErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1005, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CANNOT_CREATE);
     }
 
     public function testCannotCreateErrorIsSupported3()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1006, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CANNOT_CREATE);
     }
 
     public function testAlreadyExistsErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1007, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ALREADY_EXISTS);
     }
 
     public function testAlreadyExistsErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1022, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ALREADY_EXISTS);
     }
 
@@ -188,14 +188,14 @@ class Doctrine_Connection_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testAlreadyExistsErrorIsSupported5()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1062, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ALREADY_EXISTS);
     }
 
     public function testValueCountOnRowErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 1136, '')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_VALUE_COUNT_ON_ROW);
     }
 }

--- a/tests/Connection/OracleTestCase.php
+++ b/tests/Connection/OracleTestCase.php
@@ -35,56 +35,56 @@ class Doctrine_Connection_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testNoSuchTableErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 942, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testSyntaxErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 900, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 
     public function testSyntaxErrorIsSupported2()
     {
         $this->exc->processErrorInfo(array(0, 921, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 
     public function testSyntaxErrorIsSupported3()
     {
         $this->exc->processErrorInfo(array(0, 923, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 
     public function testNoSuchFieldErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 904, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testConstraintErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 1, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testConstraintErrorIsSupported2()
     {
         $this->exc->processErrorInfo(array(0, 2291, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testConstraintErrorIsSupported3()
     {
         $this->exc->processErrorInfo(array(0, 2449, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
@@ -98,63 +98,63 @@ class Doctrine_Connection_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testNoSuchTableErrorIsSupported4()
     {
         $this->exc->processErrorInfo(array(0, 2289, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testInvalidNumberErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 1722, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_INVALID_NUMBER);
     }
 
     public function testDivZeroErrorIsSupported1()
     {
         $this->exc->processErrorInfo(array(0, 1476, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_DIVZERO);
     }
 
     public function testNotFoundErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 1418, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOT_FOUND);
     }
 
     public function testNotNullConstraintErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 1400, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT_NOT_NULL);
     }
 
     public function testNotNullConstraintErrorIsSupported2()
     {
         $this->exc->processErrorInfo(array(0, 1407, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT_NOT_NULL);
     }
 
     public function testInvalidErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 1401, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_INVALID);
     }
 
     public function testAlreadyExistsErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 955, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ALREADY_EXISTS);
     }
-    
+
     public function testValueCountOnRowErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 913, ''));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_VALUE_COUNT_ON_ROW);
     }
 }

--- a/tests/Connection/PgsqlTestCase.php
+++ b/tests/Connection/PgsqlTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Connection_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testNoSuchTableErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'table test does not exist')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
@@ -49,56 +49,56 @@ class Doctrine_Connection_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testNoSuchTableErrorIsSupported3()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'sequence does not exist')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testNoSuchTableErrorIsSupported4()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'class xx not found')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testSyntaxErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'parser: parse error at or near')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 
     public function testSyntaxErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'syntax error at')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 
     public function testSyntaxErrorIsSupported3()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'column reference r.r is ambiguous')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 
     public function testInvalidNumberErrorIsSupported()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'pg_atoi: error in somewhere: can\'t parse ')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_INVALID_NUMBER);
     }
 
     public function testInvalidNumberErrorIsSupported2()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'value unknown is out of range for type bigint')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_INVALID_NUMBER);
     }
 
     public function testInvalidNumberErrorIsSupported3()
     {
         $this->assertTrue($this->exc->processErrorInfo(array(0, 0, 'integer out of range')));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_INVALID_NUMBER);
     }
 
@@ -112,105 +112,105 @@ class Doctrine_Connection_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testNoSuchFieldErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'column name (of relation xx) does not exist'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testNoSuchFieldErrorIsSupported2()
     {
         $this->exc->processErrorInfo(array(0, 0, 'attribute xx not found'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testNoSuchFieldErrorIsSupported3()
     {
         $this->exc->processErrorInfo(array(0, 0, 'relation xx does not have attribute'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testNoSuchFieldErrorIsSupported4()
     {
         $this->exc->processErrorInfo(array(0, 0, 'column xx specified in USING clause does not exist in left table'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testNoSuchFieldErrorIsSupported5()
     {
         $this->exc->processErrorInfo(array(0, 0, 'column xx specified in USING clause does not exist in right table'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testNotFoundErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'index xx does not exist/'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOT_FOUND);
     }
-    
+
     public function testNotNullConstraintErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'violates not-null constraint'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT_NOT_NULL);
     }
 
     public function testConstraintErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'referential integrity violation'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testConstraintErrorIsSupported2()
     {
         $this->exc->processErrorInfo(array(0, 0, 'violates xx constraint'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testInvalidErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'value too long for type character'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_INVALID);
     }
 
     public function testAlreadyExistsErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'relation xx already exists'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ALREADY_EXISTS);
     }
 
     public function testDivZeroErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'division by zero'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_DIVZERO);
     }
 
     public function testDivZeroErrorIsSupported2()
     {
         $this->exc->processErrorInfo(array(0, 0, 'divide by zero'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_DIVZERO);
     }
 
     public function testAccessViolationErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'permission denied'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_ACCESS_VIOLATION);
     }
-    
+
     public function testValueCountOnRowErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0, 0, 'more expressions than target columns'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_VALUE_COUNT_ON_ROW);
     }
 }

--- a/tests/Connection/ProfilerTestCase.php
+++ b/tests/Connection/ProfilerTestCase.php
@@ -52,12 +52,12 @@ class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->conn->setListener($this->profiler);
 
         $this->conn->exec('CREATE TABLE test (id INT)');
-        
+
         $this->assertEqual($this->profiler->lastEvent()->getQuery(), 'CREATE TABLE test (id INT)');
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getCode(), Doctrine_Event::CONN_EXEC);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         $this->assertEqual($this->conn->count(), 1);
     }
 
@@ -106,7 +106,7 @@ class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($this->conn->count(), 4);
         */
     }
-    
+
     public function testExecuteStatementMultipleTimes()
     {
         try {
@@ -140,7 +140,7 @@ class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getCode(), Doctrine_Event::TX_BEGIN);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         try {
             $this->conn->rollback();
             $this->pass();
@@ -166,7 +166,7 @@ class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getCode(), Doctrine_Event::TX_BEGIN);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         try {
             $this->conn->commit();
             $this->pass();

--- a/tests/Connection/SqliteTestCase.php
+++ b/tests/Connection/SqliteTestCase.php
@@ -35,77 +35,77 @@ class Doctrine_Connection_Sqlite_TestCase extends Doctrine_UnitTestCase
     public function testNoSuchTableErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'no such table: test1'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHTABLE);
     }
 
     public function testNoSuchIndexErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'no such index: test1'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOT_FOUND);
     }
 
     public function testUniquePrimaryKeyErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'PRIMARY KEY must be unique'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testIsNotUniqueErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'is not unique'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testColumnsNotUniqueErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'columns name, id are not unique'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testUniquenessConstraintErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'uniqueness constraint failed'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT);
     }
 
     public function testNotNullConstraintErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'may not be NULL'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_CONSTRAINT_NOT_NULL);
     }
 
     public function testNoSuchFieldErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'no such column: column1'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testColumnNotPresentInTablesErrorIsSupported2()
     {
         $this->exc->processErrorInfo(array(0,0, 'column not present in both tables'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_NOSUCHFIELD);
     }
 
     public function testNearSyntaxErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, 'near "SELECT FROM": syntax error'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_SYNTAX);
     }
 
     public function testValueCountOnRowErrorIsSupported()
     {
         $this->exc->processErrorInfo(array(0,0, '3 values for 2 columns'));
-        
+
         $this->assertEqual($this->exc->getPortableCode(), Doctrine_Core::ERR_VALUE_COUNT_ON_ROW);
     }
 }

--- a/tests/Connection/UnitOfWork.php
+++ b/tests/Connection/UnitOfWork.php
@@ -127,7 +127,7 @@ class Doctrine_Connection_UnitOfWork_TestCase extends Doctrine_UnitTestCase
         unset($user);
         $user = $this->objTable->find(5);
         $this->assertEqual($user->Phonenumber->count(), 0);
-        
+
         // ADDING REFERENCES WITH STRING KEYS
 
         $user->Phonenumber['home']->phonenumber = '123 123';
@@ -158,7 +158,7 @@ class Doctrine_Connection_UnitOfWork_TestCase extends Doctrine_UnitTestCase
         $user = $this->objTable->find(5);
         $this->assertEqual($user->Phonenumber->count(), 3);
 
-        
+
         // ONE-TO-ONE REFERENCES
 
         $user->Email->address = 'drinker@drinkmore.info';
@@ -183,7 +183,7 @@ class Doctrine_Connection_UnitOfWork_TestCase extends Doctrine_UnitTestCase
         $user = $this->objTable->find(5);
         $this->assertTrue($user->Email instanceof Email);
         $this->assertEqual($user->Email->address, 'absolutist@nottodrink.com');
-        
+
         $emails = $this->connection->query("FROM Email WHERE Email.id = $id");
         //$this->assertEqual(count($emails),0);
     }
@@ -196,9 +196,9 @@ class Doctrine_Connection_UnitOfWork_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($this->connection->transaction->getState(), Doctrine_Transaction::STATE_SLEEP);
 
         $this->connection->beginTransaction();
-        
+
         $user = $this->objTable->find(6);
-        
+
         $user->name = 'Jack Daniels';
         $this->connection->flush();
         $this->connection->commit();

--- a/tests/ConnectionTestCase.php
+++ b/tests/ConnectionTestCase.php
@@ -77,14 +77,14 @@ class Doctrine_Connection_TestCase extends Doctrine_UnitTestCase
     public function testFetchOne()
     {
         $c = $this->conn->fetchOne('SELECT COUNT(1) FROM entity');
-        
+
         $this->assertEqual($c, 2);
-        
+
         $c = $this->conn->fetchOne('SELECT COUNT(1) FROM entity WHERE id = ?', array(1));
-        
+
         $this->assertEqual($c, 1);
     }
-    
+
 
     public function testFetchColumn()
     {
@@ -129,7 +129,7 @@ class Doctrine_Connection_TestCase extends Doctrine_UnitTestCase
                             ));
 
         $c = $this->conn->fetchRow('SELECT * FROM entity WHERE id = ?', array(1));
-        
+
         $this->assertEqual($c, array(
                               'id'   => '1',
                               'name' => 'zYne',

--- a/tests/ConnectionTransactionTestCase.php
+++ b/tests/ConnectionTransactionTestCase.php
@@ -3,7 +3,7 @@
 class Transaction_TestLogger implements Doctrine_Overloadable
 {
     private $messages = array();
-    
+
     public function __call($m, $a)
     {
         $this->messages[] = $m;
@@ -56,7 +56,7 @@ class Doctrine_Connection_Transaction_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($listener->pop(), 'onPreTransactionBegin');
 
         $this->assertEqual($user->id, 1);
-        
+
         $this->assertTrue($count < count($this->dbh));
 
         $this->connection->commit();
@@ -96,7 +96,7 @@ class Doctrine_Connection_Transaction_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($users[0]->id, 2);
 
         $this->assertEqual($users[1]->id, 3);
-        
+
         $this->assertTrue($count < count($this->dbh));
 
         $this->connection->commit();
@@ -111,7 +111,7 @@ class Doctrine_Connection_Transaction_TestCase extends Doctrine_UnitTestCase
 
 
         $user = $this->connection->getTable('User')->find(1);
-        
+
         $listener = new Transaction_TestLogger();
         $user->getTable()->getConnection()->setListener($listener);
         $this->connection->beginTransaction();
@@ -129,7 +129,7 @@ class Doctrine_Connection_Transaction_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($listener->pop(), 'onPreTransactionBegin');
 
         $this->assertEqual($user->id, 1);
-        
+
         $this->assertTrue($count < count($this->dbh));
 
         $this->connection->commit();
@@ -168,7 +168,7 @@ class Doctrine_Connection_Transaction_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($users[1]->id, 2);
 
         $this->assertEqual($users[2]->id, 3);
-        
+
         $this->assertTrue($count < count($this->dbh));
 
         $this->connection->commit();

--- a/tests/CtiColumnAggregationInheritanceTestCase.php
+++ b/tests/CtiColumnAggregationInheritanceTestCase.php
@@ -51,7 +51,7 @@ class CTICATestParent2 extends CTICATestParent1
 
         $this->hasColumn('verified', 'boolean', 1);
         $this->hasColumn('type', 'integer', 2);
-        
+
         $this->setSubclasses(array(
             'CTICATest'  => array('type' => 1),
             'CTICATest2' => array('type' => 2)
@@ -90,7 +90,7 @@ class CTICATestOneToManyRelated extends Doctrine_Record
         $this->hasColumn('name', 'string');
         $this->hasColumn('cti_id', 'integer');
     }
-    
+
     public function setUp()
     {
         $this->hasMany('CTICATestParent1', array('local' => 'cti_id', 'foreign' => 'id'));

--- a/tests/CustomPrimaryKeyTestCase.php
+++ b/tests/CustomPrimaryKeyTestCase.php
@@ -35,11 +35,11 @@ class Doctrine_CustomPrimaryKey_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function prepareTables()
     {
         $this->tables = array('CustomPK');
-        
+
         parent::prepareTables();
     }
 
@@ -50,13 +50,13 @@ class Doctrine_CustomPrimaryKey_TestCase extends Doctrine_UnitTestCase
 
         $c->name = 'custom pk test';
         $this->assertEqual($c->identifier(), array());
-        
+
         $c->save();
         $this->assertEqual($c->identifier(), array('uid' => 1));
         $this->connection->clear();
-        
+
         $c = $this->connection->getTable('CustomPK')->find(1);
-    
+
         $this->assertEqual($c->identifier(), array('uid' => 1));
     }
 }

--- a/tests/CustomResultSetOrderTestCase.php
+++ b/tests/CustomResultSetOrderTestCase.php
@@ -32,7 +32,7 @@
  */
 class Doctrine_CustomResultSetOrder_TestCase extends Doctrine_UnitTestCase
 {
-    
+
     /**
      * Prepares the data under test.
      *
@@ -47,35 +47,35 @@ class Doctrine_CustomResultSetOrder_TestCase extends Doctrine_UnitTestCase
         $cat1           = new CategoryWithPosition();
         $cat1->position = 0;
         $cat1->name     = 'First';
-        
+
         $cat2           = new CategoryWithPosition();
         $cat2->position = 0; // same 'priority' as the first
         $cat2->name     = 'Second';
-        
+
         $cat3           = new CategoryWithPosition();
         $cat3->position = 1;
         $cat3->name     = 'Third';
-        
+
         $board1           = new BoardWithPosition();
         $board1->position = 0;
-        
+
         $board2           = new BoardWithPosition();
         $board2->position = 1;
-        
+
         $board3           = new BoardWithPosition();
         $board3->position = 2;
-        
+
         // The first category gets 3 boards!
         $cat1->Boards[0] = $board1;
         $cat1->Boards[1] = $board2;
         $cat1->Boards[2] = $board3;
-        
+
         $board4           = new BoardWithPosition();
         $board4->position = 0;
-        
+
         // The second category gets 1 board!
         $cat2->Boards[0] = $board4;
-        
+
         $this->connection->flush();
     }
 
@@ -112,7 +112,7 @@ class Doctrine_CustomResultSetOrder_TestCase extends Doctrine_UnitTestCase
                 ->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
 
         $this->assertEqual(3, count($categories), 'Some categories were doubled!');
-                
+
         // Check each category
         foreach ($categories as $category) {
             switch ($category['name']) {
@@ -156,7 +156,7 @@ class Doctrine_CustomResultSetOrder_TestCase extends Doctrine_UnitTestCase
                 ->execute();
 
         $this->assertEqual(3, $categories->count(), 'Some categories were doubled!');
-                
+
         // Check each category
         foreach ($categories as $category) {
             switch ($category->name) {

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -43,7 +43,7 @@ class Doctrine_Db_TestCase extends Doctrine_UnitTestCase
     public function init()
     {
     }
-    
+
     public function testInitialize()
     {
         $this->conn = Doctrine_Manager::getInstance()->openConnection(array('sqlite::memory:'));
@@ -51,8 +51,8 @@ class Doctrine_Db_TestCase extends Doctrine_UnitTestCase
 
         $this->conn->exec("INSERT INTO entity (id, name) VALUES (1, 'zYne')");
         $this->conn->exec("INSERT INTO entity (id, name) VALUES (2, 'John')");
-        
-        
+
+
         $this->assertEqual($this->conn->getAttribute(Doctrine_Core::ATTR_DRIVER_NAME), 'sqlite');
     }
 
@@ -81,7 +81,7 @@ class Doctrine_Db_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($this->conn->getListener() instanceof Doctrine_EventListener_Chain);
         $this->assertTrue($this->conn->getListener()->get(0) instanceof Doctrine_Connection_TestLogger);
         $this->assertTrue($this->conn->getListener()->get(1) instanceof Doctrine_Connection_TestValidListener);
-        
+
         try {
             $ret = $this->conn->addListener(new Doctrine_EventListener_Chain(), 'chain');
             $this->pass();
@@ -117,17 +117,17 @@ class Doctrine_Db_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($listener->pop(), 'postPrepare');
         $this->assertEqual($listener->pop(), 'prePrepare');
-        
+
         $stmt->execute(array(1));
 
         $this->assertEqual($listener->pop(), 'postStmtExecute');
         $this->assertEqual($listener->pop(), 'preStmtExecute');
-        
+
         $this->conn->exec('DELETE FROM entity');
 
         $this->assertEqual($listener->pop(), 'postExec');
         $this->assertEqual($listener->pop(), 'preExec');
-        
+
         $this->conn->beginTransaction();
 
         $this->assertEqual($listener->pop(), 'postTransactionBegin');
@@ -139,7 +139,7 @@ class Doctrine_Db_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($listener->pop(), 'preExec');
 
         $this->conn->commit();
-        
+
         $this->assertEqual($listener->pop(), 'postTransactionCommit');
         $this->assertEqual($listener->pop(), 'preTransactionCommit');
     }
@@ -265,10 +265,10 @@ class Doctrine_Db_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($listener->pop(), 'postTransactionCommit');
         $this->assertEqual($listener->pop(), 'preTransactionCommit');
-        
+
         $this->assertEqual($listener->pop(), 'postExec');
         $this->assertEqual($listener->pop(), 'preExec');
-        
+
         $this->conn->exec('DROP TABLE entity');
     }
 
@@ -406,7 +406,7 @@ class Doctrine_Db_TestCase extends Doctrine_UnitTestCase
 class Doctrine_Connection_TestLogger implements Doctrine_Overloadable
 {
     private $messages = array();
-    
+
     public function __call($m, $a)
     {
         $this->messages[] = $m;

--- a/tests/Data/ImportTestCase.php
+++ b/tests/Data/ImportTestCase.php
@@ -43,7 +43,7 @@ class Doctrine_Data_Import_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'I18nNumberLang';
         parent::prepareTables();
     }
-    
+
     public function testInlineMany()
     {
         $yml = <<<END
@@ -244,7 +244,7 @@ END;
 
         unlink('test.yml');
     }
-    
+
     public function testImportNestedSetMultipleTreeData()
     {
         $yml = <<<END
@@ -315,7 +315,7 @@ END;
             $this->assertEqual($i[4]['rgt'], 3);
             $this->assertEqual($i[4]['level'], 1);
             $this->assertEqual($i[4]['root_id'], $i[3]['root_id']);
-            
+
             $this->assertEqual($i[5]['name'], 'Item 2.2');
             $this->assertEqual($i[5]['lft'], 4);
             $this->assertEqual($i[5]['rgt'], 11);
@@ -367,7 +367,7 @@ END;
 
         unlink('test.yml');
     }
-    
+
     public function testInvalidElementThrowsException()
     {
         self::prepareTables();
@@ -394,7 +394,7 @@ END;
         } catch (Exception $e) {
             $this->pass();
         }
-        
+
         unlink('test.yml');
     }
 

--- a/tests/DataDict/MssqlTestCase.php
+++ b/tests/DataDict/MssqlTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_DataDict_Mssql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeBitType()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'bit'));
-        
+
         $this->assertEqual($type, array('type'     => array('boolean'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -59,7 +59,7 @@ class Doctrine_DataDict_Mssql_TestCase extends Doctrine_UnitTestCase
                                         'fixed'    => true));
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'varchar', 'length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('string', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
@@ -69,7 +69,7 @@ class Doctrine_DataDict_Mssql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeBlobTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'image'));
-        
+
         $this->assertEqual($type, array('type'     => array('blob'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -86,14 +86,14 @@ class Doctrine_DataDict_Mssql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeIntegerTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'int'));
-        
+
         $this->assertEqual($type, array('type'     => array('integer'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'int', 'length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('integer', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
@@ -103,7 +103,7 @@ class Doctrine_DataDict_Mssql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeTimestampType()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'datetime'));
-        
+
         $this->assertEqual($type, array('type'     => array('timestamp'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -156,7 +156,7 @@ class Doctrine_DataDict_Mssql_TestCase extends Doctrine_UnitTestCase
         $a = array('type' => 'integer', 'length' => 20, 'fixed' => false);
 
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'INT');
-        
+
         $a['length'] = 4;
 
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'INT');

--- a/tests/DataDict/MysqlTestCase.php
+++ b/tests/DataDict/MysqlTestCase.php
@@ -102,7 +102,7 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => false));
-        
+
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'mediumtext'));
 
         $this->assertEqual($type, array('type'     => array('string', 'clob'),
@@ -135,7 +135,7 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeFloatTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'float'));
-        
+
         $this->assertEqual($type, array('type'     => array('float'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -149,7 +149,7 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'double'));
-        
+
         $this->assertEqual($type, array('type'     => array('float'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -159,7 +159,7 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeDateType()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'date'));
-        
+
         $this->assertEqual($type, array('type'     => array('date'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -169,21 +169,21 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeDecimalTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'decimal'));
-        
+
         $this->assertEqual($type, array('type'     => array('decimal'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'unknown'));
-        
+
         $this->assertEqual($type, array('type'     => array('decimal'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
-        
+
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'numeric'));
-        
+
         $this->assertEqual($type, array('type'     => array('decimal'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -193,14 +193,14 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeTimestampTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'timestamp'));
-        
+
         $this->assertEqual($type, array('type'     => array('timestamp'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
-        
+
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'datetime'));
-        
+
         $this->assertEqual($type, array('type'     => array('timestamp'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -211,7 +211,7 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'year'));
 
-        
+
         $this->assertEqual($type, array('type'     => array('integer', 'date'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -233,7 +233,7 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
-        
+
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'tinyblob'));
 
         $this->assertEqual($type, array('type'     => array('blob'),
@@ -254,7 +254,7 @@ class Doctrine_DataDict_Mysql_TestCase extends Doctrine_UnitTestCase
         $a = array('type' => 'integer', 'length' => 20, 'fixed' => false);
 
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'BIGINT');
-        
+
         $a['length'] = 4;
 
         $this->assertEqual($this->dataDict->GetNativeDeclaration($a), 'INT');

--- a/tests/DataDict/OracleTestCase.php
+++ b/tests/DataDict/OracleTestCase.php
@@ -45,21 +45,21 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeIntegerTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'integer'));
-        
+
         $this->assertEqual($type, array('type'     => array('integer'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'pls_integer', 'data_length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('integer', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'binary_integer', 'data_length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('integer', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
@@ -83,12 +83,12 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
                                         'fixed'    => false));
 
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'nvarchar2', 'data_length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('string', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
                                         'fixed'    => false));
-        
+
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'char', 'data_length' => 1));
 
         $this->assertEqual($type, array('type'     => array('string', 'boolean'),
@@ -97,7 +97,7 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
                                         'fixed'    => true));
 
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'nchar', 'data_length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('string', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
@@ -107,7 +107,7 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeNumberType()
     {
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'number'));
-        
+
         $this->assertEqual($type, array('type'     => array('integer'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -115,7 +115,7 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
 
 
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'number', 'data_length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('integer', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
@@ -125,14 +125,14 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeTimestampType()
     {
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'date'));
-        
+
         $this->assertEqual($type, array('type'     => array('timestamp'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'timestamp'));
-        
+
         $this->assertEqual($type, array('type'     => array('timestamp'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -142,21 +142,21 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeClobTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'clob'));
-        
+
         $this->assertEqual($type, array('type'     => array('clob'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'long'));
-        
+
         $this->assertEqual($type, array('type'     => array('string', 'clob'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
-        
+
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'nclob'));
-        
+
         $this->assertEqual($type, array('type'     => array('clob'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -166,13 +166,6 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeBlobTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'blob'));
-        
-        $this->assertEqual($type, array('type'     => array('blob'),
-                                        'length'   => null,
-                                        'unsigned' => null,
-                                        'fixed'    => null));
-
-        $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'long raw'));
 
         $this->assertEqual($type, array('type'     => array('blob'),
                                         'length'   => null,
@@ -185,7 +178,14 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
-        
+
+        $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'long raw'));
+
+        $this->assertEqual($type, array('type'     => array('blob'),
+                                        'length'   => null,
+                                        'unsigned' => null,
+                                        'fixed'    => null));
+
         $type = $this->dataDict->getPortableDeclaration(array('data_type' => 'raw'));
 
         $this->assertEqual($type, array('type'     => array('blob'),
@@ -199,11 +199,11 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
         $a = array('type' => 'integer', 'length' => 20, 'fixed' => false);
 
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'INTEGER');
-        
+
         $a['length'] = 8;
-        
+
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'NUMBER(20)');
-        
+
         $a['length'] = 4;
 
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'NUMBER(10)');
@@ -211,17 +211,17 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
         $a['length'] = 3;
 
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'NUMBER(8)');
-        
+
         $a['length'] = 2;
-        
+
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'NUMBER(5)');
-        
+
         $a['length'] = 1;
-        
+
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'NUMBER(3)');
-        
+
         unset($a['length']);
-        
+
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'INTEGER');
     }
 
@@ -291,20 +291,20 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testGetNativeDefinitionSupportsVarcharOwnParams()
     {
         $a = array('type' => 'varchar', 'length' => 10);
-        
+
         $this->conn->setParam('char_unit', 'CHAR');
         $this->conn->setParam('varchar2_max_length', 1000);
-        
+
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'VARCHAR2(10 CHAR)');
-        
+
         $a['length'] = 1001;
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'CLOB');
-        
+
         $this->conn->setParam('char_unit', 'BYTE');
         $this->conn->setParam('varchar2_max_length', 4000);
-        
+
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'VARCHAR2(1001 BYTE)');
-        
+
         $this->conn->setParam('char_unit', null);
     }
 
@@ -339,7 +339,7 @@ class Doctrine_DataDict_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testGetNativeDefinitionSupportsLargerStrings()
     {
         $a = array('type' => 'string', 'length' => 4001);
-        
+
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'CLOB');
     }
 }

--- a/tests/DataDict/PgsqlTestCase.php
+++ b/tests/DataDict/PgsqlTestCase.php
@@ -36,11 +36,11 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
     {
         return $this->dataDict->getPortableDeclaration(array('type' => $type, 'name' => 'colname', 'length' => 2, 'fixed' => true));
     }
- 
+
     public function testGetPortableDeclarationSupportsNativeBlobTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'blob'));
-        
+
         $this->assertEqual($type, array('type'     => array('blob'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -59,7 +59,7 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
-        
+
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'longblob'));
 
         $this->assertEqual($type, array('type'     => array('blob'),
@@ -85,14 +85,14 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeTimestampTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'timestamp'));
-        
+
         $this->assertEqual($type, array('type'     => array('timestamp'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'datetime'));
-        
+
         $this->assertEqual($type, array('type'     => array('timestamp'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -126,21 +126,21 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeFloatTypes()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'float'));
-        
+
         $this->assertEqual($type, array('type'     => array('float'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'double'));
-        
+
         $this->assertEqual($type, array('type'     => array('float'),
                                         'length'   => null,
                                         'unsigned' => null,
                                         'fixed'    => null));
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'real'));
-        
+
         $this->assertEqual($type, array('type'     => array('float'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -160,7 +160,7 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeDateType()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'date'));
-        
+
         $this->assertEqual($type, array('type'     => array('date'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -170,7 +170,7 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testGetPortableDeclarationSupportsNativeTimeType()
     {
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'time'));
-        
+
         $this->assertEqual($type, array('type'     => array('time'),
                                         'length'   => null,
                                         'unsigned' => null,
@@ -201,13 +201,13 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
                                         'fixed'    => false));
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'unknown', 'length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('string', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
                                         'fixed'    => true));
 
-        
+
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'char', 'length' => 1));
 
         $this->assertEqual($type, array('type'     => array('string', 'boolean'),
@@ -217,7 +217,7 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
 
 
         $type = $this->dataDict->getPortableDeclaration(array('type' => 'bpchar', 'length' => 1));
-        
+
         $this->assertEqual($type, array('type'     => array('string', 'boolean'),
                                         'length'   => 1,
                                         'unsigned' => null,
@@ -254,7 +254,7 @@ class Doctrine_DataDict_Pgsql_TestCase extends Doctrine_UnitTestCase
         $a = array('type' => 'integer', 'length' => 20, 'fixed' => false);
 
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'BIGINT');
-        
+
         $a['length'] = 4;
 
         $this->assertEqual($this->dataDict->getNativeDeclaration($a), 'INT');

--- a/tests/DataType/BooleanTestCase.php
+++ b/tests/DataType/BooleanTestCase.php
@@ -40,7 +40,7 @@ class Doctrine_DataType_Boolean_TestCase extends Doctrine_UnitTestCase
         $this->tables = array('BooleanTest');
         parent::prepareTables();
     }
-   
+
     public function testSetFalse()
     {
         $test             = new BooleanTest();
@@ -60,12 +60,12 @@ class Doctrine_DataType_Boolean_TestCase extends Doctrine_UnitTestCase
         $test->is_working = true;
         $this->assertIdentical($test->is_working, true);
         $test->save();
-        
+
         $test->refresh();
         $this->assertIdentical($test->is_working, true);
-        
+
         $this->connection->clear();
-        
+
         $test = $test->getTable()->find($test->id);
         $this->assertIdentical($test->is_working, true);
     }
@@ -113,7 +113,7 @@ class Doctrine_DataType_Boolean_TestCase extends Doctrine_UnitTestCase
 
         $test->refresh();
         $this->assertIdentical($test->is_working, null);
-        
+
         $test                     = new BooleanTest();
         $test->is_working_notnull = null;
 

--- a/tests/DataType/EnumTestCase.php
+++ b/tests/DataType/EnumTestCase.php
@@ -47,7 +47,7 @@ class Doctrine_DataType_Enum_TestCase extends Doctrine_UnitTestCase
         $test->status = 'open';
         $this->assertEqual($test->status, 'open');
         $test->save();
-        
+
         try {
             $query = new Doctrine_Query($this->connection);
             $ret   = $query->query("FROM EnumTest WHERE EnumTest.status = 'open'");
@@ -56,7 +56,7 @@ class Doctrine_DataType_Enum_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
     }
-    
+
     public function testUpdate()
     {
         $test         = new EnumTest2();
@@ -88,7 +88,7 @@ class Doctrine_DataType_Enum_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
     }
-    
+
     public function testParameterConversionInCount()
     {
         try {
@@ -186,7 +186,7 @@ class Doctrine_DataType_Enum_TestCase extends Doctrine_UnitTestCase
 
         $enum->refresh();
         $this->assertEqual($enum->status, 'open');
-        
+
         $enum->status = 'closed';
 
         $this->assertEqual($enum->status, 'closed');

--- a/tests/Db/ProfilerTestCase.php
+++ b/tests/Db/ProfilerTestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function testQuery()
     {
         $this->conn = Doctrine_Manager::getInstance()->openConnection(array('sqlite::memory:'));
@@ -49,12 +49,12 @@ class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->conn->setListener($this->profiler);
 
         $this->conn->exec('CREATE TABLE test (id INT)');
-        
+
         $this->assertEqual($this->profiler->lastEvent()->getQuery(), 'CREATE TABLE test (id INT)');
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getCode(), Doctrine_Db_Event::EXEC);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         $this->assertEqual($this->conn->count(), 1);
     }
     public function testPrepareAndExecute()
@@ -132,7 +132,7 @@ class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getCode(), Doctrine_Db_Event::BEGIN);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         try {
             $this->conn->rollback();
             $this->pass();
@@ -157,7 +157,7 @@ class Doctrine_Connection_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getCode(), Doctrine_Db_Event::BEGIN);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         try {
             $this->conn->commit();
             $this->pass();

--- a/tests/DbProfilerTestCase.php
+++ b/tests/DbProfilerTestCase.php
@@ -2,7 +2,7 @@
 class Doctrine_Db_Profiler_TestCase extends Doctrine_UnitTestCase
 {
     protected $dbh;
-    
+
     protected $profiler;
     public function prepareTables()
     {
@@ -10,7 +10,7 @@ class Doctrine_Db_Profiler_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function testQuery()
     {
         $this->dbh = Doctrine_Db2::getConnection('sqlite::memory:');
@@ -20,12 +20,12 @@ class Doctrine_Db_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->dbh->setListener($this->profiler);
 
         $this->dbh->query('CREATE TABLE test (id INT)');
-        
+
         $this->assertEqual($this->profiler->lastEvent()->getQuery(), 'CREATE TABLE test (id INT)');
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getType(), Doctrine_Db_Event::QUERY);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         $this->assertEqual($this->dbh->count(), 1);
     }
     public function testPrepareAndExecute()
@@ -103,7 +103,7 @@ class Doctrine_Db_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getType(), Doctrine_Db_Event::BEGIN);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         try {
             $this->dbh->rollback();
             $this->pass();
@@ -128,7 +128,7 @@ class Doctrine_Db_Profiler_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($this->profiler->lastEvent()->hasEnded());
         $this->assertEqual($this->profiler->lastEvent()->getType(), Doctrine_Db_Event::BEGIN);
         $this->assertTrue(is_numeric($this->profiler->lastEvent()->getElapsedSecs()));
-        
+
         try {
             $this->dbh->commit();
             $this->pass();

--- a/tests/DoctrineTest/Doctrine_UnitTestCase.php
+++ b/tests/DoctrineTest/Doctrine_UnitTestCase.php
@@ -97,7 +97,7 @@ class Doctrine_UnitTestCase extends UnitTestCase
 
         if (! $this->driverName) {
             $this->driverName = 'main';
-    
+
             switch ($e[1]) {
                 case 'Export':
                 case 'Import':
@@ -107,9 +107,9 @@ class Doctrine_UnitTestCase extends UnitTestCase
                     $this->driverName = 'Sqlite';
                 break;
             }
-            
+
             $module = $e[1];
-    
+
             if (count($e) > 3) {
                 $driver = $e[2];
                 switch ($e[2]) {
@@ -162,7 +162,7 @@ class Doctrine_UnitTestCase extends UnitTestCase
                     case 'Sequence':
                     case 'Expression':
                         $lower = strtolower($module);
-    
+
                         $this->$lower = $this->connection->$lower;
                     break;
                     case 'DataDict':
@@ -262,7 +262,7 @@ class Doctrine_UnitTestCase extends UnitTestCase
     public function assertDeclarationType($type, $type2)
     {
         $dec = $this->getDeclaration($type);
-        
+
         if (! is_array($type2)) {
             $type2 = array($type2);
         }
@@ -284,7 +284,7 @@ class Doctrine_UnitTestCase extends UnitTestCase
 
         $this->init = true;
     }
-    
+
     public function tearDown()
     {
     }

--- a/tests/DoctrineTest/Reporter.php
+++ b/tests/DoctrineTest/Reporter.php
@@ -25,7 +25,7 @@ class DoctrineTest_Reporter
             return '<span style="font-weight: bold; color: ' . $color . ';">' . $message . '</span>';
         }
     }
-    
+
     public function setTestCase($test)
     {
         $this->_test = $test;

--- a/tests/DoctrineTest/Reporter/Html.php
+++ b/tests/DoctrineTest/Reporter/Html.php
@@ -58,7 +58,7 @@ class DoctrineTest_Reporter_Html extends DoctrineTest_Reporter
     public function paintFooter()
     {
         print '</div></div>';
-        
+
         $this->paintSummary();
     }
 

--- a/tests/DoctrineTest/UnitTestCase.php
+++ b/tests/DoctrineTest/UnitTestCase.php
@@ -2,9 +2,9 @@
 class UnitTestCase
 {
     protected $_passed = 0;
-    
+
     protected $_failed = 0;
-    
+
     protected $_messages = array();
 
     protected static $_passesAndFails = array('passes' => array(), 'fails' => array());
@@ -156,7 +156,7 @@ class UnitTestCase
                 $this->setUp();
 
                 $this->$method();
-                
+
                 $this->tearDown();
             }
         }

--- a/tests/DriverTestCase.php
+++ b/tests/DriverTestCase.php
@@ -2,11 +2,11 @@
 class AdapterMock implements Doctrine_Adapter_Interface
 {
     private $name;
-    
+
     private $queries = array();
-    
+
     private $exception = array();
-    
+
     private $lastInsertIdFail = false;
 
     public function __construct($name)
@@ -140,7 +140,7 @@ class AdapterMock implements Doctrine_Adapter_Interface
 class AdapterStatementMock
 {
     private $mock;
-    
+
     private $query;
 
     public function __construct(AdapterMock $mock, $query)
@@ -222,12 +222,12 @@ class Doctrine_Driver_UnitTestCase extends UnitTestCase
             if ($this->adapter->getName() == 'oci') {
                 $name = 'Oracle';
             }
-            
+
             $tx       = 'Doctrine_Transaction_' . ucwords($name);
             $dataDict = 'Doctrine_DataDict_' . ucwords($name);
-            
+
             $exc = 'Doctrine_Connection_' . ucwords($name) . '_Exception';
-            
+
             $this->exc = new $exc();
             if (class_exists($tx)) {
                 $this->transaction = new $tx($this->conn);

--- a/tests/EventListenerTestCase.php
+++ b/tests/EventListenerTestCase.php
@@ -47,9 +47,9 @@ class Doctrine_EventListener_TestCase extends Doctrine_UnitTestCase
     public function testSetListener()
     {
         $this->logger = new Doctrine_EventListener_TestLogger();
-    
+
         $e = new EventListenerTest;
-        
+
         $e->getTable()->setListener($this->logger);
 
         $e->name = 'listener';

--- a/tests/Export/CheckConstraintTestCase.php
+++ b/tests/Export/CheckConstraintTestCase.php
@@ -38,15 +38,15 @@ class Doctrine_Export_CheckConstraint_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
     }
-    
+
     public function testCheckConstraints()
     {
         $e = $this->conn->export;
 
         $sql = $e->exportClassesSql(array('CheckConstraintTest'));
-   
+
         $this->assertEqual($sql[0], 'CREATE TABLE check_constraint_test (id INTEGER PRIMARY KEY AUTOINCREMENT, price DECIMAL(2,2), discounted_price DECIMAL(2,2), CHECK (price >= 100), CHECK (price <= 5000), CHECK (price > discounted_price))');
-    
+
         try {
             $dbh = new PDO('sqlite::memory:');
             $dbh->exec($sql[0]);

--- a/tests/Export/MssqlTestCase.php
+++ b/tests/Export/MssqlTestCase.php
@@ -44,7 +44,7 @@ class Doctrine_Export_Mssql_TestCase extends Doctrine_UnitTestCase
         $this->export->alterTable('user', array(
             'name' => 'userlist'
         ));
-        
+
         $this->assertEqual($this->adapter->pop(), "EXECUTE sp_RENAME '[user]', 'userlist';");
     }
     public function testAlterTableRename()
@@ -129,7 +129,7 @@ class Doctrine_Export_Mssql_TestCase extends Doctrine_UnitTestCase
         $name = 'mytable';
 
         $fields = array('id' => array('type' => 'integer', 'unsigned' => 1));
-        
+
 
         $this->export->createTable($name, $fields);
 
@@ -179,7 +179,7 @@ class Doctrine_Export_Mssql_TestCase extends Doctrine_UnitTestCase
     public function testCreateDatabaseExecutesSql()
     {
         $this->export->createDatabase('db');
-        
+
         $this->assertEqual($this->adapter->pop(), 'CREATE DATABASE db');
     }
     public function testDropDatabaseExecutesSql()
@@ -222,7 +222,7 @@ class Doctrine_Export_Mssql_TestCase extends Doctrine_UnitTestCase
                          );
 
         $sql = $this->export->createTableSql($name, $fields, $options);
-        
+
         $this->assertEqual(count($sql), 2);
         $this->assertEqual($sql[0], 'CREATE TABLE mytable (id BIT NOT NULL, lang INT NOT NULL, PRIMARY KEY([id], [lang]))');
         $this->assertEqual($sql[1], 'ALTER TABLE [mytable] ADD FOREIGN KEY ([id], [lang]) REFERENCES [sometable]([id], [lang])');

--- a/tests/Export/MysqlTestCase.php
+++ b/tests/Export/MysqlTestCase.php
@@ -52,10 +52,10 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableExecutesSql()
     {
         $name = 'mytable';
-        
+
         $fields  = array('id' => array('type' => 'integer', 'unsigned' => 1));
         $options = array('type' => 'MYISAM');
-        
+
         $this->export->createTable($name, $fields, $options);
 
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (id INT UNSIGNED) ENGINE = MYISAM');
@@ -63,7 +63,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsDefaultTableType()
     {
         $name = 'mytable';
-        
+
         $fields = array('id' => array('type' => 'integer', 'unsigned' => 1));
 
         $this->export->createTable($name, $fields);
@@ -76,10 +76,10 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
         $name   = 'mytable';
         $fields = array('name'  => array('type' => 'char', 'length' => 10),
                          'type' => array('type' => 'integer', 'length' => 3));
-                         
+
         $options = array('primary' => array('name', 'type'));
         $this->export->createTable($name, $fields, $options);
-        
+
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (name CHAR(10), type MEDIUMINT, PRIMARY KEY(name, type)) ENGINE = INNODB');
     }
     public function testCreateTableSupportsAutoincPks()
@@ -89,7 +89,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
         $fields  = array('id' => array('type' => 'integer', 'unsigned' => 1, 'autoincrement' => true));
         $options = array('primary' => array('id'),
                         'type'     => 'INNODB');
-        
+
         $this->export->createTable($name, $fields, $options);
 
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (id INT UNSIGNED AUTO_INCREMENT, PRIMARY KEY(id)) ENGINE = INNODB');
@@ -97,10 +97,10 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsCharType()
     {
         $name = 'mytable';
-        
+
         $fields  = array('id' => array('type' => 'char', 'length' => 3));
         $options = array('type' => 'MYISAM');
-        
+
         $this->export->createTable($name, $fields, $options);
 
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (id CHAR(3)) ENGINE = MYISAM');
@@ -108,10 +108,10 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsCharType2()
     {
         $name = 'mytable';
-        
+
         $fields  = array('id' => array('type' => 'char'));
         $options = array('type' => 'MYISAM');
-        
+
         $this->export->createTable($name, $fields, $options);
 
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (id CHAR(255)) ENGINE = MYISAM');
@@ -119,7 +119,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsVarcharType()
     {
         $name = 'mytable';
-        
+
         $fields  = array('id' => array('type' => 'varchar', 'length' => '100'));
         $options = array('type' => 'MYISAM');
 
@@ -130,7 +130,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsIntegerType()
     {
         $name = 'mytable';
-        
+
         $fields  = array('id' => array('type' => 'integer', 'length' => '10'));
         $options = array('type' => 'MYISAM');
 
@@ -141,7 +141,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsBlobType()
     {
         $name = 'mytable';
-        
+
         $fields  = array('content' => array('type' => 'blob'));
         $options = array('type' => 'MYISAM');
 
@@ -152,7 +152,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsBlobType2()
     {
         $name = 'mytable';
-        
+
         $fields  = array('content' => array('type' => 'blob', 'length' => 2000));
         $options = array('type' => 'MYISAM');
 
@@ -164,7 +164,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsBooleanType()
     {
         $name = 'mytable';
-        
+
         $fields  = array('id' => array('type' => 'boolean'));
         $options = array('type' => 'MYISAM');
 
@@ -175,7 +175,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsForeignKeys()
     {
         $name = 'mytable';
-        
+
         $fields = array('id'         => array('type' => 'boolean', 'primary' => true),
                         'foreignKey' => array('type' => 'integer')
                         );
@@ -239,7 +239,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableDoesNotAutoAddIndexesWhenIndexForFkFieldAlreadyExists()
     {
         $name = 'mytable';
-        
+
         $fields = array('id'         => array('type' => 'boolean', 'primary' => true),
                         'foreignKey' => array('type' => 'integer')
                         );
@@ -325,7 +325,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
                          );
 
         $this->export->createTable('sometable', $fields, $options);
-        
+
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE sometable (id INT UNSIGNED AUTO_INCREMENT, name VARCHAR(4), INDEX myindex_idx (id ASC, name DESC), PRIMARY KEY(id)) ENGINE = INNODB');
     }
     public function testCreateTableSupportsFulltextIndexes()
@@ -345,7 +345,7 @@ class Doctrine_Export_Mysql_TestCase extends Doctrine_UnitTestCase
                          );
 
         $this->export->createTable('sometable', $fields, $options);
-        
+
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE sometable (id INT UNSIGNED AUTO_INCREMENT, content VARCHAR(4), FULLTEXT INDEX myindex_idx (content DESC), PRIMARY KEY(id)) ENGINE = MYISAM');
     }
     public function testCreateTableSupportsCompoundForeignKeys()

--- a/tests/Export/OracleTestCase.php
+++ b/tests/Export/OracleTestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Export_Oracle_TestCase extends Doctrine_UnitTestCase
         $query        = 'CREATE SEQUENCE ' . $sequenceName . '_seq START WITH ' . $start . ' INCREMENT BY 1 NOCACHE';
 
         $this->export->createSequence($sequenceName, $start);
-        
+
         $this->assertEqual($this->adapter->pop(), $query);
     }
 
@@ -50,16 +50,16 @@ class Doctrine_Export_Oracle_TestCase extends Doctrine_UnitTestCase
         $query = 'DROP SEQUENCE ' . $sequenceName;
 
         $this->export->dropSequence($sequenceName);
-        
+
         $this->assertEqual($this->adapter->pop(), $query . '_seq');
     }
     public function testCreateTableExecutesSql()
     {
         $name = 'mytable';
-        
+
         $fields  = array('id' => array('type' => 'integer'));
         $options = array('type' => 'MYISAM');
-        
+
         $this->export->createTable($name, $fields);
 
         $this->assertEqual($this->adapter->pop(), 'COMMIT');
@@ -72,43 +72,43 @@ class Doctrine_Export_Oracle_TestCase extends Doctrine_UnitTestCase
         $fields = array('name'  => array('type' => 'char', 'length' => 10, 'default' => 'def'),
                          'type' => array('type' => 'integer', 'length' => 3, 'default' => 12)
                          );
-                         
+
         $options = array('primary' => array('name', 'type'));
         $this->export->createTable($name, $fields, $options);
-        
+
 
         $this->assertEqual($this->adapter->pop(), 'COMMIT');
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (name CHAR(10) DEFAULT \'def\', type NUMBER(8) DEFAULT 12, PRIMARY KEY(name, type))');
         $this->assertEqual($this->adapter->pop(), 'BEGIN TRANSACTION');
     }
-    
+
     public function testCreateTableWithOwnParams()
     {
         $this->conn->setParam('char_unit', 'CHAR');
         $this->conn->setParam('varchar2_max_length', 1000);
-        
+
         $fields = array(
             'type'  => array('type' => 'char', 'length' => 10, 'default' => 'admin'),
             'name'  => array('type' => 'string', 'length' => 1000),
             'about' => array('type' => 'string', 'length' => 1001, 'default' => 'def'),
         );
-        
+
         $sql = $this->export->createTableSql('mytable', $fields);
         $this->assertEqual($sql[0], "CREATE TABLE mytable (type CHAR(10 CHAR) DEFAULT 'admin', name VARCHAR2(1000 CHAR), about CLOB DEFAULT 'def')");
-        
+
         $this->conn->setParam('char_unit', null);
         $this->conn->setParam('varchar2_max_length', 4000);
     }
-    
+
     public function testCreateTableSupportsMultiplePks()
     {
         $name   = 'mytable';
         $fields = array('name'  => array('type' => 'char', 'length' => 10),
                          'type' => array('type' => 'integer', 'length' => 3));
-                         
+
         $options = array('primary' => array('name', 'type'));
         $this->export->createTable($name, $fields, $options);
-        
+
 
         $this->assertEqual($this->adapter->pop(), 'COMMIT');
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (name CHAR(10), type NUMBER(8), PRIMARY KEY(name, type))');
@@ -117,7 +117,7 @@ class Doctrine_Export_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsAutoincPks()
     {
         $name = 'mytable';
-        
+
         $fields = array('id' => array('type' => 'integer', 'autoincrement' => true));
 
 
@@ -134,7 +134,7 @@ class Doctrine_Export_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsCharType()
     {
         $name = 'mytable';
-        
+
         $fields = array('id' => array('type' => 'char', 'length' => 3));
 
         $this->export->createTable($name, $fields);
@@ -169,7 +169,7 @@ class Doctrine_Export_Oracle_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($sql[0], 'CREATE TABLE sometable (id INTEGER UNIQUE, name VARCHAR2(4), PRIMARY KEY(id))');
         $this->assertEqual($sql[4], 'CREATE INDEX myindex ON sometable (id, name)');
-        
+
         $fields = array('id'       => array('type' => 'integer', 'unisgned' => 1, 'autoincrement' => true),
                         'name'     => array('type' => 'string', 'length' => 4),
                         'category' => array('type' => 'integer', 'length' => 2),
@@ -181,18 +181,18 @@ class Doctrine_Export_Oracle_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($sql[0], 'CREATE TABLE sometable (id INTEGER, name VARCHAR2(4), category NUMBER(5), PRIMARY KEY(id), CONSTRAINT unique_index UNIQUE (id, name))');
         $this->assertEqual($sql[4], 'CREATE INDEX category_index ON sometable (category)');
     }
-    
+
     public function testIdentifierQuoting()
     {
         $this->conn->setAttribute(Doctrine_Core::ATTR_QUOTE_IDENTIFIER, true);
-        
+
         $fields = array('id'   => array('type' => 'integer', 'unsigned' => 1, 'autoincrement' => true),
                         'name' => array('type' => 'string', 'length' => 4),
                         );
         $options = array('primary' => array('id'),
                          'indexes' => array('myindex' => array('fields' => array('id', 'name')))
                          );
-                         
+
         $sql = $this->export->createTableSql('sometable', $fields, $options);
         $this->assertEqual($sql[0], 'CREATE TABLE "sometable" ("id" INTEGER, "name" VARCHAR2(4), PRIMARY KEY("id"))');
         $this->assertEqual($sql[1], 'DECLARE
@@ -225,11 +225,11 @@ BEGIN
    END IF;
 END;');
         $this->assertEqual($sql[4], 'CREATE INDEX "myindex" ON "sometable" ("id", "name")');
-        
+
         // test dropping sequence
         $sql = $this->export->dropSequenceSql('sometable');
         $this->assertEqual($sql, 'DROP SEQUENCE "sometable_seq"');
-        
+
         $this->conn->setAttribute(Doctrine_Core::ATTR_QUOTE_IDENTIFIER, false);
     }
 }

--- a/tests/Export/PgsqlTestCase.php
+++ b/tests/Export/PgsqlTestCase.php
@@ -46,10 +46,10 @@ class Doctrine_Export_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsAutoincPks()
     {
         $name = 'mytable';
-        
+
         $fields  = array('id' => array('type' => 'integer', 'unsigned' => 1, 'autoincrement' => true));
         $options = array('primary' => array('id'));
-        
+
         $this->export->createTable($name, $fields, $options);
 
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (id SERIAL, PRIMARY KEY(id))');
@@ -108,7 +108,7 @@ class Doctrine_Export_Pgsql_TestCase extends Doctrine_UnitTestCase
                          'is_active' => array('type' => 'boolean', 'default' => '0'),
                          'is_admin'  => array('type' => 'boolean', 'default' => 'true'),
                          );
-                         
+
         $options = array('primary' => array('name', 'type'));
         $this->export->createTable($name, $fields, $options);
 
@@ -119,10 +119,10 @@ class Doctrine_Export_Pgsql_TestCase extends Doctrine_UnitTestCase
         $name   = 'mytable';
         $fields = array('name'  => array('type' => 'char', 'length' => 10),
                          'type' => array('type' => 'integer', 'length' => 3));
-                         
+
         $options = array('primary' => array('name', 'type'));
         $this->export->createTable($name, $fields, $options);
-        
+
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (name CHAR(10), type INT, PRIMARY KEY(name, type))');
     }
     public function testExportSql()
@@ -162,7 +162,7 @@ class Doctrine_Export_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testAlterTableSqlIdentifierQuoting()
     {
         $this->conn->setAttribute(Doctrine_Core::ATTR_QUOTE_IDENTIFIER, true);
-        
+
         $changes = array(
             'add'    => array('newfield' => array('type' => 'int')),
             'remove' => array('oldfield' => array())

--- a/tests/Export/SchemaTestCase.php
+++ b/tests/Export/SchemaTestCase.php
@@ -52,7 +52,7 @@ class Doctrine_Export_Schema_TestCase extends Doctrine_UnitTestCase
                       'Assignment',
                       'ResourceType',
                       'ResourceReference');
-    
+
     public function testYmlExport()
     {
         $export = new Doctrine_Export_Schema();

--- a/tests/Export/SqliteTestCase.php
+++ b/tests/Export/SqliteTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
     public function testCreateDatabaseDoesNotExecuteSqlAndCreatesSqliteFile()
     {
         $this->export->createDatabase('sqlite.db');
-      
+
         $this->assertTrue(file_exists('sqlite.db'));
     }
     public function testDropDatabaseDoesNotExecuteSqlAndDeletesSqliteFile()
@@ -47,7 +47,7 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
     public function testCreateTableSupportsAutoincPks()
     {
         $name = 'mytable';
-        
+
         $fields = array('id' => array('type' => 'integer', 'unsigned' => 1, 'autoincrement' => true));
 
         $this->export->createTable($name, $fields);
@@ -71,10 +71,10 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
         $name   = 'mytable';
         $fields = array('name'  => array('type' => 'char', 'length' => 10),
                          'type' => array('type' => 'integer', 'length' => 3));
-                         
+
         $options = array('primary' => array('name', 'type'));
         $this->export->createTable($name, $fields, $options);
-        
+
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE mytable (name CHAR(10), type INTEGER, PRIMARY KEY(name, type))');
     }
     public function testCreateTableSupportsIndexes()
@@ -128,10 +128,10 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
         $name   = 'mytable';
         $fields = array('name'  => array('type' => 'char', 'length' => 10),
                          'type' => array('type' => 'integer', 'length' => 3));
-                         
+
         $options = array('primary' => array('name', 'type'));
         $this->export->createTable($name, $fields, $options);
-        
+
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE "mytable" ("name" CHAR(10), "type" INTEGER, PRIMARY KEY("name", "type"))');
 
         $this->conn->setAttribute(Doctrine_Core::ATTR_QUOTE_IDENTIFIER, false);
@@ -164,7 +164,7 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
                          );
 
         $this->export->createTable('sometable', $fields, $options);
-        
+
         //removed this assertion and inserted the two below
 //        $this->assertEqual($this->adapter->pop(), 'CREATE TABLE sometable (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(4), INDEX myindex (id ASC, name DESC))');
 

--- a/tests/ExportTestCase.php
+++ b/tests/ExportTestCase.php
@@ -61,20 +61,20 @@ class Doctrine_Export_TestCase extends Doctrine_UnitTestCase
     public function testCreateIndexExecutesSql()
     {
         $this->export->createIndex('sometable', 'relevancy', array('fields' => array('title' => array(), 'content' => array())));
-        
+
         $this->assertEqual($this->adapter->pop(), 'CREATE INDEX relevancy_idx ON sometable (title, content)');
     }
 
     public function testDropIndexExecutesSql()
     {
         $this->export->dropIndex('sometable', 'relevancy');
-        
+
         $this->assertEqual($this->adapter->pop(), 'DROP INDEX relevancy_idx');
     }
     public function testDropTableExecutesSql()
     {
         $this->export->dropTable('sometable');
-        
+
         $this->assertEqual($this->adapter->pop(), 'DROP TABLE sometable');
     }
     public function testRecordIsExportedProperly()

--- a/tests/ForeignKeyTestCase.php
+++ b/tests/ForeignKeyTestCase.php
@@ -38,15 +38,15 @@ class Doctrine_ForeignKey_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
     }
-    
+
 
     public function testExportingForeignKeysSupportsAssociationTables()
     {
         $this->dbh  = new Doctrine_Adapter_Mock('mysql');
         $this->conn = $this->manager->openConnection($this->dbh);
-        
+
         $sql = $this->conn->export->exportClassesSql(array('ClientModel', 'ClientToAddressModel', 'AddressModel'));
-        
+
         $this->assertEqual($sql, array(
                                         0 => 'CREATE TABLE clients_to_addresses (client_id BIGINT, address_id BIGINT, INDEX client_id_idx (client_id), INDEX address_id_idx (address_id), PRIMARY KEY(client_id, address_id)) ENGINE = INNODB',
                                         1 => 'CREATE TABLE clients (id INT UNSIGNED NOT NULL AUTO_INCREMENT, short_name VARCHAR(32) NOT NULL UNIQUE, PRIMARY KEY(id)) ENGINE = INNODB',

--- a/tests/HookTestCase.php
+++ b/tests/HookTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Hook_TestCase extends Doctrine_UnitTestCase
     public function testWordLikeParserSupportsHyphens()
     {
         $parser = new Doctrine_Hook_WordLike();
-        
+
         $parser->parse('u', 'name', "'some guy' OR zYne");
 
         $this->assertEqual($parser->getCondition(), '(u.name LIKE ? OR u.name LIKE ?)');

--- a/tests/Hydrate/CollectionInitializationTestCase.php
+++ b/tests/Hydrate/CollectionInitializationTestCase.php
@@ -36,31 +36,31 @@ class Doctrine_Hydrate_CollectionInitialization_TestCase extends Doctrine_UnitTe
     {
         $user       = new User();
         $user->name = 'romanb';
-        
+
         $user->Phonenumber[0]->phonenumber = '112';
         $user->Phonenumber[1]->phonenumber = '110';
-        
+
         $user->save();
     }
-    
+
     public function prepareTables()
     {
         $this->tables = array('Entity', 'Phonenumber');
         parent::prepareTables();
     }
-    
+
     public function testCollectionsAreReinitializedOnHydration()
     {
         // query for user with first phonenumber.
         $q = Doctrine_Query::create();
         $q->select('u.*, p.*')->from('User u')->innerJoin('u.Phonenumber p')
                 ->where("p.phonenumber = '112'");
-        
+
         $users = $q->execute();
         $this->assertEqual(1, count($users));
         $this->assertEqual(1, count($users[0]->Phonenumber));
         $this->assertEqual('112', $users[0]->Phonenumber[0]->phonenumber);
-        
+
         // now query again. this time for the other phonenumber. collection should be re-initialized.
         $q = Doctrine_Query::create();
         $q->select('u.*, p.*')->from('User u')->innerJoin('u.Phonenumber p')

--- a/tests/Hydrate/ScalarTestCase.php
+++ b/tests/Hydrate/ScalarTestCase.php
@@ -40,22 +40,22 @@ class Doctrine_Hydrate_Scalar_TestCase extends Doctrine_UnitTestCase
         $user->Phonenumber[1]->phonenumber = '110';
         $user->save();
     }
-    
+
     public function prepareTables()
     {
         $this->tables = array('Entity', 'Phonenumber');
         parent::prepareTables();
     }
-    
+
     public function testHydrateScalarWithJoin()
     {
         $q = Doctrine_Query::create();
         $q->select('u.*, p.*')
             ->from('User u')
             ->innerJoin('u.Phonenumber p');
-        
+
         $res = $q->execute(array(), Doctrine_Core::HYDRATE_SCALAR);
-        
+
         $this->assertTrue(is_array($res));
         $this->assertEqual(2, count($res));
         //row1
@@ -82,17 +82,17 @@ class Doctrine_Hydrate_Scalar_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(2, $res[1]['p_id']);
         $this->assertEqual(110, $res[1]['p_phonenumber']);
         $this->assertEqual(1, $res[1]['p_entity_id']);
-        
+
         $q->free();
     }
-    
+
     public function testHydrateScalar()
     {
         $q = Doctrine_Query::create();
         $q->select('u.*')->from('User u');
-        
+
         $res = $q->execute(array(), Doctrine_Core::HYDRATE_SCALAR);
-        
+
         $this->assertTrue(is_array($res));
         $this->assertEqual(1, count($res));
         //row1
@@ -104,10 +104,10 @@ class Doctrine_Hydrate_Scalar_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(null, $res[0]['u_created']);
         $this->assertEqual(null, $res[0]['u_updated']);
         $this->assertEqual(null, $res[0]['u_email_id']);
-        
+
         $q->free();
     }
-    
+
     public function testHydrateSingleScalarDoesNotAddPKToSelect()
     {
         $q = Doctrine_Query::create();
@@ -116,7 +116,7 @@ class Doctrine_Hydrate_Scalar_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual('romanb', $res);
         $q->free();
     }
-    
+
     public function testHydrateSingleScalarWithAggregate()
     {
         $q = Doctrine_Query::create();
@@ -125,19 +125,19 @@ class Doctrine_Hydrate_Scalar_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(1, $res);
         $q->free();
     }
-    
+
     public function testHydrateScalarWithJoinAndAggregate()
     {
         $q = Doctrine_Query::create();
         $q->select('u.id, UPPER(u.name) nameUpper, p.*')
             ->from('User u')
             ->innerJoin('u.Phonenumber p');
-        
+
         $res = $q->execute(array(), Doctrine_Core::HYDRATE_SCALAR);
-        
+
         $this->assertTrue(is_array($res));
         $this->assertEqual(2, count($res));
-        
+
         //row1
         $this->assertEqual(1, $res[0]['u_id']);
         $this->assertEqual('ROMANB', $res[0]['u_nameUpper']);
@@ -150,7 +150,7 @@ class Doctrine_Hydrate_Scalar_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(2, $res[1]['p_id']);
         $this->assertEqual(110, $res[1]['p_phonenumber']);
         $this->assertEqual(1, $res[1]['p_entity_id']);
-        
+
         $q->free();
     }
 

--- a/tests/HydrateTestCase.php
+++ b/tests/HydrateTestCase.php
@@ -81,7 +81,7 @@ class HydrationListener extends Doctrine_Record_Listener
     {
         $data             = $event->data;
         $data['password'] = 'default pass';
-        
+
         $event->data = $data;
     }
     public function postHydrate(Doctrine_Event $event)
@@ -100,7 +100,7 @@ class Doctrine_Hydrate_Mock extends Doctrine_Hydrator_Abstract
     {
         $this->data = $data;
     }
-    
+
     public function hydrateResultSet($stmt)
     {
         return true;

--- a/tests/I18nTestCase.php
+++ b/tests/I18nTestCase.php
@@ -46,7 +46,7 @@ class Doctrine_I18n_TestCase extends Doctrine_UnitTestCase
     public function testTranslationTableGetsExported()
     {
         $this->conn->setAttribute(Doctrine_Core::ATTR_EXPORT, Doctrine_Core::EXPORT_ALL);
-        
+
         $this->assertTrue(Doctrine_Core::EXPORT_ALL & Doctrine_Core::EXPORT_TABLES);
         $this->assertTrue(Doctrine_Core::EXPORT_ALL & Doctrine_Core::EXPORT_CONSTRAINTS);
         $this->assertTrue(Doctrine_Core::EXPORT_ALL & Doctrine_Core::EXPORT_PLUGINS);
@@ -61,7 +61,7 @@ class Doctrine_I18n_TestCase extends Doctrine_UnitTestCase
     public function testTranslatedColumnsAreRemovedFromMainComponent()
     {
         $i = new I18nTest();
-        
+
         $columns = $i->getTable()->getColumns();
 
         $this->assertFalse(isset($columns['title']));
@@ -124,13 +124,13 @@ class Doctrine_I18n_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($i['Translation']['FI']['title'], 'joku otsikko');
         $this->assertEqual($i['Translation']['FI']['lang'], 'FI');
     }
-    
+
     public function testIndexByLangIsAttachedToNewlyCreatedCollections()
     {
         $coll = new Doctrine_Collection('I18nTestTranslation');
 
         $coll['EN']['name'] = 'some name';
-        
+
         $this->assertEqual($coll['EN']->lang, 'EN');
     }
 

--- a/tests/Import/BuilderTestCase.php
+++ b/tests/Import/BuilderTestCase.php
@@ -55,10 +55,10 @@ class Doctrine_Import_Builder_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($schemaTestInheritanceParent->isSubClassOf('PackageSchemaTestInheritanceParent'));
         $this->assertTrue($schemaTestInheritanceChild1->isSubClassOf('BaseSchemaTestInheritanceChild1'));
         $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('BaseSchemaTestInheritanceChild2'));
-        
+
         $this->assertTrue($schemaTestInheritanceChild1->isSubClassOf('SchemaTestInheritanceParent'));
         $this->assertTrue($schemaTestInheritanceChild1->isSubClassOf('BaseSchemaTestInheritanceParent'));
-        
+
         $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('SchemaTestInheritanceParent'));
         $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('BaseSchemaTestInheritanceParent'));
         $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('SchemaTestInheritanceChild1'));

--- a/tests/Import/MssqlTestCase.php
+++ b/tests/Import/MssqlTestCase.php
@@ -35,38 +35,38 @@ class Doctrine_Import_Mssql_TestCase extends Doctrine_UnitTestCase
     public function testListSequencesExecutesSql()
     {
         $this->import->listSequences('table');
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT name FROM sysobjects WHERE xtype = 'U'");
     }
     public function testListTableColumnsExecutesSql()
     {
         $this->conn->setAttribute(Doctrine_Core::ATTR_QUOTE_IDENTIFIER, false);
         $this->import->listTableColumns('table');
-        
+
         $this->assertEqual($this->adapter->pop(), 'EXEC sp_columns @table_name = table');
     }
     public function testListTablesExecutesSql()
     {
         $this->import->listTables();
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT name FROM sysobjects WHERE type = 'U' AND name <> 'dtproperties' AND name <> 'sysdiagrams' ORDER BY name");
     }
     public function testListTriggersExecutesSql()
     {
         $this->import->listTriggers();
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT name FROM sysobjects WHERE xtype = 'TR'");
     }
     public function testListTableTriggersExecutesSql()
     {
         $this->import->listTableTriggers('table');
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT name FROM sysobjects WHERE xtype = 'TR' AND object_name(parent_obj) = 'table'");
     }
     public function testListViewsExecutesSql()
     {
         $this->import->listViews();
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT name FROM sysobjects WHERE xtype = 'V'");
     }
 }

--- a/tests/Import/OracleTestCase.php
+++ b/tests/Import/OracleTestCase.php
@@ -37,7 +37,7 @@ class Doctrine_Import_Oracle_TestCase extends Doctrine_UnitTestCase
         $this->conn->setAttribute(Doctrine_Core::ATTR_EMULATE_DATABASE, true);
 
         $this->import->listSequences('table');
-        
+
         $this->assertEqual($this->adapter->pop(), 'SELECT sequence_name FROM sys.user_sequences');
     }
     public function testListTableColumnsExecutesSql()
@@ -70,42 +70,42 @@ WHERE tc.table_name = :tableName ORDER BY column_id";
     public function testListTablesExecutesSql()
     {
         $this->import->listTables();
-        
+
         $q = "SELECT * FROM user_objects WHERE object_type = 'TABLE' and object_name in (select table_name from user_tables)";
         $this->assertEqual($this->adapter->pop(), $q);
     }
     public function testListDatabasesExecutesSql()
     {
         $this->import->listDatabases();
-        
+
         $q = 'SELECT username FROM sys.user_users';
         $this->assertEqual($this->adapter->pop(), $q);
     }
     public function testListUsersExecutesSql()
     {
         $this->import->listUsers();
-        
+
         $q = 'SELECT username FROM sys.all_users';
         $this->assertEqual($this->adapter->pop(), $q);
     }
     public function testListViewsExecutesSql()
     {
         $this->import->listViews();
-        
+
         $q = 'SELECT view_name FROM sys.user_views';
         $this->assertEqual($this->adapter->pop(), $q);
     }
     public function testListFunctionsExecutesSql()
     {
         $this->import->listFunctions();
-        
+
         $q = "SELECT name FROM sys.user_source WHERE line = 1 AND type = 'FUNCTION'";
         $this->assertEqual($this->adapter->pop(), $q);
     }
     public function testListTableConstraintsExecutesSql()
     {
         $this->import->listTableConstraints('table');
-        
+
         $q = 'SELECT index_name name FROM user_constraints'
            . " WHERE table_name = 'table' OR table_name = 'TABLE'";
 

--- a/tests/Import/PgsqlTestCase.php
+++ b/tests/Import/PgsqlTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Import_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testListSequencesExecutesSql()
     {
         $this->import->listSequences('table');
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT
                                                 regexp_replace(relname, '_seq$', '')
                                             FROM
@@ -47,7 +47,7 @@ class Doctrine_Import_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testListTableColumnsExecutesSql()
     {
         $this->import->listTableColumns('table');
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT
                                                      ordinal_position as attnum,
                                                      column_name as field,
@@ -71,7 +71,7 @@ class Doctrine_Import_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testListTableIndexesExecutesSql()
     {
         $this->import->listTableIndexes('table');
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT
                                                         relname
                                                    FROM
@@ -88,7 +88,7 @@ class Doctrine_Import_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testListTablesExecutesSql()
     {
         $this->import->listTables();
-        
+
         $q = "SELECT
                                                 c.relname AS table_name
                                             FROM pg_class c, pg_user u
@@ -108,28 +108,28 @@ class Doctrine_Import_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testListDatabasesExecutesSql()
     {
         $this->import->listDatabases();
-        
+
         $q = 'SELECT datname FROM pg_database';
         $this->assertEqual($this->adapter->pop(), $q);
     }
     public function testListUsersExecutesSql()
     {
         $this->import->listUsers();
-        
+
         $q = 'SELECT usename FROM pg_user';
         $this->assertEqual($this->adapter->pop(), $q);
     }
     public function testListViewsExecutesSql()
     {
         $this->import->listViews();
-        
+
         $q = 'SELECT viewname FROM pg_views';
         $this->assertEqual($this->adapter->pop(), $q);
     }
     public function testListFunctionsExecutesSql()
     {
         $this->import->listFunctions();
-        
+
         $q = "SELECT
                                                 proname
                                             FROM

--- a/tests/Import/PluginHierarchyTestCase.php
+++ b/tests/Import/PluginHierarchyTestCase.php
@@ -52,7 +52,7 @@ WikiTest:
     title: string(255)
     content: string
 END;
-        
+
         file_put_contents('wiki.yml', $yml);
         $path = dirname(__FILE__) . '/tmp/import_builder_test';
 
@@ -74,11 +74,11 @@ END;
             3 => 'CREATE TABLE wiki_test (id INTEGER PRIMARY KEY AUTOINCREMENT)',
             4 => 'CREATE UNIQUE INDEX wiki_test_translation_sluggable_idx ON wiki_test_translation (slug)',
         );
-            
+
         foreach ($sql as $idx => $req) {
             $this->assertEqual($req, $result[$idx]);
         }
-        
+
         Doctrine_Lib::removeDirectories($path);
         unlink('wiki.yml');
     }

--- a/tests/Import/SchemaTestCase.php
+++ b/tests/Import/SchemaTestCase.php
@@ -34,18 +34,18 @@ class Doctrine_Import_Schema_TestCase extends Doctrine_UnitTestCase
 {
     public $buildSchema;
     public $schema;
-    
+
     public function testYmlImport()
     {
         $path = dirname(__FILE__) . '/import_builder_test';
-        
+
         $import = new Doctrine_Import_Schema();
         $import->importSchema('schema.yml', 'yml', $path);
-        
+
         if (! file_exists($path . '/SchemaTestUser.php')) {
             $this->fail();
         }
-        
+
         if (! file_exists($path . '/SchemaTestProfile.php')) {
             $this->fail();
         }
@@ -54,12 +54,12 @@ class Doctrine_Import_Schema_TestCase extends Doctrine_UnitTestCase
 
         Doctrine_Lib::removeDirectories($path);
     }
-    
+
     public function testBuildSchema()
     {
         $schema = new Doctrine_Import_Schema();
         $array  = $schema->buildSchema('schema.yml', 'yml');
-        
+
         $model = $array['SchemaTestUser'];
 
         $this->assertTrue(array_key_exists('connection', $model));
@@ -77,32 +77,32 @@ class Doctrine_Import_Schema_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue(array_key_exists('detect_relations', $model) && is_bool($model['detect_relations']));
         $this->assertEqual($array['AliasTest']['columns']['test_col']['name'], 'test_col as test_col_alias');
     }
-    
+
     public function testSchemaRelationshipCompletion()
     {
         $this->buildSchema = new Doctrine_Import_Schema();
         $this->schema      = $this->buildSchema->buildSchema('schema.yml', 'yml');
-        
+
         foreach ($this->schema as $name => $properties) {
             foreach ($properties['relations'] as $alias => $relation) {
                 if (! $this->_verifyMultiDirectionalRelationship($name, $alias, $relation)) {
                     $this->fail();
-                    
+
                     return false;
                 }
             }
         }
-        
+
         $this->pass();
     }
-    
+
     protected function _verifyMultiDirectionalRelationship($class, $relationAlias, $relation)
     {
         $foreignClass = $relation['class'];
         $foreignAlias = isset($relation['foreignAlias']) ? $relation['foreignAlias']:$class;
-        
+
         $foreignClassRelations = $this->schema[$foreignClass]['relations'];
-        
+
         // Check to see if the foreign class has the opposite end defined for the class/foreignAlias
         if (isset($foreignClassRelations[$foreignAlias])) {
             return true;

--- a/tests/Import/SqliteTestCase.php
+++ b/tests/Import/SqliteTestCase.php
@@ -35,25 +35,25 @@ class Doctrine_Import_Sqlite_TestCase extends Doctrine_UnitTestCase
     public function testListSequencesExecutesSql()
     {
         $this->import->listSequences('table');
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT name FROM sqlite_master WHERE type='table' AND sql NOT NULL ORDER BY name");
     }
     public function testListTableColumnsExecutesSql()
     {
         $this->import->listTableColumns('table');
-        
+
         $this->assertEqual($this->adapter->pop(), 'PRAGMA table_info(table)');
     }
     public function testListTableIndexesExecutesSql()
     {
         $this->import->listTableIndexes('table');
-        
+
         $this->assertEqual($this->adapter->pop(), 'PRAGMA index_list(table)');
     }
     public function testListTablesExecutesSql()
     {
         $this->import->listTables();
-        
+
         $q = "SELECT name FROM sqlite_master WHERE type = 'table' AND name != 'sqlite_sequence' UNION ALL SELECT name FROM sqlite_temp_master WHERE type = 'table' ORDER BY name";
 
         $this->assertEqual($this->adapter->pop(), $q);

--- a/tests/IntegrityActionTestCase.php
+++ b/tests/IntegrityActionTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_IntegrityAction_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('CascadeDeleteTest', 'CascadeDeleteRelatedTest', 'CascadeDeleteRelatedTest2');
-        
+
         parent::prepareTables();
     }
     public function testIntegrityActionsAreAddedIntoGlobalActionsArray()
@@ -48,7 +48,7 @@ class Doctrine_IntegrityAction_TestCase extends Doctrine_UnitTestCase
 
         $expected = array('CascadeDeleteRelatedTest' => 'CASCADE');
         $this->assertEqual($this->manager->getDeleteActions('CascadeDeleteTest'), $expected);
-        
+
         $expected = array('CascadeDeleteRelatedTest' => 'SET NULL');
         $this->assertEqual($this->manager->getUpdateActions('CascadeDeleteTest'), $expected);
     }
@@ -60,13 +60,13 @@ class Doctrine_IntegrityAction_TestCase extends Doctrine_UnitTestCase
         $c->Related[]->name             = 'r 2';
         $c->Related[0]->Related[]->name = 'r r 1';
         $c->Related[1]->Related[]->name = 'r r 2';
-        
+
         $c->save();
-        
+
         $this->connection->clear();
-        
+
         $c = $this->conn->queryOne('FROM CascadeDeleteTest c WHERE c.id = 1');
-        
+
         $c->delete();
     }
 }

--- a/tests/ManagerTestCase.php
+++ b/tests/ManagerTestCase.php
@@ -69,9 +69,9 @@ class Doctrine_Manager_TestCase extends Doctrine_UnitTestCase
         $sqlite           = 'sqlite:////full/unix/path/to/file.db';
         $sqlitewin        = 'sqlite:///c:/full/windows/path/to/file.db';
         $sqlitewin2       = 'sqlite:///D:\full\windows\path\to\file.db';
-        
+
         $manager = Doctrine_Manager::getInstance();
-        
+
         try {
             $res              = $manager->parseDsn($mysql);
             $expectedMysqlDsn = array(
@@ -107,7 +107,7 @@ class Doctrine_Manager_TestCase extends Doctrine_UnitTestCase
         } catch (Exception $e) {
             $this->fail($e->getMessage());
         }
-        
+
         try {
             $expectedDsn = array(
                 'scheme'   => 'sqlite',
@@ -120,13 +120,13 @@ class Doctrine_Manager_TestCase extends Doctrine_UnitTestCase
                 'query'    => null,
                 'fragment' => null,
                 'database' => '/full/unix/path/to/file.db');
-              
+
             $res = $manager->parseDsn($sqlite);
             $this->assertEqual($expectedDsn, $res);
         } catch (Exception $e) {
             $this->fail($e->getMessage());
         }
-        
+
         try {
             $expectedDsn = array(
                 'scheme'   => 'sqlite',
@@ -163,30 +163,30 @@ class Doctrine_Manager_TestCase extends Doctrine_UnitTestCase
             $this->fail($e->getMessage());
         }
     }
-    
+
     public function testCreateDatabases()
     {
         // We need to know if we're under Windows or *NIX
         $OS = strtoupper(substr(PHP_OS, 0, 3));
 
         $tmp_dir = ($OS == 'WIN') ? str_replace('\\', '/', sys_get_temp_dir()) : '/tmp';
-       
+
         $this->conn1_database = $tmp_dir . '/doctrine1.db';
         $this->conn2_database = $tmp_dir . '/doctrine2.db';
 
         $this->conn1 = Doctrine_Manager::connection('sqlite:///' . $this->conn1_database, 'doctrine1');
         $this->conn2 = Doctrine_Manager::connection('sqlite:///' . $this->conn2_database, 'doctrine2');
-        
+
         $result1 = $this->conn1->createDatabase();
         $result2 = $this->conn2->createDatabase();
     }
-    
+
     public function testDropDatabases()
     {
         $result1 = $this->conn1->dropDatabase();
         $result2 = $this->conn2->dropDatabase();
     }
-    
+
     public function testConnectionInformationDecoded()
     {
         $dsn = 'mysql://' . urlencode('test/t') . ':' . urlencode('p@ssword') . '@localhost/' . urlencode('db/name');

--- a/tests/Migration/DiffTestCase.php
+++ b/tests/Migration/DiffTestCase.php
@@ -60,7 +60,7 @@ class Doctrine_Migration_Diff_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(count($files), 2);
         $this->assertTrue(strpos($files[0], '_version1.php'));
         $this->assertTrue(strpos($files[1], '_version2.php'));
-        
+
         $code1 = file_get_contents($files[0]);
         $this->assertTrue(strpos($code1, 'this->dropTable'));
         $this->assertTrue(strpos($code1, 'this->createTable'));

--- a/tests/NestedSet/HydrationTestCase.php
+++ b/tests/NestedSet/HydrationTestCase.php
@@ -44,11 +44,11 @@ class Doctrine_NestedSet_Hydration_TestCase extends Doctrine_UnitTestCase
         $node->name = 'root';
         $treeMngr   = $this->conn->getTable('NestedSetTest_SingleRootNode')->getTree();
         $treeMngr->createRoot($node);
-        
+
         $node2       = new NestedSetTest_SingleRootNode();
         $node2->name = 'node2';
         $node2->getNode()->insertAsLastChildOf($node);
-        
+
         $node3       = new NestedSetTest_SingleRootNode();
         $node3->name = 'node3';
         $node3->getNode()->insertAsLastChildOf($node2);

--- a/tests/NestedSet/MultiRootTestCase.php
+++ b/tests/NestedSet/MultiRootTestCase.php
@@ -41,7 +41,7 @@ class Doctrine_NestedSet_MultiRoot_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function testSavingNewRecordAsRootWithoutRootIdThrowsException()
     {
         $node       = new NestedSet_MultiRootNode();
@@ -54,7 +54,7 @@ class Doctrine_NestedSet_MultiRoot_TestCase extends Doctrine_UnitTestCase
             $this->pass();
         }
     }
-    
+
     public function testSavingNewRecordWithRootIdWorks()
     {
         $node          = new NestedSet_MultiRootNode();
@@ -70,7 +70,7 @@ class Doctrine_NestedSet_MultiRoot_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
     }
-    
+
     public function testSavingPersistentRecordAsRootAssignsIdToRootId()
     {
         $node       = new NestedSet_MultiRootNode();
@@ -87,7 +87,7 @@ class Doctrine_NestedSet_MultiRoot_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
     }
-    
+
     public function testSaveMultipleRootsWithChildren()
     {
         $root1       = new NestedSet_MultiRootNode();
@@ -102,7 +102,7 @@ class Doctrine_NestedSet_MultiRoot_TestCase extends Doctrine_UnitTestCase
         } catch (Doctrine_Tree_Exception $e) {
             $this->fail();
         }
-        
+
         $root2       = new NestedSet_MultiRootNode();
         $root2->name = 'root';
         $root2->save();
@@ -115,12 +115,12 @@ class Doctrine_NestedSet_MultiRoot_TestCase extends Doctrine_UnitTestCase
         } catch (Doctrine_Tree_Exception $e) {
             $this->fail();
         }
-        
+
         // now a child for root1
         $child1       = new NestedSet_MultiRootNode();
         $child1->name = 'child1';
         $child1->getNode()->insertAsLastChildOf($root1);
-        
+
         $root1->refresh(); // ! updates lft/rgt
         // test insertion
         $this->assertEqual(2, $child1->lft);
@@ -130,12 +130,12 @@ class Doctrine_NestedSet_MultiRoot_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(1, $root1->lft);
         $this->assertEqual(4, $root1->rgt);
         $this->assertEqual(0, $root1->level);
-        
+
         // now a child for root2
         $child2       = new NestedSet_MultiRootNode();
         $child2->name = 'child2';
         $child2->getNode()->insertAsLastChildOf($root2);
-        
+
         $root2->refresh(); // ! updates lft/rgt
         // test insertion
         $this->assertEqual(2, $child2->lft);
@@ -145,7 +145,7 @@ class Doctrine_NestedSet_MultiRoot_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(1, $root2->lft);
         $this->assertEqual(4, $root2->rgt);
         $this->assertEqual(0, $root2->level);
-        
+
         // query some
         $root1Id = $root1->id;
         $root2Id = $root2->id;

--- a/tests/NestedSet/SingleRootTestCase.php
+++ b/tests/NestedSet/SingleRootTestCase.php
@@ -44,16 +44,16 @@ class Doctrine_NestedSet_SingleRoot_TestCase extends Doctrine_UnitTestCase
         $node->name = 'root';
         $treeMngr   = $this->conn->getTable('NestedSetTest_SingleRootNode')->getTree();
         $treeMngr->createRoot($node);
-        
+
         $node2       = new NestedSetTest_SingleRootNode();
         $node2->name = 'node2';
         $node2->getNode()->insertAsLastChildOf($node);
-        
+
         $node3       = new NestedSetTest_SingleRootNode();
         $node3->name = 'node3';
         $node3->getNode()->insertAsLastChildOf($node2);
     }
-    
+
     public function testLftRgtValues()
     {
         $treeMngr = $this->conn->getTable('NestedSetTest_SingleRootNode')->getTree();
@@ -80,7 +80,7 @@ class Doctrine_NestedSet_SingleRoot_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(1, $root->getNode()->getNumberChildren());
         $this->assertFalse($root->getNode()->hasParent());
     }
-    
+
     public function testGetAncestors()
     {
         $node = $this->conn->query(

--- a/tests/NestedSet/TimestampableMultiRootTestCase.php
+++ b/tests/NestedSet/TimestampableMultiRootTestCase.php
@@ -41,8 +41,8 @@ class Doctrine_NestedSet_TimestampableMultiRoot_TestCase extends Doctrine_UnitTe
     public function prepareData()
     {
     }
-    
-    
+
+
     public function testSavingNewRecordWithRootIdWorks()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, true);
@@ -64,7 +64,7 @@ class Doctrine_NestedSet_TimestampableMultiRoot_TestCase extends Doctrine_UnitTe
         $this->assertNotEqual(null, $node['updated_at']);
         $child1->name = 'child1';
         $child1->getNode()->insertAsLastChildOf($node);
-        
+
         $node->refresh(); // ! updates lft/rgt
         // test insertion
         $this->assertEqual(2, $child1->lft);
@@ -74,7 +74,7 @@ class Doctrine_NestedSet_TimestampableMultiRoot_TestCase extends Doctrine_UnitTe
         $this->assertEqual(1, $node->lft);
         $this->assertEqual(4, $node->rgt);
         $this->assertEqual(0, $node->level);
-            
+
         $node->getNode()->delete();
         //} catch (Exception $e) {
         //    $this->fail();

--- a/tests/NewCoreTestCase.php
+++ b/tests/NewCoreTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_NewCore_TestCase extends Doctrine_UnitTestCase
     public function testFromParser()
     {
         $q = new Doctrine_Query();
-        
+
         $q->load('User u', true);
 
         $this->assertEqual($q->getSqlQueryPart('from'), array('entity e'));

--- a/tests/ParserTestCase.php
+++ b/tests/ParserTestCase.php
@@ -35,23 +35,23 @@ class Doctrine_Parser_TestCase extends Doctrine_UnitTestCase
     public function testGetParserInstance()
     {
         $instance = Doctrine_Parser::getParser('Yml');
-        
+
         if ($instance instanceof Doctrine_Parser_Yml) {
             $this->pass();
         } else {
             $this->fail();
         }
     }
-    
+
     public function testFacadeLoadAndDump()
     {
         Doctrine_Parser::dump(array('test' => 'good job', 'test2' => true, array('testing' => false)), 'yml', 'test.yml');
         $array = Doctrine_Parser::load('test.yml', 'yml');
-        
+
         $this->assertEqual($array, array('test' => 'good job', 'test2' => true, array('testing' => false)));
         unlink('test.yml');
     }
-    
+
     public function testParserSupportsEmbeddingPhpSyntax()
     {
         $parser = Doctrine_Parser::getParser('Yml');
@@ -62,29 +62,29 @@ testing: <?php echo 'false'.\"\n\"; ?>
 w00t: not now
 ";
         $data = $parser->doLoad($yml);
-        
+
         $array = $parser->loadData($data);
-        
+
         $this->assertEqual($array, array('test' => 'good job', 'test2' => true, 'testing' => false, 'w00t' => 'not now'));
     }
-    
+
     public function testParserWritingToDisk()
     {
         $parser = Doctrine_Parser::getParser('Yml');
         $parser->doDump('test', 'test.yml');
-        
+
         $this->assertEqual('test', file_get_contents('test.yml'));
         unlink('test.yml');
     }
-    
+
     public function testParserReturningLoadedData()
     {
         $parser = Doctrine_Parser::getParser('Yml');
         $result = $parser->doDump('test');
-        
+
         $this->assertEqual('test', $result);
     }
-    
+
     public function testLoadFromString()
     {
         $yml = "---
@@ -95,7 +95,7 @@ w00t: not now
 ";
 
         $array = Doctrine_Parser::load($yml, 'yml');
-        
+
         $this->assertEqual($array, array('test' => 'good job', 'test2' => true, 'testing' => false, 'w00t' => 'not now'));
     }
 }

--- a/tests/PessimisticLockingTestCase.php
+++ b/tests/PessimisticLockingTestCase.php
@@ -42,14 +42,14 @@ class Doctrine_PessimisticLocking_TestCase extends Doctrine_UnitTestCase
     public function testInitData()
     {
         $this->lockingManager = new Doctrine_Locking_Manager_Pessimistic($this->connection);
-        
+
         // Create sample data to test on
         $entry1         = new Forum_Entry();
         $entry1->author = 'Bart Simpson';
         $entry1->topic  = 'I love donuts!';
         $entry1->save();
     }
-    
+
     public function prepareTables()
     {
         $this->tables = array('Forum_Entry', 'Entity', 'Phonenumber', 'Email', 'Groupuser');
@@ -64,15 +64,15 @@ class Doctrine_PessimisticLocking_TestCase extends Doctrine_UnitTestCase
     public function testLock()
     {
         $entries = $this->connection->query("FROM Forum_Entry WHERE Forum_Entry.author = 'Bart Simpson'");
-        
+
         // Test successful lock
         $gotLock = $this->lockingManager->getLock($entries[0], 'romanb');
         $this->assertTrue($gotLock);
-        
+
         // Test failed lock (another user already got a lock on the entry)
         $gotLock = $this->lockingManager->getLock($entries[0], 'konstav');
         $this->assertFalse($gotLock);
-        
+
         // Test release lock
         $released = $this->lockingManager->releaseLock($entries[0], 'romanb');
         $this->assertTrue($released);
@@ -88,18 +88,18 @@ class Doctrine_PessimisticLocking_TestCase extends Doctrine_UnitTestCase
         $this->lockingManager->getLock($entries[0], 'romanb');
         $released = $this->lockingManager->releaseAgedLocks(-1); // age -1 seconds => release all
         $this->assertEqual(1, $released);
-        
+
         // A second call should return false (no locks left)
         $released = $this->lockingManager->releaseAgedLocks(-1);
         $this->assertEqual(0, $released);
-        
+
         // Test with further parameters
         $this->lockingManager->getLock($entries[0], 'romanb');
         $released = $this->lockingManager->releaseAgedLocks(-1, 'User'); // shouldnt release anything
         $this->assertEqual(0, $released);
         $released = $this->lockingManager->releaseAgedLocks(-1, 'Forum_Entry'); // should release the lock
         $this->assertEqual(1, $released);
-        
+
         $this->lockingManager->getLock($entries[0], 'romanb');
         $released = $this->lockingManager->releaseAgedLocks(-1, 'Forum_Entry', 'zyne'); // shouldnt release anything
         $this->assertEqual(0, $released);

--- a/tests/PluginTestCase.php
+++ b/tests/PluginTestCase.php
@@ -70,7 +70,7 @@ class Doctrine_Plugin_TestCase extends Doctrine_UnitTestCase
 
         $fi->title = 'Micheal Jordan';
         $fi->save();
-        
+
         $this->assertEqual($fi->version, 2);
     }
 
@@ -79,7 +79,7 @@ class Doctrine_Plugin_TestCase extends Doctrine_UnitTestCase
         $this->conn->clear();
 
         $wiki = Doctrine_Query::create()->from('Wiki w')->where('w.id = 1')->fetchOne();
-        
+
         $wiki->save();
 
         $this->assertEqual($wiki->Translation['FI']->version, 2);

--- a/tests/Query/AggregateValueTestCase.php
+++ b/tests/Query/AggregateValueTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_Query_AggregateValue_TestCase extends Doctrine_UnitTestCase
     public function testInitData()
     {
         $users = new Doctrine_Collection('User');
-        
+
         $users[0]->name                        = 'John';
         $users[0]->Phonenumber[0]->phonenumber = '123 123';
         $users[0]->Phonenumber[1]->phonenumber = '222 222';
@@ -100,10 +100,10 @@ class Doctrine_Query_AggregateValue_TestCase extends Doctrine_UnitTestCase
         $users = $q->execute();
 
         $this->assertEqual($users->count(), 2);
-        
+
         $this->assertEqual($users[0]->state(), Doctrine_Record::STATE_PROXY);
         $this->assertEqual($users[1]->state(), Doctrine_Record::STATE_PROXY);
-        
+
         $this->assertEqual($users[0]->count, 2);
         $this->assertEqual($users[1]->count, 2);
     }
@@ -117,10 +117,10 @@ class Doctrine_Query_AggregateValue_TestCase extends Doctrine_UnitTestCase
         $users = $q->execute();
 
         $this->assertEqual($users->count(), 2);
-        
+
         $this->assertEqual($users[0]->state(), Doctrine_Record::STATE_PROXY);
         $this->assertEqual($users[1]->state(), Doctrine_Record::STATE_PROXY);
-        
+
         $this->assertEqual($users[0]->count, 2);
         $this->assertEqual($users[1]->count, 2);
     }
@@ -163,7 +163,7 @@ class Doctrine_Query_AggregateValue_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($users[0]->max, 3);
         $this->assertEqual($users[0]->count, 3);
     }
-    
+
     public function testAggregateValueMappingSupportsMultipleValues2()
     {
         $q = new Doctrine_Query();
@@ -175,7 +175,7 @@ class Doctrine_Query_AggregateValue_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($users[0]['max'], 3);
         $this->assertEqual($users[0]['count'], 3);
     }
-    
+
     public function testAggregateValueMappingSupportsInnerJoins()
     {
         $q = new Doctrine_Query();

--- a/tests/Query/ApplyInheritanceTestCase.php
+++ b/tests/Query/ApplyInheritanceTestCase.php
@@ -35,22 +35,22 @@ class Doctrine_Query_ApplyInheritance_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function prepareTables()
     {
         $this->tables = array('InheritanceDeal', 'InheritanceEntityUser', 'InheritanceUser');
-        
+
         parent::prepareTables();
     }
-    
+
     public function testApplyInheritance()
     {
         $query = new Doctrine_Query();
         $query->from('InheritanceDeal d, d.Users u');
         $query->where('u.id = 1');
-        
+
         $sql = 'SELECT i.id AS i__id, i.name AS i__name, i2.id AS i2__id, i2.username AS i2__username FROM inheritance_deal i LEFT JOIN inheritance_entity_user i3 ON (i.id = i3.entity_id) AND i3.type = 1 LEFT JOIN inheritance_user i2 ON i2.id = i3.user_id WHERE (i2.id = 1)';
-        
+
         $this->assertEqual($sql, $query->getSqlQuery());
     }
 }

--- a/tests/Query/CacheTestCase.php
+++ b/tests/Query/CacheTestCase.php
@@ -249,7 +249,7 @@ class Doctrine_Query_Cache_TestCase extends Doctrine_UnitTestCase
         $this->assertFalse($cache->contains($q->calculateQueryCacheHash()));
         $this->assertEqual(count($coll), 0);
     }
-    
+
     protected function _getCacheDriver()
     {
         return new Doctrine_Cache_Array();

--- a/tests/Query/CheckTestCase.php
+++ b/tests/Query/CheckTestCase.php
@@ -41,15 +41,15 @@ class Doctrine_Query_Check_TestCase extends Doctrine_UnitTestCase
     public function testCheckParserSupportsStandardFunctions()
     {
         $q = new Doctrine_Query_Check('User');
-        
+
         $q->parse('LENGTH(name) > 6');
-        
+
         $this->assertEqual($q->getSql(), 'LENGTH(name) > 6');
     }
     public function testCheckParserThrowsExceptionForUnknownOperator()
     {
         $q = new Doctrine_Query_Check('User');
-        
+
         try {
             $q->parse('LENGTH(name) ? 6');
             $this->fail();
@@ -60,7 +60,7 @@ class Doctrine_Query_Check_TestCase extends Doctrine_UnitTestCase
     public function testCheckParserThrowsExceptionForUnknownFunction()
     {
         $q = new Doctrine_Query_Check('User');
-        
+
         try {
             $q->parse('SomeUnknownFunction(name) = 6');
             $this->fail();

--- a/tests/Query/ConditionTestCase.php
+++ b/tests/Query/ConditionTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_Query_Condition_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
     }
-    
+
     /** @todo belongs in TokenizerTestCase? */
     public function testBracktExplode()
     {

--- a/tests/Query/CopyTestCase.php
+++ b/tests/Query/CopyTestCase.php
@@ -37,9 +37,9 @@ class Doctrine_Query_Copy_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->from('User u');
-        
+
         $q2 = $q->copy();
-        
+
         $this->assertEqual($q->getSqlQuery(), $q2->getSqlQuery());
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id FROM entity e WHERE (e.type = 0)');

--- a/tests/Query/DeleteTestCase.php
+++ b/tests/Query/DeleteTestCase.php
@@ -50,7 +50,7 @@ class Doctrine_Query_Delete_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->delete()->from('User');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'DELETE FROM entity WHERE (type = 0)');
     }
 
@@ -61,11 +61,11 @@ class Doctrine_Query_Delete_TestCase extends Doctrine_UnitTestCase
         $q->parseDqlQuery('DELETE FROM Entity');
 
         $this->assertEqual($q->getSqlQuery(), 'DELETE FROM entity');
-        
+
         $q = new Doctrine_Query();
 
         $q->delete()->from('Entity');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'DELETE FROM entity');
     }
 
@@ -76,11 +76,11 @@ class Doctrine_Query_Delete_TestCase extends Doctrine_UnitTestCase
         $q->parseDqlQuery('DELETE FROM Entity WHERE id = 3');
 
         $this->assertEqual($q->getSqlQuery(), 'DELETE FROM entity WHERE (id = 3)');
-        
+
         $q = new Doctrine_Query();
 
         $q->delete()->from('Entity')->where('id = 3');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'DELETE FROM entity WHERE (id = 3)');
     }
 
@@ -91,11 +91,11 @@ class Doctrine_Query_Delete_TestCase extends Doctrine_UnitTestCase
         $q->parseDqlQuery('DELETE FROM Entity LIMIT 20');
 
         $this->assertEqual($q->getSqlQuery(), 'DELETE FROM entity LIMIT 20');
-        
+
         $q = new Doctrine_Query();
 
         $q->delete()->from('Entity')->limit(20);
-        
+
         $this->assertEqual($q->getSqlQuery(), 'DELETE FROM entity LIMIT 20');
     }
 
@@ -110,7 +110,7 @@ class Doctrine_Query_Delete_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->delete()->from('Entity')->limit(10)->offset(20);
-        
+
         $this->assertEqual($q->getSqlQuery(), 'DELETE FROM entity LIMIT 10 OFFSET 20');
     }
 

--- a/tests/Query/DriverTestCase.php
+++ b/tests/Query/DriverTestCase.php
@@ -46,7 +46,7 @@ class Doctrine_Query_Driver_TestCase extends Doctrine_UnitTestCase
         $conn = $this->manager->openConnection($this->dbh);
 
         $q = new Doctrine_Query($conn);
-    
+
         $q->from('User u')->limit(5);
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id FROM entity e WHERE (e.type = 0) LIMIT 5');
@@ -59,12 +59,12 @@ class Doctrine_Query_Driver_TestCase extends Doctrine_UnitTestCase
         $conn = $this->manager->openConnection($this->dbh);
 
         $q = new Doctrine_Query($conn);
-    
+
         $q->from('User u')->limit(5);
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id FROM entity e WHERE (e.type = 0) LIMIT 5');
     }
-    
+
     public function testLimitQueriesForMysql()
     {
         $this->dbh = new Doctrine_Adapter_Mock('mysql');
@@ -72,7 +72,7 @@ class Doctrine_Query_Driver_TestCase extends Doctrine_UnitTestCase
         $conn = $this->manager->openConnection($this->dbh);
 
         $q = new Doctrine_Query($conn);
-    
+
         $q->from('User u')->limit(5);
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id FROM entity e WHERE (e.type = 0) LIMIT 5');
@@ -103,14 +103,14 @@ class Doctrine_Query_Driver_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT b.* FROM ( SELECT a.*, ROWNUM AS doctrine_rownum FROM ( SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id FROM entity e WHERE (e.type = 0) ) a  ) b WHERE doctrine_rownum BETWEEN 3 AND 7');
     }
-    
+
     public function testLimitOffsetLimitSubqueriesForOracle()
     {
         $this->dbh = new Doctrine_Adapter_Mock('oracle');
         $conn      = $this->manager->openConnection($this->dbh);
         $q         = new Doctrine_Query($conn);
         $q->from('User u')->innerJoin('u.Phonenumber p')->limit(5)->offset(2);
-        
+
         $correctSql = 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, '
                             . 'e.password AS e__password, e.type AS e__type, e.created AS e__created, '
                             . 'e.updated AS e__updated, e.email_id AS e__email_id, p.id AS p__id, '
@@ -129,10 +129,10 @@ class Doctrine_Query_Driver_TestCase extends Doctrine_UnitTestCase
                         . ' ) b '
                         . 'WHERE doctrine_rownum BETWEEN 3 AND 7'
                     . ') AND (e.type = 0)';
-        
+
         $this->assertEqual($q->getSqlQuery(), $correctSql);
     }
-    
+
     /**
     * Ticket #1038
      */
@@ -169,7 +169,7 @@ class Doctrine_Query_Driver_TestCase extends Doctrine_UnitTestCase
                               . ' ) b '
                               . 'WHERE doctrine_rownum BETWEEN 3 AND 7'
                           . ') AND (e.type = 0) GROUP BY e.name ORDER BY p.id';
-                         
+
         $this->assertEqual($q->getSqlQuery(), $correctSql);
     }
 }

--- a/tests/Query/ExpressionTestCase.php
+++ b/tests/Query/ExpressionTestCase.php
@@ -92,25 +92,25 @@ class Doctrine_Query_Expression_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->parseDqlQuery('SELECT u.id, CONCAT(u.name, u.loginname) FROM User u');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, CONCAT(e.name, e.loginname) AS e__0 FROM entity e WHERE (e.type = 0)');
     }
 
     public function testConcatInSelectClauseSupportsLiteralStrings()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery("SELECT u.id, CONCAT(u.name, 'The Man') FROM User u");
-        
+
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id, CONCAT(e.name, 'The Man') AS e__0 FROM entity e WHERE (e.type = 0)");
     }
 
     public function testConcatInSelectClauseSupportsMoreThanTwoArgs()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery("SELECT u.id, CONCAT(u.name, 'The Man', u.loginname) FROM User u");
-        
+
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id, CONCAT(e.name, 'The Man', e.loginname) AS e__0 FROM entity e WHERE (e.type = 0)");
     }
 

--- a/tests/Query/FromTestCase.php
+++ b/tests/Query/FromTestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Query_From_TestCase extends Doctrine_UnitTestCase
     public function testCount()
     {
         $count = Doctrine_Query::create()->from('User')->count();
-    
+
         $this->assertEqual($count, 0);
     }
     public function testLeftJoin()

--- a/tests/Query/GroupbyTestCase.php
+++ b/tests/Query/GroupbyTestCase.php
@@ -35,9 +35,9 @@ class Doctrine_Query_Groupby_TestCase extends Doctrine_UnitTestCase
     public function testAggregateFunctionsInHavingReturnValidSql()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery('SELECT u.name, COUNT(p.id) count FROM User u LEFT JOIN u.Phonenumber p GROUP BY count');
-        
+
         $this->assertEqual($q->getQuery(), 'SELECT e.id AS e__id, e.name AS e__name, COUNT(p.id) AS p__0 FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE (e.type = 0) GROUP BY p__0');
     }
 }

--- a/tests/Query/HavingTestCase.php
+++ b/tests/Query/HavingTestCase.php
@@ -35,15 +35,15 @@ class Doctrine_Query_Having_TestCase extends Doctrine_UnitTestCase
     public function testAggregateFunctionsInHavingReturnValidSql()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery('SELECT u.name FROM User u LEFT JOIN u.Phonenumber p HAVING COUNT(p.id) > 2');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE (e.type = 0) HAVING COUNT(p.id) > 2');
     }
     public function testAggregateFunctionsInHavingReturnValidSql2()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery("SELECT u.name FROM User u LEFT JOIN u.Phonenumber p HAVING MAX(u.name) = 'zYne'");
 
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id, e.name AS e__name FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE (e.type = 0) HAVING MAX(e.name) = 'zYne'");

--- a/tests/Query/IdentifierQuotingTestCase.php
+++ b/tests/Query/IdentifierQuotingTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('Entity', 'Phonenumber');
-        
+
         parent::prepareTables();
     }
 
@@ -66,7 +66,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q->parseDqlQuery('SELECT u.name FROM User u WHERE u.id = 3');
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT "e"."id" AS "e__id", "e"."name" AS "e__name" FROM "entity" "e" WHERE ("e"."id" = 3 AND ("e"."type" = 0))');
-    
+
         $q->execute();
     }
 
@@ -98,13 +98,13 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT "e"."id" AS "e__id", "e"."name" AS "e__name" FROM "entity" "e" INNER JOIN "phonenumber" "p" ON "e"."id" = "p"."entity_id" WHERE "e"."id" IN (SELECT DISTINCT "e2"."id" FROM "entity" "e2" INNER JOIN "phonenumber" "p2" ON "e2"."id" = "p2"."entity_id" WHERE ("e2"."type" = 0) LIMIT 5) AND ("e"."type" = 0)');
     }
-    
+
     public function testCountQuerySupportsIdentifierQuoting()
     {
         $q = new Doctrine_Query();
 
         $q->parseDqlQuery('SELECT u.name FROM User u INNER JOIN u.Phonenumber p');
-        
+
         $this->assertEqual($q->getCountSqlQuery(), 'SELECT COUNT(*) AS "num_results" FROM (SELECT "e"."id" FROM "entity" "e" INNER JOIN "phonenumber" "p" ON "e"."id" = "p"."entity_id" WHERE ("e"."type" = 0) GROUP BY "e"."id") "dctrn_count_query"');
     }
 
@@ -113,7 +113,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->parseDqlQuery('UPDATE User u SET u.name = ? WHERE u.id = ?');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'UPDATE "entity" SET "name" = ? WHERE ("id" = ? AND ("type" = 0))');
     }
 
@@ -122,7 +122,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->update('User')->set('name', '?', 'guilhermeblanco')->where('id = ?');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'UPDATE "entity" SET "name" = ? WHERE ("id" = ? AND ("type" = 0))');
     }
 
@@ -131,7 +131,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->update('User')->set('name', 'LOWERCASE(name)')->where('id = ?');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'UPDATE "entity" SET "name" = LOWERCASE("name") WHERE ("id" = ? AND ("type" = 0))');
     }
 
@@ -140,7 +140,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->update('User u')->set('u.name', 'LOWERCASE(u.name)')->where('u.id = ?');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'UPDATE "entity" SET "name" = LOWERCASE("name") WHERE ("id" = ? AND ("type" = 0))');
     }
 
@@ -149,7 +149,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->update('User u')->set('u.name', 'UPPERCASE(LOWERCASE(u.name))')->where('u.id = ?');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'UPDATE "entity" SET "name" = UPPERCASE(LOWERCASE("name")) WHERE ("id" = ? AND ("type" = 0))');
     }
 
@@ -158,7 +158,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->update('User u')->set('u.name', 'UPPERCASE(LOWERCASE(u.id))')->where('u.id = ?');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'UPDATE "entity" SET "name" = UPPERCASE(LOWERCASE("id")) WHERE ("id" = ? AND ("type" = 0))');
     }
 
@@ -167,7 +167,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->update('User u')->set('u.name', 'CURRENT_TIMESTAMP')->where('u.id = ?');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'UPDATE "entity" SET "name" = CURRENT_TIMESTAMP WHERE ("id" = ? AND ("type" = 0))');
     }
 
@@ -176,7 +176,7 @@ class Doctrine_Query_IdentifierQuoting_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->update('User u')->set('u.id', 'u.id + 1')->where('u.name = ?');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'UPDATE "entity" SET "id" = "id" + 1 WHERE ("name" = ? AND ("type" = 0))');
 
         $this->conn->setAttribute(Doctrine_Core::ATTR_QUOTE_IDENTIFIER, false);

--- a/tests/Query/JoinConditionTestCase.php
+++ b/tests/Query/JoinConditionTestCase.php
@@ -43,7 +43,7 @@ class Doctrine_Query_JoinCondition_TestCase extends Doctrine_UnitTestCase
     public function testJoinConditionsAreSupportedForOneToManyLeftJoins()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery("SELECT u.name, p.id FROM User u LEFT JOIN u.Phonenumber p ON p.phonenumber = '123 123'");
 
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id, e.name AS e__name, p.id AS p__id FROM entity e LEFT JOIN phonenumber p ON (p.phonenumber = '123 123') WHERE (e.type = 0)");
@@ -52,7 +52,7 @@ class Doctrine_Query_JoinCondition_TestCase extends Doctrine_UnitTestCase
     public function testJoinConditionsAreSupportedForOneToManyInnerJoins()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery("SELECT u.name, p.id FROM User u INNER JOIN u.Phonenumber p ON p.phonenumber = '123 123'");
 
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id, e.name AS e__name, p.id AS p__id FROM entity e INNER JOIN phonenumber p ON (p.phonenumber = '123 123') WHERE (e.type = 0)");
@@ -61,7 +61,7 @@ class Doctrine_Query_JoinCondition_TestCase extends Doctrine_UnitTestCase
     public function testJoinConditionsAreSupportedForManyToManyLeftJoins()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery('SELECT u.name, g.id FROM User u LEFT JOIN u.Group g ON g.id > 2');
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e2.id AS e2__id FROM entity e LEFT JOIN groupuser g ON (e.id = g.user_id) LEFT JOIN entity e2 ON (e2.id > 2) AND e2.type = 1 WHERE (e.type = 0)');
@@ -70,9 +70,9 @@ class Doctrine_Query_JoinCondition_TestCase extends Doctrine_UnitTestCase
     public function testJoinConditionsAreSupportedForManyToManyInnerJoins()
     {
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery('SELECT u.name, g.id FROM User u INNER JOIN u.Group g ON g.id > 2');
-    
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e2.id AS e2__id FROM entity e INNER JOIN groupuser g ON (e.id = g.user_id) INNER JOIN entity e2 ON (e2.id > 2) AND e2.type = 1 WHERE (e.type = 0)');
     }
 

--- a/tests/Query/JoinTestCase.php
+++ b/tests/Query/JoinTestCase.php
@@ -55,7 +55,7 @@ class Doctrine_Query_Join_TestCase extends Doctrine_UnitTestCase
 
         $c->City[0]->District->name = 'District 1';
         $c->City[2]->District->name = 'District 2';
-        
+
         $this->assertTrue(gettype($c->City[0]->District), 'object');
         $this->assertTrue(gettype($c->City[0]->District->name), 'string');
 
@@ -115,8 +115,8 @@ class Doctrine_Query_Join_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT r.id AS r__id, r.name AS r__name, r2.id AS r2__id, r2.name AS r2__name, r2.country_id AS r2__country_id, r2.district_id AS r2__district_id FROM record__country r INNER JOIN record__city r2 ON r.id = r2.country_id AND (LOWER(UPPER(r2.name)) LIKE LOWER(?)) WHERE (r.id = ?)');
     }
-    
-    
+
+
     public function testQueryMultipleAggFunctionInJoins2()
     {
         $q = new Doctrine_Query();
@@ -128,8 +128,8 @@ class Doctrine_Query_Join_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT r.id AS r__id, r.name AS r__name, r2.id AS r2__id, r2.name AS r2__name, r2.country_id AS r2__country_id, r2.district_id AS r2__district_id FROM record__country r INNER JOIN record__city r2 ON r.id = r2.country_id AND (LOWER(UPPER(r2.name)) LIKE CONCAT(UPPER(?), UPPER(r2.name))) WHERE (r.id = ?)');
     }
-    
-    
+
+
     public function testQueryMultipleAggFunctionInJoins3()
     {
         $q = new Doctrine_Query();
@@ -259,7 +259,7 @@ class Doctrine_Query_Join_TestCase extends Doctrine_UnitTestCase
     {
         $q    = new Doctrine_Query();
         $coll = $q->from('Record_City c INDEXBY c.name')->fetchArray();
-        
+
         $this->assertTrue(isset($coll['City 1']));
         $this->assertTrue(isset($coll['City 2']));
         $this->assertTrue(isset($coll['City 3']));
@@ -282,7 +282,7 @@ class Doctrine_Query_Join_TestCase extends Doctrine_UnitTestCase
         try {
             $q       = new Doctrine_Query();
             $country = $q->from('Record_Country c LEFT JOIN c.City c2 INDEXBY c2.unknown')->fetchOne();
-        
+
             $this->fail();
         } catch (Doctrine_Query_Exception $e) {
             $this->pass();

--- a/tests/Query/LimitTestCase.php
+++ b/tests/Query/LimitTestCase.php
@@ -42,7 +42,7 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
 
         parent::prepareTables();
     }
-    
+
     public function testLimitWithNormalManyToMany()
     {
         $coll                 = new Doctrine_Collection($this->connection->getTable('Photo'));
@@ -64,10 +64,10 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
         $photos = $q->execute(array(1));
         $this->assertEqual($photos->count(), 3);
         $this->assertEqual(
-            
+
             $q->getSqlQuery(),
         'SELECT p.id AS p__id, p.name AS p__name FROM photo p LEFT JOIN phototag p2 ON (p.id = p2.photo_id) LEFT JOIN tag t ON t.id = p2.tag_id WHERE p.id IN (SELECT DISTINCT p3.id FROM photo p3 LEFT JOIN phototag p4 ON (p3.id = p4.photo_id) LEFT JOIN tag t2 ON t2.id = p4.tag_id WHERE t2.id = ? ORDER BY p3.id DESC LIMIT 100) AND (t.id = ?) ORDER BY p.id DESC'
-            
+
         );
     }
 
@@ -143,7 +143,7 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
     {
         $q = new Doctrine_Query();
         $q->select('User.name')->distinct()->from('User')->where("User.Phonenumber.phonenumber LIKE '%123%'")->orderby('User.Email.address')->limit(5);
-        
+
 
         $users = $q->execute();
 
@@ -179,12 +179,12 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($users->count(), 5);
         $users[3]->Phonenumber[0];
         $this->assertEqual($count, $this->conn->count());
-        
+
         $this->assertEqual(
-        
+
             $q->getSqlQuery(),
         'SELECT e.id AS e__id, p.id AS p__id, p.phonenumber AS p__phonenumber, p.entity_id AS p__entity_id FROM entity e INNER JOIN phonenumber p ON e.id = p.entity_id WHERE e.id IN (SELECT DISTINCT e2.id FROM entity e2 INNER JOIN phonenumber p2 ON e2.id = p2.entity_id WHERE (e2.type = 0) LIMIT 5 OFFSET 2) AND (e.type = 0)'
-        
+
         );
     }
 
@@ -238,7 +238,7 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
         $users = $q->execute();
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id, p.id AS p__id, p.phonenumber AS p__phonenumber, p.entity_id AS p__entity_id FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE e.id IN (SELECT DISTINCT e2.id FROM entity e2 LEFT JOIN phonenumber p2 ON e2.id = p2.entity_id WHERE e2.name = ? AND (e2.type = 0) LIMIT 5) AND (e.name = ? AND (e.type = 0))');
-        
+
         $this->assertEqual($users->count(), 1);
         //$this->connection->flush();
     }
@@ -246,24 +246,24 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
     {
         $q = new Doctrine_Query();
         $q->from('User.Group')->limit(5);
-        
+
         $users = $q->execute();
 
         $this->assertEqual($users->count(), 5);
-        
+
         $user = $this->objTable->find(5);
-        
+
         $user->Group[1]->name = 'Tough guys inc.';
-        
+
         $user->Group[2]->name = 'Terminators';
-        
+
         $user2 = $this->objTable->find(4);
         //$user2->Group = $user->Group;
         $user2->Group   = new Doctrine_Collection('Group');
         $user2->Group[] = $user->Group[0];
         $user2->Group[] = $user->Group[1];
         $user2->Group[] = $user->Group[2];
-        
+
         $user3 = $this->objTable->find(6);
         //$user3->Group = $user->Group;
         $user3->Group   = new Doctrine_Collection('Group');
@@ -277,17 +277,17 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(count($user3->Group), 3);
 
         $this->connection->flush();
-        
+
         $this->assertEqual($user->Group[0]->name, 'Action Actors');
         $this->assertEqual(count($user->Group), 3);
-        
+
         $q = new Doctrine_Query();
         $q->from('User')->where('User.Group.id = ?')->orderby('User.id ASC')->limit(5);
-        
+
         $users = $q->execute(array($user->Group[1]->id));
-        
+
         $this->assertEqual($users->count(), 3);
-        
+
         $this->connection->clear();
         $q = new Doctrine_Query();
         $q->from('User')->where('User.Group.id = ?')->orderby('User.id DESC');
@@ -299,7 +299,7 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
     public function testLimitAttribute()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_QUERY_LIMIT, Doctrine_Core::LIMIT_ROWS);
-        
+
         $this->connection->clear();
         $q = new Doctrine_Query();
         $q->from('User')->where('User.Group.name = ?')->orderby('User.id DESC')->limit(5);
@@ -320,14 +320,14 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
     public function testLimitNoticesOrderbyJoins()
     {
         $q = new Doctrine_Query();
-        
+
         $q->from('Photo p')
           ->leftJoin('p.Tag t')
           ->orderby('t.id DESC')->limit(10);
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT p.id AS p__id, p.name AS p__name, t.id AS t__id, t.tag AS t__tag FROM photo p LEFT JOIN phototag p2 ON (p.id = p2.photo_id) LEFT JOIN tag t ON t.id = p2.tag_id WHERE p.id IN (SELECT DISTINCT p3.id FROM photo p3 LEFT JOIN phototag p4 ON (p3.id = p4.photo_id) LEFT JOIN tag t2 ON t2.id = p4.tag_id ORDER BY t2.id DESC LIMIT 10) ORDER BY t.id DESC');
     }
-    
+
     public function testLimitSubqueryNotNeededIfSelectSingleFieldDistinct()
     {
         $q = new Doctrine_Query();
@@ -337,7 +337,7 @@ class Doctrine_Query_Limit_TestCase extends Doctrine_UnitTestCase
 
         $users = $q->execute(array('zYne'));
         $this->assertEqual(1, $users->count());
-        
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT DISTINCT e.id AS e__id FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE (e.name = ? AND (e.type = 0)) LIMIT 5');
     }
 }

--- a/tests/Query/MultiJoin2TestCase.php
+++ b/tests/Query/MultiJoin2TestCase.php
@@ -38,13 +38,13 @@ class Doctrine_Query_MultiJoin2_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('QueryTest_Category', 'QueryTest_Board', 'QueryTest_User', 'QueryTest_Entry');
-        
+
         parent::prepareTables();
     }
     public function testInitializeData()
     {
         $query = new Doctrine_Query($this->connection);
-        
+
         $cat = new QueryTest_Category();
 
         $cat->rootCategoryId   = 0;
@@ -52,13 +52,13 @@ class Doctrine_Query_MultiJoin2_TestCase extends Doctrine_UnitTestCase
         $cat->name             = 'Cat1';
         $cat->position         = 0;
         $cat->save();
-        
+
         $board             = new QueryTest_Board();
         $board->name       = 'B1';
         $board->categoryId = $cat->id;
         $board->position   = 0;
         $board->save();
-        
+
         $author           = new QueryTest_User();
         $author->username = 'romanb';
         $author->save();
@@ -92,7 +92,7 @@ class Doctrine_Query_MultiJoin2_TestCase extends Doctrine_UnitTestCase
             $this->fail($e->getMessage());
         }
     }
-    
+
     public function testMultipleJoinFetchingWithArrayFetching()
     {
         $query      = new Doctrine_Query($this->connection);

--- a/tests/Query/MultipleAggregateValueTestCase.php
+++ b/tests/Query/MultipleAggregateValueTestCase.php
@@ -40,16 +40,16 @@ class Doctrine_Query_MultipleAggregateValue_TestCase extends Doctrine_UnitTestCa
     {
         $user       = new User();
         $user->name = 'jon';
-        
+
         $user->Album[0] = new Album();
         $user->Album[1] = new Album();
         $user->Album[2] = new Album();
-        
+
         $user->Book[0] = new Book();
         $user->Book[1] = new Book();
         $user->save();
     }
-    
+
     public function testMultipleAggregateValues()
     {
         $query = new Doctrine_Query();
@@ -58,9 +58,9 @@ class Doctrine_Query_MultipleAggregateValue_TestCase extends Doctrine_UnitTestCa
         $query->leftJoin('u.Album a, u.Book b');
         $query->where("u.name = 'jon'");
         $query->limit(1);
-        
+
         $user = $query->execute()->getFirst();
-        
+
         try {
             $name       = $user->name;
             $num_albums = $user->num_albums;
@@ -68,7 +68,7 @@ class Doctrine_Query_MultipleAggregateValue_TestCase extends Doctrine_UnitTestCa
         } catch (Doctrine_Exception $e) {
             $this->fail();
         }
-        
+
         $this->assertEqual($num_albums, 3);
         $this->assertEqual($num_books, 2);
     }
@@ -80,7 +80,7 @@ class Doctrine_Query_MultipleAggregateValue_TestCase extends Doctrine_UnitTestCa
         $query->leftJoin('u.Album a, u.Book b');
         $query->where("u.name = 'jon'");
         $query->limit(1);
-        
+
         $users = $query->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
 
         try {

--- a/tests/Query/MysqlSubqueryHavingTestCase.php
+++ b/tests/Query/MysqlSubqueryHavingTestCase.php
@@ -54,7 +54,7 @@ class Doctrine_Query_MysqlSubqueryHaving_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($this->dbh->pop(), 'SELECT DISTINCT e2.id, COUNT(DISTINCT a2.id) AS a2__0 FROM entity e2 LEFT JOIN album a2 ON e2.id = a2.user_id WHERE (e2.type = 0) GROUP BY e2.id HAVING a2__0 > 0 ORDER BY a2__0 DESC LIMIT 5');
     }
-    
+
     public function testGetLimitSubqueryWithHavingOnAggregateValuesIncorrectAlias()
     {
         $q = new Doctrine_Query();

--- a/tests/Query/MysqlSubqueryTestCase.php
+++ b/tests/Query/MysqlSubqueryTestCase.php
@@ -53,6 +53,7 @@ class Doctrine_Query_MysqlSubquery_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($this->dbh->pop(), 'SELECT DISTINCT e2.id, COUNT(DISTINCT a2.id) AS a2__0 FROM entity e2 LEFT JOIN album a2 ON e2.id = a2.user_id WHERE (e2.type = 0) GROUP BY e2.id ORDER BY a2__0 LIMIT 5');
     }
+
     public function testGetLimitSubquerySupportsOrderByWithAggregateValuesAndDescKeyword()
     {
         $q = new Doctrine_Query();
@@ -66,8 +67,9 @@ class Doctrine_Query_MysqlSubquery_TestCase extends Doctrine_UnitTestCase
 
         $this->dbh->pop();
 
-        $this->assertEqual($this->dbh->pop(), 'SELECT DISTINCT e2.id, COUNT(DISTINCT a2.id) AS a2__0 FROM entity e2 LEFT JOIN album a2 ON e2.id = a2.user_id WHERE (e2.type = 0) GROUP BY e2.id ORDER BY a2__0 DESC, e2.name LIMIT 5');
+        $this->assertEqual($this->dbh->pop(), 'SELECT DISTINCT e2.id, e2.name, COUNT(DISTINCT a2.id) AS a2__0 FROM entity e2 LEFT JOIN album a2 ON e2.id = a2.user_id WHERE (e2.type = 0) GROUP BY e2.id ORDER BY a2__0 DESC, e2.name LIMIT 5');
     }
+
     public function testGetLimitSubquerySupportsOrderByWithAggregateValuesAndColumns()
     {
         $q = new Doctrine_Query();
@@ -81,8 +83,9 @@ class Doctrine_Query_MysqlSubquery_TestCase extends Doctrine_UnitTestCase
 
         $this->dbh->pop();
 
-        $this->assertEqual($this->dbh->pop(), 'SELECT DISTINCT e2.id, COUNT(DISTINCT a2.id) AS a2__0 FROM entity e2 LEFT JOIN album a2 ON e2.id = a2.user_id WHERE (e2.type = 0) GROUP BY e2.id ORDER BY a2__0, e2.name LIMIT 5');
+        $this->assertEqual($this->dbh->pop(), 'SELECT DISTINCT e2.id, e2.name, COUNT(DISTINCT a2.id) AS a2__0 FROM entity e2 LEFT JOIN album a2 ON e2.id = a2.user_id WHERE (e2.type = 0) GROUP BY e2.id ORDER BY a2__0, e2.name LIMIT 5');
     }
+
     public function testGetLimitSubquerySupportsOrderByAndHavingWithAggregateValues()
     {
         $q = new Doctrine_Query();
@@ -96,9 +99,10 @@ class Doctrine_Query_MysqlSubquery_TestCase extends Doctrine_UnitTestCase
         $q->execute();
 
         $this->dbh->pop();
-        
+
         $this->assertEqual($this->dbh->pop(), 'SELECT DISTINCT e2.id, COUNT(DISTINCT a2.id) AS a2__0 FROM entity e2 LEFT JOIN album a2 ON e2.id = a2.user_id WHERE (e2.type = 0) GROUP BY e2.id HAVING a2__0 > 0 ORDER BY a2__0 DESC LIMIT 5');
     }
+
     public function testGetLimitSubquerySupportsHavingWithAggregateValues()
     {
         $q = new Doctrine_Query();
@@ -111,7 +115,7 @@ class Doctrine_Query_MysqlSubquery_TestCase extends Doctrine_UnitTestCase
         $q->execute();
 
         $this->dbh->pop();
-        
+
         $this->assertEqual($this->dbh->pop(), 'SELECT DISTINCT e2.id, COUNT(DISTINCT a2.id) AS a2__0 FROM entity e2 LEFT JOIN album a2 ON e2.id = a2.user_id WHERE (e2.type = 0) GROUP BY e2.id HAVING a2__0 > 0 LIMIT 5');
     }
 }

--- a/tests/Query/OneToOneFetchingTestCase.php
+++ b/tests/Query/OneToOneFetchingTestCase.php
@@ -47,7 +47,7 @@ class Doctrine_Query_OneToOneFetching_TestCase extends Doctrine_UnitTestCase
     public function testInitializeData()
     {
         $query = new Doctrine_Query($this->connection);
-        
+
         $cat = new QueryTest_Category();
 
         $cat->rootCategoryId   = 0;
@@ -55,32 +55,32 @@ class Doctrine_Query_OneToOneFetching_TestCase extends Doctrine_UnitTestCase
         $cat->name             = 'Testcat';
         $cat->position         = 0;
         $cat->save();
-        
+
         $board             = new QueryTest_Board();
         $board->name       = 'Testboard';
         $board->categoryId = $cat->id;
         $board->position   = 0;
         $board->save();
-        
+
         $author           = new QueryTest_User();
         $author->username = 'romanbb';
         $author->save();
-        
+
         $lastEntry           = new QueryTest_Entry();
         $lastEntry->authorId = $author->id;
         $lastEntry->date     = 1234;
         $lastEntry->save();
-        
+
         // Set the last entry
         $board->lastEntry = $lastEntry;
         $board->save();
-        
+
         $visibleRank        = new QueryTest_Rank();
         $visibleRank->title = 'Freak';
         $visibleRank->color = 'red';
         $visibleRank->icon  = 'freak.png';
         $visibleRank->save();
-        
+
         // grant him a rank
         $author->visibleRank = $visibleRank;
         $author->save();
@@ -110,17 +110,17 @@ class Doctrine_Query_OneToOneFetching_TestCase extends Doctrine_UnitTestCase
                     ->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
 
             // --> currently quits here with a fatal error! <--
-                    
+
             // check boards/categories
             $this->assertEqual(1, count($categories));
             $this->assertTrue(isset($categories[0]['boards']));
             $this->assertEqual(1, count($categories[0]['boards']));
-            
+
             // get the baord for inspection
             $board = $categories[0]['boards'][0];
-            
+
             $this->assertTrue(isset($board['lastEntry']));
-            
+
             // lastentry should've 2 fields. one regular field, one relation.
             //$this->assertEqual(2, count($board['lastEntry']));
             $this->assertEqual(1234, (int)$board['lastEntry']['date']);
@@ -152,7 +152,7 @@ class Doctrine_Query_OneToOneFetching_TestCase extends Doctrine_UnitTestCase
         $lastEntryId        = $board->lastEntryId;
         $board->lastEntryId = 0;
         $board->save();
-        
+
         $query = new Doctrine_Query($this->connection);
         try {
             $categories = $query->select('c.*, b.*, le.*, a.username, vr.title, vr.color, vr.icon')
@@ -168,15 +168,15 @@ class Doctrine_Query_OneToOneFetching_TestCase extends Doctrine_UnitTestCase
             $this->assertEqual(1, count($categories));
             $this->assertTrue(isset($categories[0]['boards']));
             $this->assertEqual(1, count($categories[0]['boards']));
-            
+
             // get the board for inspection
             $tmpBoard = $categories[0]['boards'][0];
-            
+
             $this->assertTrue(! isset($tmpBoard['lastEntry']));
         } catch (Doctrine_Exception $e) {
             $this->fail();
         }
-        
+
         $board->lastEntryId = $lastEntryId;
         $board->save();
     }
@@ -194,20 +194,20 @@ class Doctrine_Query_OneToOneFetching_TestCase extends Doctrine_UnitTestCase
                     ->leftJoin('le.author a')
                     ->leftJoin('a.visibleRank vr')
                     ->execute();
- 
+
             // check boards/categories
             $this->assertEqual(1, count($categories));
             $this->assertEqual(1, count($categories[0]['boards']));
-            
+
             // get the baord for inspection
             $board = $categories[0]['boards'][0];
 
             $this->assertEqual(1234, (int)$board['lastEntry']['date']);
             $this->assertTrue(isset($board['lastEntry']['author']));
-            
+
             $this->assertEqual('romanbb', $board['lastEntry']['author']['username']);
             $this->assertTrue(isset($board['lastEntry']['author']['visibleRank']));
-            
+
             $this->assertEqual('Freak', $board['lastEntry']['author']['visibleRank']['title']);
             $this->assertEqual('red', $board['lastEntry']['author']['visibleRank']['color']);
             $this->assertEqual('freak.png', $board['lastEntry']['author']['visibleRank']['icon']);
@@ -228,7 +228,7 @@ class Doctrine_Query_OneToOneFetching_TestCase extends Doctrine_UnitTestCase
         $board->lastEntryId = null;
         $board->lastEntry   = null;
         $board->save();
-        
+
         $query = new Doctrine_Query($this->connection);
         try {
             $categories = $query->select('c.*, b.*, le.*, a.username, vr.title, vr.color, vr.icon')

--- a/tests/Query/OrderbyTestCase.php
+++ b/tests/Query/OrderbyTestCase.php
@@ -35,13 +35,14 @@ class Doctrine_Query_Orderby_TestCase extends Doctrine_UnitTestCase
     public function testOrderByRandomIsSupported()
     {
         $q = new Doctrine_Query();
-        
+
         $q->select('u.name, RANDOM() rand')
           ->from('User u')
           ->orderby('rand DESC');
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, ((RANDOM() + 2147483648) / 4294967296) AS e__0 FROM entity e WHERE (e.type = 0) ORDER BY e__0 DESC');
     }
+
     public function testOrderByAggregateValueIsSupported()
     {
         $q = new Doctrine_Query();
@@ -59,27 +60,27 @@ class Doctrine_Query_Orderby_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $q = new Doctrine_Query();
-        
+
             $q->select('u.name')
               ->from('User u')
               ->orderby('COALESCE(u.id, u.name) DESC');
-            // nonesese results expected, but query is syntatically ok.
+            // nonsense results expected, but query is syntatically ok.
             $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name FROM entity e WHERE (e.type = 0) ORDER BY COALESCE(e.id, e.name) DESC');
             $this->pass();
         } catch (Exception $e) {
             $this->fail($e->getMessage());
         }
     }
-    
+
     public function testOrderByWithMultipleCoalesce()
     {
         try {
             $q = new Doctrine_Query();
-        
+
             $q->select('u.name')
               ->from('User u')
               ->orderby('COALESCE(u.id, u.name) DESC, COALESCE(u.name, u.id) ASC');
-            // nonesese results expected, but query is syntatically ok.
+            // nonsense results expected, but query is syntatically ok.
             $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name FROM entity e WHERE (e.type = 0) ORDER BY COALESCE(e.id, e.name) DESC, COALESCE(e.name, e.id) ASC');
             $this->pass();
         } catch (Exception $e) {
@@ -87,15 +88,15 @@ class Doctrine_Query_Orderby_TestCase extends Doctrine_UnitTestCase
         }
     }
 
-    public function testOrderByWithDifferentOrderning()
+    public function testOrderByWithDifferentOrdering()
     {
         try {
             $q = new Doctrine_Query();
-        
+
             $q->select('u.name')
               ->from('User u')
               ->orderby('u.id ASC, u.name DESC');
-            // nonesese results expected, but query is syntatically ok.
+            // nonsense results expected, but query is syntatically ok.
             $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name FROM entity e WHERE (e.type = 0) ORDER BY e.id ASC, e.name DESC');
             $this->pass();
         } catch (Exception $e) {

--- a/tests/Query/ReferenceModelTestCase.php
+++ b/tests/Query/ReferenceModelTestCase.php
@@ -81,12 +81,12 @@ class Doctrine_Query_ReferenceModel_TestCase extends Doctrine_UnitTestCase
     public function testSelfReferencingWithNestedOrderBy()
     {
         $query = new Doctrine_Query();
-        
+
         $query->from('Forum_Category.Subcategory.Subcategory');
         $query->orderby('Forum_Category.id ASC, Forum_Category.Subcategory.name DESC');
 
         $coll = $query->execute();
-        
+
         $category = $coll[0];
 
         $this->assertEqual($category->name, 'Root');

--- a/tests/Query/RegistryTestCase.php
+++ b/tests/Query/RegistryTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Query_Registry_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('User');
-        
+
         parent::prepareTables();
     }
     public function prepareData()
@@ -58,11 +58,11 @@ class Doctrine_Query_Registry_TestCase extends Doctrine_UnitTestCase
         $registry->add('User/all', 'SELECT u.* FROM User u');
 
         $this->assertEqual($registry->get('all', 'User')->getDql(), 'SELECT u.* FROM User u');
-        
+
         $this->manager->setQueryRegistry($registry);
 
         $user = new User();
-        
+
         $user->getTable()->execute('all');
     }
 }

--- a/tests/Query/SelectExpressionTestCase.php
+++ b/tests/Query/SelectExpressionTestCase.php
@@ -54,13 +54,13 @@ class Doctrine_Query_SelectExpression_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
     }
-    
+
     public function testSubtractionExpression()
     {
         $query = new Doctrine_Query();
         $query->select('u.*, (u.id - u.id) subtraction');
         $query->from('User u');
-        
+
         try {
             $users = $query->execute();
             $this->pass();
@@ -68,13 +68,13 @@ class Doctrine_Query_SelectExpression_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
     }
-    
+
     public function testDivisionExpression()
     {
         $query = new Doctrine_Query();
         $query->select('u.*, (u.id/u.id) division');
         $query->from('User u');
-        
+
         try {
             $users = $query->execute();
             $this->pass();
@@ -82,13 +82,13 @@ class Doctrine_Query_SelectExpression_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
     }
-    
+
     public function testMultiplicationExpression()
     {
         $query = new Doctrine_Query();
         $query->select('u.*, (u.id * u.id) multiplication');
         $query->from('User u');
-        
+
         try {
             $users = $query->execute();
             $this->pass();
@@ -96,14 +96,14 @@ class Doctrine_Query_SelectExpression_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
     }
-    
+
     public function testOrderByExpression()
     {
         $query = new Doctrine_Query();
         $query->select('u.*, (u.id * u.id) multiplication');
         $query->from('User u');
         $query->orderby('multiplication asc');
-        
+
         try {
             $users = $query->execute();
             $this->pass();

--- a/tests/Query/SelectTestCase.php
+++ b/tests/Query/SelectTestCase.php
@@ -56,7 +56,7 @@ class Doctrine_Query_Select_TestCase extends Doctrine_UnitTestCase
     public function testSelectDistinctIsSupported()
     {
         $q = new Doctrine_Query();
-        
+
         $q->distinct()->select('u.name')->from('User u');
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT DISTINCT e.id AS e__id, e.name AS e__name FROM entity e WHERE (e.type = 0)');
@@ -65,7 +65,7 @@ class Doctrine_Query_Select_TestCase extends Doctrine_UnitTestCase
     public function testSelectDistinctIsSupported2()
     {
         $q = new Doctrine_Query();
-        
+
         $q->select('DISTINCT u.name')->from('User u');
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT DISTINCT e.id AS e__id, e.name AS e__name FROM entity e WHERE (e.type = 0)');
@@ -126,10 +126,10 @@ class Doctrine_Query_Select_TestCase extends Doctrine_UnitTestCase
     public function testUnknownAggregateFunction()
     {
         $q = new Doctrine_Query();
-        
+
         try {
             $q->parseDqlQuery('SELECT UNKNOWN(u.id) FROM User u');
-            
+
             $q->getSqlQuery();
             $this->fail();
         } catch (Doctrine_Query_Exception $e) {
@@ -166,7 +166,7 @@ class Doctrine_Query_Select_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->parseDqlQuery('SELECT u.name, u.type FROM User u');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.type AS e__type FROM entity e WHERE (e.type = 0)');
     }
     public function testMultipleComponentsWithAsterisk()
@@ -225,7 +225,7 @@ class Doctrine_Query_Select_TestCase extends Doctrine_UnitTestCase
         $q = new Doctrine_Query();
 
         $q->parseDqlQuery('SELECT u.id, COUNT(p.id) count, MAX(p.phonenumber) max FROM User u, u.Phonenumber p GROUP BY u.id');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, COUNT(p.id) AS p__0, MAX(p.phonenumber) AS p__1 FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE (e.type = 0) GROUP BY e.id');
 
         $users = $q->execute();
@@ -259,7 +259,7 @@ class Doctrine_Query_Select_TestCase extends Doctrine_UnitTestCase
         );
 
         $users = $q->execute($params, Doctrine_Core::HYDRATE_ARRAY);
-        
+
         $this->assertEqual(count($users), 3);
     }
 }

--- a/tests/Query/ShortAliasesTestCase.php
+++ b/tests/Query/ShortAliasesTestCase.php
@@ -13,13 +13,13 @@ class Doctrine_Query_ShortAliases_TestCase extends Doctrine_UnitTestCase
     public function testShortAliasesWithOneToManyLeftJoin()
     {
         $q = new Doctrine_Query();
-        
+
         $q->select('u.name, p.id')->from('User u LEFT JOIN u.Phonenumber p');
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, p.id AS p__id FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE (e.type = 0)');
 
         $users = $q->execute();
-        
+
         $this->assertEqual($users->count(), 8);
     }
 

--- a/tests/Query/SubqueryTestCase.php
+++ b/tests/Query/SubqueryTestCase.php
@@ -61,7 +61,7 @@ class Doctrine_Query_Subquery_TestCase extends Doctrine_UnitTestCase
     {
         // ticket #307
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery("SELECT u.name, (SELECT COUNT(p.id) FROM Phonenumber p WHERE p.entity_id = u.id) pcount FROM User u WHERE u.name = 'zYne' LIMIT 1");
 
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id, e.name AS e__name, (SELECT COUNT(p.id) AS p__0 FROM phonenumber p WHERE (p.entity_id = e.id)) AS e__0 FROM entity e WHERE (e.name = 'zYne' AND (e.type = 0)) LIMIT 1");
@@ -80,7 +80,7 @@ class Doctrine_Query_Subquery_TestCase extends Doctrine_UnitTestCase
     {
         // ticket DC-706
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery("SELECT u.name, (SQL:SELECT COUNT(p.id) AS p__0 FROM phonenumber p WHERE (p.entity_id = e.id)) as pcount FROM User u WHERE u.name = 'zYne' LIMIT 1");
 
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id, e.name AS e__name, (SELECT COUNT(p.id) AS p__0 FROM phonenumber p WHERE (p.entity_id = e.id)) AS e__0 FROM entity e WHERE (e.name = 'zYne' AND (e.type = 0)) LIMIT 1");
@@ -99,9 +99,9 @@ class Doctrine_Query_Subquery_TestCase extends Doctrine_UnitTestCase
     {
         // ticket #307
         $q = new Doctrine_Query();
-        
+
         $q->parseDqlQuery("SELECT u.name, (SELECT COUNT(w.id) FROM User w WHERE w.id = u.id) pcount FROM User u WHERE u.name = 'zYne' LIMIT 1");
-        
+
         $this->assertNotEqual($q->getSqlQuery(), "SELECT e.id AS e__id, e.name AS e__name, (SELECT COUNT(e.id) AS e__0 FROM entity e WHERE e.id = e.id AND (e.type = 0)) AS e__0 FROM entity e WHERE e.name = 'zYne' AND (e.type = 0) LIMIT 1");
     }
 
@@ -138,11 +138,11 @@ class Doctrine_Query_Subquery_TestCase extends Doctrine_UnitTestCase
           ->groupby('u.id')
           ->having('num_albums > 0')
           ->limit(5);
-        
+
         try {
             $this->assertEqual($q->getCountSqlQuery(), 'SELECT COUNT(*) AS num_results FROM (SELECT e.id, COUNT(a.id) AS a__0 FROM entity e LEFT JOIN album a ON e.id = a.user_id WHERE (e.type = 0) GROUP BY e.id HAVING a__0 > 0) dctrn_count_query');
             $q->count();
-            
+
             $this->pass();
         } catch (Doctrine_Exception $e) {
             $this->fail($e->getMessage());

--- a/tests/Query/UpdateTestCase.php
+++ b/tests/Query/UpdateTestCase.php
@@ -70,7 +70,7 @@ class Doctrine_Query_Update_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($q->getSqlQuery(), "UPDATE entity SET name = 'someone', email_id = 5 WHERE (type = 0)");
     }
-    
+
     public function testUpdateSupportsConditions()
     {
         $q = new Doctrine_Query();

--- a/tests/Query/WhereTestCase.php
+++ b/tests/Query/WhereTestCase.php
@@ -109,7 +109,7 @@ class Doctrine_Query_Where_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($users[0]->name, 'someone');
         $this->assertEqual($users[1]->name, 'someone.2');
     }
-    
+
     public function testExceptionIsThrownWhenParameterIsNull()
     {
         try {
@@ -143,7 +143,7 @@ class Doctrine_Query_Where_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($users[0]->name, 'someone');
         $this->assertEqual($users[1]->name, 'someone.2');
     }
-    
+
     public function testNotInExpression()
     {
         $q = new Doctrine_Query();
@@ -158,12 +158,12 @@ class Doctrine_Query_Where_TestCase extends Doctrine_UnitTestCase
     public function testExistsExpression()
     {
         $q = new Doctrine_Query();
-        
+
         $user                 = new User();
         $user->name           = 'someone with a group';
         $user->Group[0]->name = 'some group';
         $user->save();
-        
+
         // find all users which have groups
         try {
             $q->from('User u')->where('EXISTS (SELECT g.id FROM Groupuser g WHERE g.user_id = u.id)');
@@ -222,36 +222,36 @@ class Doctrine_Query_Where_TestCase extends Doctrine_UnitTestCase
     public function testOperatorWithNoTrailingSpaces()
     {
         $q = new Doctrine_Query();
-        
+
         $q->select('User.id')->from('User')->where("User.name='someone'");
 
         $users = $q->execute();
         $this->assertEqual($users->count(), 1);
-        
+
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id FROM entity e WHERE (e.name = 'someone' AND (e.type = 0))");
     }
 
     public function testOperatorWithNoTrailingSpaces2()
     {
         $q = new Doctrine_Query();
-        
+
         $q->select('User.id')->from('User')->where("User.name='foo.bar'");
 
         $users = $q->execute();
         $this->assertEqual($users->count(), 0);
-        
+
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id FROM entity e WHERE (e.name = 'foo.bar' AND (e.type = 0))");
     }
 
     public function testOperatorWithSingleTrailingSpace()
     {
         $q = new Doctrine_Query();
-        
+
         $q->select('User.id')->from('User')->where("User.name= 'foo.bar'");
 
         $users = $q->execute();
         $this->assertEqual($users->count(), 0);
-        
+
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id FROM entity e WHERE (e.name = 'foo.bar' AND (e.type = 0))");
     }
 
@@ -263,7 +263,7 @@ class Doctrine_Query_Where_TestCase extends Doctrine_UnitTestCase
 
         $users = $q->execute();
         $this->assertEqual($users->count(), 0);
-        
+
         $this->assertEqual($q->getSqlQuery(), "SELECT e.id AS e__id FROM entity e WHERE (e.name = 'foo.bar' AND (e.type = 0))");
     }
 
@@ -288,16 +288,16 @@ class Doctrine_Query_Where_TestCase extends Doctrine_UnitTestCase
     public function testLiteralValueAsInOperatorOperandIsSupported()
     {
         $q = new Doctrine_Query();
-        
+
         $q->select('u.id')->from('User u')->where('1 IN (1, 2)');
-        
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id FROM entity e WHERE (1 IN (1, 2) AND (e.type = 0))');
     }
 
     public function testCorrelatedSubqueryWithInOperatorIsSupported()
     {
         $q = new Doctrine_Query();
-        
+
         $q->select('u.id')->from('User u')->where('u.name IN (SELECT u2.name FROM User u2 WHERE u2.id = u.id)');
 
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id FROM entity e WHERE (e.name IN (SELECT e2.name AS e2__name FROM entity e2 WHERE (e2.id = e.id AND (e2.type = 0))) AND (e.type = 0))');

--- a/tests/QueryTestCase.php
+++ b/tests/QueryTestCase.php
@@ -45,8 +45,8 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id FROM entity e WHERE (e.id IN (?, ?, ?) AND e.name NOT IN (?, ?) AND e.id NOT IN (?, ?, ?, ?) AND (e.type = 0))'
         );
     }
-    
-    
+
+
     public function testWhereInSupportInDql2()
     {
         $q = Doctrine_Query::create()
@@ -59,7 +59,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
         );
     }
 
-    
+
     public function testGetQueryHookResetsTheManuallyAddedDqlParts()
     {
         $q = new MyQuery();
@@ -128,7 +128,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
         //Doctrine_Core::dump($q->getCachedForm(array('foo' => 'bar')));
         $this->assertEqual($q->parseClause("CONCAT('u.name', u.name)"), "CONCAT('u.name', e.name)");
     }
-    
+
     public function testCountMaintainsParams()
     {
         $q = new Doctrine_Query();
@@ -155,19 +155,19 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
         $query = new Doctrine_Query();
         $query->select('u.*')->from('User u');
         $sql = $query->getSqlQuery();
-        
+
         $data   = $query->execute();
         $query2 = $query->copy();
-        
+
         $this->assertTrue($sql, $query2->getSqlQuery());
-        
+
         $query2->limit(0);
         $query2->offset(0);
         $query2->select('COUNT(u.id) as nb');
-        
+
         $this->assertTrue($query2->getSqlQuery(), 'SELECT COUNT(e.id) AS e__0 FROM entity e WHERE (e.type = 0)');
     }
-    
+
     public function testNullAggregateIsSet()
     {
         $user                              = new User();
@@ -202,8 +202,8 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             $this->pass();
         }
     }
-    
-    
+
+
     public function testOrQuerySupport()
     {
         $q1 = Doctrine_Query::create()
@@ -212,7 +212,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             ->leftJoin('u.Phonenumber p')
             ->where('u.name = ?')
             ->orWhere('u.loginname = ?');
-            
+
         $q2 = Doctrine_Query::create()
             ->select('u.id')
             ->from('User u')
@@ -224,12 +224,12 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             'SELECT e.id AS e__id FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id ' .
             'WHERE (e.name = ? OR e.loginname = ? AND (e.type = 0))'
         );
-        
+
         $items1 = $q1->execute(array('zYne', 'jwage'), Doctrine_Core::HYDRATE_ARRAY);
         $items2 = $q2->execute(array('zYne', 'jwage'), Doctrine_Core::HYDRATE_ARRAY);
 
         $this->assertEqual(count($items1), count($items2));
-        
+
         $q1->free();
         $q2->free();
     }
@@ -244,7 +244,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             ->where('u.name = ?')
             ->andWhere('u.loginname = ?')
             ->orWhere('u.id = ?');
-            
+
         $q2 = Doctrine_Query::create()
             ->select('u.id')
             ->from('User u')
@@ -256,7 +256,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             'SELECT e.id AS e__id FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id ' .
             'WHERE (e.name = ? AND e.loginname = ? OR e.id = ? AND (e.type = 0))'
         );
-        
+
         $items1 = $q1->execute(array('jon', 'jwage', 4), Doctrine_Core::HYDRATE_ARRAY);
         $items2 = $q2->execute(array('jon', 'jwage', 4), Doctrine_Core::HYDRATE_ARRAY);
 
@@ -265,8 +265,8 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
         $q1->free();
         $q2->free();
     }
-    
-    
+
+
     public function testOrQuerySupport3()
     {
         $q1 = Doctrine_Query::create()
@@ -278,7 +278,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             ->orWhere('u.id = 4')
             ->orWhere('u.id = 5')
             ->andWhere("u.name LIKE 'Arnold%'");
-            
+
         $q2 = Doctrine_Query::create()
             ->select('u.id')
             ->from('User u')
@@ -290,7 +290,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             'SELECT e.id AS e__id FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id ' .
             "WHERE (e.name = 'jon' AND e.loginname = 'jwage' OR e.id = 4 OR e.id = 5 AND e.name LIKE 'Arnold%' AND (e.type = 0))"
         );
-        
+
         $items1 = $q1->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
         $items2 = $q2->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
 
@@ -299,7 +299,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
         $q1->free();
         $q2->free();
     }
-    
+
     public function testParseTableAliasesWithBetweenInWhereClause()
     {
         $q1 = Doctrine_Query::create()
@@ -308,9 +308,9 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
             ->where('CURRENT_DATE() BETWEEN u.QueryTest_Subscription.begin AND u.QueryTest_Subscription.begin')
             ->addWhere('u.id != 5')
             ;
-            
+
         $expected = 'SELECT q.id AS q__id FROM query_test__user q LEFT JOIN query_test__subscription q2 ON q.subscriptionid = q2.id WHERE (CURRENT_DATE() BETWEEN q2.begin AND q2.begin AND q.id != 5)';
-        
+
         $this->assertEqual($q1->getSqlQuery(), $expected);
     }
 
@@ -366,7 +366,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
 
         $userTable->setAttribute(Doctrine_Core::ATTR_QUERY_CLASS, 'Doctrine_Query');
     }
-    
+
     public function testNoLimitSubqueryIfXToOneSelected()
     {
         $q = Doctrine_Query::create()
@@ -376,7 +376,7 @@ class Doctrine_Query_TestCase extends Doctrine_UnitTestCase
                     ->leftJoin('u.Phonenumber p')
                     ->distinct()
                     ->limit(1);
-        
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT DISTINCT e.id AS e__id, e.name AS e__name, e2.id AS e2__id, e2.address AS e2__address FROM entity e LEFT JOIN email e2 ON e.email_id = e2.id LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE (e.type = 0) LIMIT 1');
     }
 }

--- a/tests/RawSqlTestCase.php
+++ b/tests/RawSqlTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
         $sql   = 'SELECT {p.*} FROM photos p';
         $query = new Doctrine_RawSql($this->connection);
         $query->parseDqlQuery($sql);
-        
+
         $this->assertEqual($query->getSqlQueryPart('from'), array('photos p'));
 
 
@@ -91,12 +91,12 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
     {
         $query = new Doctrine_RawSql($this->connection);
         // smart component mapping (no need for additional addComponent call
-        
+
         $query->parseDqlQuery('SELECT {entity.name}, {entity.id} FROM entity');
         $fields = $query->getFields();
 
         $this->assertEqual($fields, array('entity.name', 'entity.id'));
-        
+
         $coll = $query->execute();
 
         $this->assertEqual($coll->count(), 11);
@@ -120,14 +120,14 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($coll->count(), 11);
 
         $count = $this->conn->count();
-        
+
         $coll[4]->Phonenumber[0]->phonenumber;
         $this->assertEqual($count, $this->conn->count());
 
         $coll[5]->Phonenumber[0]->phonenumber;
         $this->assertEqual($count, $this->conn->count());
     }
-    
+
     public function testAliasesAreSupportedInAddComponent()
     {
         $query = new Doctrine_RawSql();
@@ -142,7 +142,7 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($coll->count(), 11);
 
         $count = $this->conn->count();
-        
+
         $coll[4]['Phonenumber'][0]['phonenumber'];
         $this->assertEqual($count, $this->conn->count());
 
@@ -152,25 +152,25 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
     public function testPrimaryKeySelectForcing()
     {
         // forcing the select of primary key fields
-        
+
         $query = new Doctrine_RawSql($this->connection);
 
         $query->parseDqlQuery('SELECT {entity.name} FROM entity');
-        
+
         $coll = $query->execute();
-        
+
         $this->assertEqual($coll->count(), 11);
         $this->assertTrue(is_numeric($coll[0]->id));
         $this->assertTrue(is_numeric($coll[3]->id));
         $this->assertTrue(is_numeric($coll[7]->id));
     }
-    
+
     public function testConvenienceMethods()
     {
         $query = new Doctrine_RawSql($this->connection);
         $query->select('{entity.name}')->from('entity');
         $query->addComponent('entity', 'User');
-        
+
         $coll = $query->execute();
 
         $this->assertEqual($coll->count(), 8);
@@ -218,7 +218,7 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
     public function testQueryParser2()
     {
         $query = new Doctrine_RawSql();
-        
+
         $query->parseDqlQuery("SELECT {entity.name} FROM (SELECT entity.name FROM entity WHERE entity.name = 'something') WHERE entity.id = 2 ORDER BY entity.name");
 
         $this->assertEqual(
@@ -239,7 +239,7 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual(count($coll), 3);
     }
-    
+
     public function testSwitchingTheFieldOrder()
     {
         $query = new Doctrine_RawSql();
@@ -252,7 +252,7 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual(count($coll), 3);
     }
-    
+
     public function testParseQueryPartShouldAddPartIfNotSelectAndAppend()
     {
         $query = new Doctrine_Rawsql();
@@ -263,7 +263,7 @@ class Doctrine_RawSql_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue(isset($parts['test'][0]));
         $this->assertEqual('test', $parts['test'][0]);
     }
-    
+
     public function testParseQueryShouldExtractGroupBy()
     {
         $query = new Doctrine_RawSql();

--- a/tests/Record/FilterTestCase.php
+++ b/tests/Record/FilterTestCase.php
@@ -38,16 +38,16 @@ class Doctrine_Record_Filter_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('CompositeRecord', 'RelatedCompositeRecord');
-        
+
         parent::prepareTables();
     }
     public function testStandardFiltersThrowsExceptionWhenGettingUnknownProperties()
     {
         $u = new User();
-        
+
         try {
             $u->unknown;
-        
+
             $this->fail();
         } catch (Doctrine_Record_Exception $e) {
             $this->pass();
@@ -57,10 +57,10 @@ class Doctrine_Record_Filter_TestCase extends Doctrine_UnitTestCase
     public function testStandardFiltersThrowsExceptionWhenSettingUnknownProperties()
     {
         $u = new User();
-        
+
         try {
             $u->unknown = 'something';
-        
+
             $this->fail();
         } catch (Doctrine_Record_Exception $e) {
             $this->pass();
@@ -70,7 +70,7 @@ class Doctrine_Record_Filter_TestCase extends Doctrine_UnitTestCase
     public function testCompoundFilterSupportsAccessingRelatedComponentProperties()
     {
         $u = new CompositeRecord();
-        
+
         try {
             $u->name    = 'someone';
             $u->address = 'something';

--- a/tests/Record/GeneratorTestCase.php
+++ b/tests/Record/GeneratorTestCase.php
@@ -44,9 +44,9 @@ class Doctrine_Record_Generator_TestCase extends Doctrine_UnitTestCase
             $i->Translation['EN']->title = 'en test';
             $i->Translation['FR']->title = 'fr test';
             $i->save();
-            
+
             $this->pass();
-            
+
             $this->assertTrue($i->id > 0);
             $this->assertEqual($i->Translation['EN']->title, 'en test');
             $this->assertEqual($i->Translation['FR']->title, 'fr test');
@@ -64,7 +64,7 @@ class I18nGeneratorComponentBinding extends Doctrine_Record
         $this->hasColumn('name', 'string');
         $this->hasColumn('title', 'string');
     }
-    
+
     public function setUp()
     {
         $this->actAs('I18n', array('fields' => array('title')));

--- a/tests/Record/HookTestCase.php
+++ b/tests/Record/HookTestCase.php
@@ -45,7 +45,7 @@ class Doctrine_Record_Hook_TestCase extends Doctrine_UnitTestCase
     public function testInsertHooksGetInvoked()
     {
         $r = new RecordHookTest();
-        
+
         $r->name = 'record';
         $r->save();
 

--- a/tests/Record/LockTestCase.php
+++ b/tests/Record/LockTestCase.php
@@ -7,11 +7,11 @@ class Doctrine_Record_Lock_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'rec2';
         parent::prepareTables();
     }
-        
+
     public function prepareData()
     {
     }
-    
+
     public function testDeleteRecords()
     {
         $rec1                   = new Rec1();
@@ -19,7 +19,7 @@ class Doctrine_Record_Lock_TestCase extends Doctrine_UnitTestCase
         $rec1->Account          = new Rec2();
         $rec1->Account->address = 'Some address';
         $rec1->save();
-        
+
         $rec1->delete();
         $this->pass();
     }

--- a/tests/Record/SaveBlankRecordTestCase.php
+++ b/tests/Record/SaveBlankRecordTestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Record_SaveBlankRecord_TestCase extends Doctrine_UnitTestCase
 
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
@@ -49,16 +49,16 @@ class Doctrine_Record_SaveBlankRecord_TestCase extends Doctrine_UnitTestCase
         $user = new MyUser();
         $user->state('TDIRTY');
         $user->save();
-        
+
         $this->assertTrue(isset($user['id']) && $user['id']);
     }
-    
+
     public function testSaveBlankRecord2()
     {
         $group = new MyUserGroup();
         $group->state('TDIRTY');
         $group->save();
-        
+
         $this->assertTrue(isset($group['id']) && $group['id']);
     }
 }

--- a/tests/Record/SerializeUnserializeTestCase.php
+++ b/tests/Record/SerializeUnserializeTestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Record_SerializeUnserialize_TestCase extends Doctrine_UnitTestCas
 
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
@@ -60,13 +60,13 @@ class Doctrine_Record_SerializeUnserialize_TestCase extends Doctrine_UnitTestCas
         $object->timestamptest = '2007-08-07 11:55:00';
         $object->timetest      = '11:55:00';
         $object->datetest      = '2007-08-07';
-        
+
         $object->save();
-        
+
         $object_before = clone($object);
         $serialized    = serialize($object);
         $object_after  = unserialize($serialized);
-        
+
         $this->assertIdentical($object_before->booltest, $object_after->booltest);
         $this->assertIdentical($object_before->integertest, $object_after->integertest);
         $this->assertIdentical($object_before->floattest, $object_after->floattest);
@@ -81,22 +81,22 @@ class Doctrine_Record_SerializeUnserialize_TestCase extends Doctrine_UnitTestCas
         $this->assertIdentical($object_before->timetest, $object_after->timetest);
         $this->assertIdentical($object_before->datetest, $object_after->datetest);
     }
-    
+
     public function testSerializeUnserializeRecord()
     {
         $test = new TestRecord();
         $test->save();
-        
+
         $object             = new SerializeTest();
         $object->objecttest = $test;
-         
+
         $object->save();
-        
+
         $object_before = clone($object);
-       
+
         $serialized   = serialize($object);
         $object_after = unserialize($serialized);
-        
+
         $this->assertIdentical(get_class($object_after->objecttest), 'TestRecord');
     }
 }
@@ -104,7 +104,7 @@ class Doctrine_Record_SerializeUnserialize_TestCase extends Doctrine_UnitTestCas
 class TestObject
 {
     private $test_field;
-    
+
     public function __construct($value)
     {
         $this->test_field = $value;

--- a/tests/Record/StateTestCase.php
+++ b/tests/Record/StateTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Record_State_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('Entity');
-        
+
         parent::prepareTables();
     }
 
@@ -46,19 +46,19 @@ class Doctrine_Record_State_TestCase extends Doctrine_UnitTestCase
     public function testAssigningAutoincId()
     {
         $user = new User();
-        
+
         $this->assertEqual($user->id, null);
-        
+
         $user->name = 'zYne';
 
         $user->save();
 
         $this->assertEqual($user->id, 1);
-        
+
         $user->id = 2;
 
         $this->assertEqual($user->id, 2);
-        
+
         $user->save();
     }
 }

--- a/tests/RecordTestCase.php
+++ b/tests/RecordTestCase.php
@@ -394,14 +394,14 @@ class Doctrine_Record_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($user->updated, null);
         $this->assertEqual($user->getTable()->getData(), array());
     }
-    
-    
+
+
     public function testUnknownFieldGet()
     {
         $user       = new User();
         $user->name = 'Jack Daniels';
         $user->save();
-        
+
         try {
             $foo = $user->unexistentColumnInThisClass;
 

--- a/tests/Relation/CircularSavingTestCase.php
+++ b/tests/Relation/CircularSavingTestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Relation_CircularSaving_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('NestTest', 'NestReference');
-        
+
         parent::prepareTables();
     }
 

--- a/tests/Relation/ColumnAliasesTestCase.php
+++ b/tests/Relation/ColumnAliasesTestCase.php
@@ -7,10 +7,10 @@ class Doctrine_Relation_ColumnAliases_TestCase extends Doctrine_UnitTestCase
             'ColumnAliasTest2',
             'ColumnAliasTest3'
         );
-        
+
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
@@ -21,11 +21,11 @@ class Doctrine_Relation_ColumnAliases_TestCase extends Doctrine_UnitTestCase
         $c2->alias1                   = 'foo';
         $c2->ColumnAliasTest3->alias1 = 'bar';
         $c2->save();
-        
+
         $this->assertNotNull($c2->column_alias_test3_id);
     }
-    
-    
+
+
     public function testHasOneCompoundSave2()
     {
         $c3                           = new ColumnAliasTest3();
@@ -61,7 +61,7 @@ class ColumnAliasTest3 extends Doctrine_Record
         $this->hasColumn('column1 as alias1', 'string', 200);
         $this->hasColumn('column2 as alias2', 'integer', 4);
     }
-       
+
     public function setUp()
     {
         $this->hasOne('ColumnAliasTest2', array('local' => 'id', 'foreign' => 'column_alias_test3_id'));

--- a/tests/Relation/ManyToMany2TestCase.php
+++ b/tests/Relation/ManyToMany2TestCase.php
@@ -35,26 +35,26 @@ class Doctrine_Relation_ManyToMany2_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function prepareTables()
     {
         $this->tables = array('TestUser', 'TestMovie', 'TestMovieUserBookmark', 'TestMovieUserVote');
         parent::prepareTables();
     }
-    
+
     public function testManyToManyCreateSelectAndUpdate()
     {
         $user         = new TestUser();
         $user['name'] = 'tester';
         $user->save();
-        
+
         $data                      = new TestMovie();
         $data['name']              = 'movie';
         $data['User']              = $user;
         $data['MovieBookmarks'][0] = $user;
         $data['MovieVotes'][0]     = $user;
         $data->save(); //All ok here
-        
+
         $this->conn->clear();
 
         $q       = new Doctrine_Query();
@@ -114,7 +114,7 @@ class Doctrine_Relation_ManyToMany2_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($movies->count(), 2);
 
         $profiler = new Doctrine_Connection_Profiler();
-        
+
         $this->conn->addListener($profiler);
 
         $this->assertEqual($users[0]->UserBookmarks->count(), 0);

--- a/tests/Relation/ManyToManyTestCase.php
+++ b/tests/Relation/ManyToManyTestCase.php
@@ -36,7 +36,7 @@ class Doctrine_Relation_ManyToMany_TestCase extends Doctrine_UnitTestCase
     public function testJoinComponent()
     {
         $component = new JC3();
-        
+
         try {
             $rel = $component->getTable()->getRelation('M2MTest2');
             $this->pass();
@@ -86,7 +86,7 @@ class Doctrine_Relation_ManyToMany_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
         $this->assertTrue($rel instanceof Doctrine_Relation_Association);
-        
+
         $this->assertTrue($component->RTC3 instanceof Doctrine_Collection);
     }
 
@@ -102,7 +102,7 @@ class Doctrine_Relation_ManyToMany_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
         $this->assertTrue($rel instanceof Doctrine_Relation_Association);
-        
+
         $this->assertTrue($component->RTC1 instanceof Doctrine_Collection);
     }
 
@@ -117,7 +117,7 @@ class Doctrine_Relation_ManyToMany_TestCase extends Doctrine_UnitTestCase
             $this->fail();
         }
         $this->assertTrue($rel instanceof Doctrine_Relation_Association);
-        
+
         $this->assertTrue($component->RTC1 instanceof Doctrine_Collection);
     }
 
@@ -129,17 +129,17 @@ class Doctrine_Relation_ManyToMany_TestCase extends Doctrine_UnitTestCase
         $component->RTC1[0]->name = '1';
         $component->RTC1[1]->name = '2';
         $component->name          = '2';
-        
+
         $count = $this->connection->count();
 
         $component->save();
 
         $this->assertEqual($this->connection->count(), ($count + 5));
-        
+
         $this->assertEqual($component->RTC1->count(), 2);
-        
+
         $component = $component->getTable()->find($component->id);
-        
+
         $this->assertEqual($component->RTC1->count(), 2);
 
         // check that it doesn't matter saving the other M2M components as well
@@ -167,15 +167,15 @@ class Doctrine_Relation_ManyToMany_TestCase extends Doctrine_UnitTestCase
         $component->RTC2[0]->name = '1';
         $component->RTC2[1]->name = '2';
         $component->name          = '2';
-        
+
         $count = $this->connection->count();
 
         $component->save();
 
         $this->assertEqual($this->connection->count(), ($count + 5));
-        
+
         $this->assertEqual($component->RTC2->count(), 2);
-        
+
         $component = $component->getTable()->find($component->id);
 
         $this->assertEqual($component->RTC2->count(), 2);
@@ -190,24 +190,24 @@ class Doctrine_Relation_ManyToMany_TestCase extends Doctrine_UnitTestCase
         $component->save();
 
         $this->assertEqual($this->connection->count(), ($count + 3));
-        
+
         $this->assertEqual($component->RTC1->count(), 2);
-        
+
         $component = $component->getTable()->find($component->id);
-        
+
         $this->assertEqual($component->RTC1->count(), 2);
     }
-    
+
     public function testManyToManySimpleUpdate()
     {
         $component = $this->connection->getTable('M2MTest')->find(1);
-        
+
         $this->assertEqual($component->name, 2);
-        
+
         $component->name = 'changed name';
-        
+
         $component->save();
-        
+
         $this->assertEqual($component->name, 'changed name');
     }
 }

--- a/tests/Relation/NestTestCase.php
+++ b/tests/Relation/NestTestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Relation_Nest_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('NestTest', 'NestReference', 'Entity', 'EntityReference');
-        
+
         parent::prepareTables();
     }
 
@@ -53,10 +53,10 @@ class Doctrine_Relation_Nest_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($e->Entity[0]->state(), Doctrine_Record::STATE_TCLEAN);
         $this->assertEqual($e->Entity[1]->state(), Doctrine_Record::STATE_TCLEAN);
-        
+
         $e->Entity[0]->name = 'Friend 1';
         $e->Entity[1]->name = 'Friend 2';
-        
+
         $e->Entity[0]->Entity[0]->name = 'Friend 1 1';
         $e->Entity[0]->Entity[1]->name = 'Friend 1 2';
 
@@ -91,7 +91,7 @@ class Doctrine_Relation_Nest_TestCase extends Doctrine_UnitTestCase
 
         $this->assertTrue($e->Entity[0] instanceof Entity);
         $this->assertTrue($e->Entity[1] instanceof Entity);
-        
+
         $this->assertEqual($e->Entity[0]->name, 'Friend 1');
         $this->assertEqual($e->Entity[1]->name, 'Friend 2');
 
@@ -147,13 +147,13 @@ class Doctrine_Relation_Nest_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($e->Entity[0]->state(), Doctrine_Record::STATE_CLEAN);
         $this->assertEqual($e->Entity[1]->state(), Doctrine_Record::STATE_CLEAN);
-        
+
         $coll = $this->connection->query("FROM Entity WHERE Entity.name = 'Friend 1'");
         $this->assertEqual($coll->count(), 1);
         $this->assertEqual($coll[0]->state(), Doctrine_Record::STATE_CLEAN);
-        
+
         $this->assertEqual($coll[0]->name, 'Friend 1');
-        
+
         $query = new Doctrine_Query($this->connection);
 
         $query->from('Entity e LEFT JOIN e.Entity e2')->where("e2.name = 'Friend 1 1'");
@@ -166,11 +166,11 @@ class Doctrine_Relation_Nest_TestCase extends Doctrine_UnitTestCase
     public function testNestRelationsParsing()
     {
         $nest = new NestTest();
-        
+
         $rel = $nest->getTable()->getRelation('Parents');
 
         $this->assertTrue($rel instanceof Doctrine_Relation_Nest);
-        
+
         $this->assertEqual($rel->getLocal(), 'child_id');
         $this->assertEqual($rel->getForeign(), 'parent_id');
     }
@@ -188,19 +188,19 @@ class Doctrine_Relation_Nest_TestCase extends Doctrine_UnitTestCase
         $nest->Children[1]->name              = 'c 2';
         $nest->Children[1]->Parents[]->name   = 'n 2';
         $nest->save();
-        
+
         $this->connection->clear();
     }
 
     public function testNestRelationsLoading()
     {
         $nest = $this->conn->queryOne('FROM NestTest n WHERE n.id = 1');
-        
+
         $this->assertEqual($nest->Parents->count(), 3);
         $this->assertEqual($nest->Children->count(), 2);
         $this->assertEqual($nest->Children[0]->Children->count(), 2);
         $this->assertEqual($nest->Children[1]->Parents->count(), 2);
-        
+
         $this->connection->clear();
     }
 

--- a/tests/Relation/OneToManyTestCase.php
+++ b/tests/Relation/OneToManyTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_Relation_OneToMany_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('Entity', 'Phonenumber', 'Email', 'Policy', 'PolicyAsset', 'Role', 'Auth');
-        
+
         parent::prepareTables();
     }
     public function testRelationParsing()
@@ -75,13 +75,13 @@ class Doctrine_Relation_OneToMany_TestCase extends Doctrine_UnitTestCase
     {
         $p                = new Policy();
         $p->policy_number = '123';
-        
+
         $a        = new PolicyAsset();
         $a->value = '123.13';
 
         $p->PolicyAssets[] = $a;
         $p->save();
-        
+
         $this->assertEqual($a->policy_number, '123');
     }
     public function testRelationSaving2()
@@ -89,7 +89,7 @@ class Doctrine_Relation_OneToMany_TestCase extends Doctrine_UnitTestCase
         $e       = new Entity();
         $e->name = 'test';
         $e->save();
-         
+
         $nr              = new Phonenumber();
         $nr->phonenumber = '1234556';
         $nr->save();
@@ -102,14 +102,14 @@ class Doctrine_Relation_OneToMany_TestCase extends Doctrine_UnitTestCase
         $role       = new Role();
         $role->name = 'role1';
         $role->save();
-     
+
         $auth       = new Auth();
         $auth->name = 'auth1';
         $auth->Role = $role;
         $auth->save();
-        
+
         $this->conn->commit();
-     
+
         $this->conn->clear();
 
         $auths = $this->conn->query('FROM Auth a LEFT JOIN a.Role r');

--- a/tests/Relation/OneToOneTestCase.php
+++ b/tests/Relation/OneToOneTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_Relation_OneToOne_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('gnatUser','gnatEmail','Email','Entity','Record_City', 'Record_Country', 'SelfRefTest');
-        
+
         parent::prepareTables();
     }
 
@@ -49,25 +49,25 @@ class Doctrine_Relation_OneToOne_TestCase extends Doctrine_UnitTestCase
 
         $this->assertTrue($country instanceof Record_Country);
     }
-    
+
     public function testSelfReferentialOneToOneRelationsAreSupported()
     {
         $ref = new SelfRefTest();
-        
+
         $rel = $ref->getTable()->getRelation('createdBy');
 
         $this->assertEqual($rel->getForeign(), 'id');
         $this->assertEqual($rel->getLocal(), 'created_by');
-        
+
         $ref->name            = 'ref 1';
         $ref->createdBy->name = 'ref 2';
-        
+
         $ref->save();
     }
     public function testSelfReferentialOneToOneRelationsAreSupported2()
     {
         $this->connection->clear();
-        
+
         $ref = $this->conn->queryOne("FROM SelfRefTest s WHERE s.name = 'ref 1'");
         $this->assertEqual($ref->name, 'ref 1');
         $this->assertEqual($ref->createdBy->name, 'ref 2');

--- a/tests/Relation/ParserTestCase.php
+++ b/tests/Relation/ParserTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Relation_Parser_TestCase extends Doctrine_UnitTestCase
     public function testPendingRelations()
     {
         $r = new Doctrine_Relation_Parser($this->conn->getTable('User'));
-        
+
         $p = array('type'  => Doctrine_Relation::ONE,
                    'local' => 'email_id');
 
@@ -151,7 +151,7 @@ class Doctrine_Relation_Parser_TestCase extends Doctrine_UnitTestCase
         $r->bind('Email', $p);
 
         $rel = $r->getRelation('Email');
-        
+
         $this->assertTrue($rel instanceof Doctrine_Relation_LocalKey);
     }
     public function testGetRelationReturnsForeignKeyObjectForOneToManyRelation()
@@ -174,7 +174,7 @@ class Doctrine_Relation_Parser_TestCase extends Doctrine_UnitTestCase
         $r->bind('Group', $p);
 
         $rel = $r->getRelation('Group');
-        
+
         $this->assertTrue($rel instanceof Doctrine_Relation_Association);
         $rel = $r->getRelation('GroupUser');
         $this->assertTrue($rel instanceof Doctrine_Relation_ForeignKey);
@@ -195,6 +195,6 @@ class Doctrine_Relation_Parser_TestCase extends Doctrine_UnitTestCase
         $rel = $r->getRelation('EntityReference');
         $this->assertTrue($rel instanceof Doctrine_Relation_ForeignKey);
     }
-    
+
     // TODO: BETTER ASSOCIATION TABLE GUESSING
 }

--- a/tests/RelationTestCase.php
+++ b/tests/RelationTestCase.php
@@ -38,42 +38,42 @@ class Doctrine_Relation_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('RelationTest', 'RelationTestChild', 'Group', 'Groupuser', 'User', 'Email', 'Account', 'Phonenumber');
-        
+
         parent::prepareTables();
     }
 
     public function testInitData()
     {
         $user = new User();
-        
+
         $user->name           = 'zYne';
         $user->Group[0]->name = 'Some Group';
         $user->Group[1]->name = 'Other Group';
         $user->Group[2]->name = 'Third Group';
-        
+
         $user->Phonenumber[0]->phonenumber = '123 123';
         $user->Phonenumber[1]->phonenumber = '234 234';
         $user->Phonenumber[2]->phonenumber = '456 456';
-        
+
         $user->Email->address = 'someone@some.where';
 
         $user->save();
     }
-    
+
     public function testUnlinkSupportsManyToManyRelations()
     {
         $users = Doctrine_Query::create()->from('User u')->where('u.name = ?', array('zYne'))->execute();
-        
+
         $user = $users[0];
-        
+
         $this->assertEqual($user->Group->count(), 3);
-        
+
         $user->unlink('Group', array(2, 3, 4), true);
-        
+
         $this->assertEqual($user->Group->count(), 0);
-        
+
         $this->conn->clear();
-        
+
         $groups = Doctrine_Query::create()->from('Group g')->execute();
 
         $this->assertEqual($groups->count(), 3);
@@ -88,17 +88,17 @@ class Doctrine_Relation_TestCase extends Doctrine_UnitTestCase
         $this->conn->clear();
 
         $users = Doctrine_Query::create()->from('User u')->where('u.name = ?', array('zYne'))->execute();
-        
+
         $user = $users[0];
-        
+
         $this->assertEqual($user->Phonenumber->count(), 3);
-        
+
         $user->unlink('Phonenumber', array(1, 2, 3), true);
-        
+
         $this->assertEqual($user->Phonenumber->count(), 0);
-        
+
         $this->conn->clear();
-        
+
         $phonenumber = Doctrine_Query::create()->from('Phonenumber p')->execute();
 
         $this->assertEqual($phonenumber->count(), 3);
@@ -127,7 +127,7 @@ class Doctrine_Relation_TestCase extends Doctrine_UnitTestCase
     public function testOneToOneTreeRelationWithConcreteInheritance()
     {
         $component = new RelationTestChild();
-        
+
         try {
             $rel = $component->getTable()->getRelation('Parent');
             $this->pass();
@@ -139,7 +139,7 @@ class Doctrine_Relation_TestCase extends Doctrine_UnitTestCase
     public function testManyToManyRelation()
     {
         $user = new User();
-         
+
         // test that join table relations can be initialized even before the association have been initialized
         try {
             $user->Groupuser;
@@ -153,19 +153,19 @@ class Doctrine_Relation_TestCase extends Doctrine_UnitTestCase
     public function testOneToOneLocalKeyRelation()
     {
         $user = new User();
-        
+
         $this->assertTrue($user->getTable()->getRelation('Email') instanceof Doctrine_Relation_LocalKey);
     }
     public function testOneToOneForeignKeyRelation()
     {
         $user = new User();
-        
+
         $this->assertTrue($user->getTable()->getRelation('Account') instanceof Doctrine_Relation_ForeignKey);
     }
     public function testOneToManyForeignKeyRelation()
     {
         $user = new User();
-        
+
         $this->assertTrue($user->getTable()->getRelation('Phonenumber') instanceof Doctrine_Relation_ForeignKey);
     }
 }

--- a/tests/Search/FileTestCase.php
+++ b/tests/Search/FileTestCase.php
@@ -51,7 +51,7 @@ class Doctrine_Search_File_TestCase extends Doctrine_UnitTestCase
         $this->_search->indexDirectory(dirname(__FILE__) . DIRECTORY_SEPARATOR . '_files');
 
         $resultSet = $this->_search->search('dbms');
-        
+
         $this->assertEqual(count($resultSet), 1);
     }
 }

--- a/tests/Search/IndexerTestCase.php
+++ b/tests/Search/IndexerTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_Search_Indexer_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('Doctrine_File', 'Doctrine_File_Index');
-        
+
         parent::prepareTables();
     }
 
@@ -51,7 +51,7 @@ class Doctrine_Search_Indexer_TestCase extends Doctrine_UnitTestCase
 
         $indexer->indexDirectory(dirname(__FILE__) . DIRECTORY_SEPARATOR . '_files');
     }
-    
+
     public function testIndexerAddsFiles()
     {
         $files = Doctrine_Query::create()->from('Doctrine_File')->execute();

--- a/tests/Search/QueryWeightTestCase.php
+++ b/tests/Search/QueryWeightTestCase.php
@@ -52,7 +52,7 @@ class Doctrine_Search_QueryWeight_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($q->getSqlQuery(), $sql);
     }
-    
+
     public function testSearchSupportsMixingOfOperatorsParenthesisAndWeights()
     {
         $q = new Doctrine_Search_Query('SearchTestIndex');
@@ -123,7 +123,7 @@ class Doctrine_Search_QueryWeight_TestCase extends Doctrine_UnitTestCase
                             )
                 GROUP BY foreign_id
                 ORDER BY relevancy_sum";
-                
+
         $this->assertEqual($q->getSqlQuery(), $sql);
     }
 }

--- a/tests/SearchTestCase.php
+++ b/tests/SearchTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Search_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('SearchTest');
-        
+
         parent::prepareTables();
     }
     public function prepareData()
@@ -45,9 +45,9 @@ class Doctrine_Search_TestCase extends Doctrine_UnitTestCase
     public function testBuildingOfSearchRecordDefinition()
     {
         $e = new SearchTest();
-        
+
         $this->assertTrue($e->SearchTestIndex instanceof Doctrine_Collection);
-        
+
         $rel = $e->getTable()->getRelation('SearchTestIndex');
 
         $this->assertIdentical($rel->getLocal(), 'id');
@@ -106,7 +106,7 @@ class Doctrine_Search_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($array[0]['title'], '007');
     }
-    
+
     public function testUsingWordRange()
     {
         $q = new Doctrine_Query();
@@ -159,7 +159,7 @@ class Doctrine_Search_TestCase extends Doctrine_UnitTestCase
         $e->content = 'Some searchable content';
 
         $e->save();
-        
+
         $coll = Doctrine_Query::create()
                 ->from('SearchTestIndex s')
                 ->orderby('s.id DESC')
@@ -177,7 +177,7 @@ class Doctrine_Search_TestCase extends Doctrine_UnitTestCase
     {
         $e = new SearchTest();
         $e->batchUpdateIndex();
-        
+
         $coll = Doctrine_Query::create()
                 ->from('SearchTestIndex s')
                 ->setHydrationMode(Doctrine_Core::HYDRATE_ARRAY)
@@ -212,7 +212,7 @@ class Doctrine_Search_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($words[2], 'ca');
         $this->assertEqual($words[4], 'enormement');
     }
-    
+
     public function testUtf8AnalyzerWorks()
     {
         $analyzer = new Doctrine_Search_Analyzer_Utf8(array('encoding' => 'utf-8'));
@@ -222,7 +222,7 @@ class Doctrine_Search_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($words[2], 'ça');
         $this->assertEqual($words[4], 'énormément');
     }
- 
+
     public function testUtf8AnalyzerKnowsToHandleOtherEncodingsWorks()
     {
         $analyzer = new Doctrine_Search_Analyzer_Utf8();

--- a/tests/Sequence/MysqlTestCase.php
+++ b/tests/Sequence/MysqlTestCase.php
@@ -41,7 +41,7 @@ class Doctrine_Sequence_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testNextIdExecutesSql()
     {
         $id = $this->sequence->nextId('user');
-        
+
         $this->assertEqual($id, 1);
 
         $this->assertEqual($this->adapter->pop(), 'DELETE FROM user WHERE id < 1');
@@ -51,7 +51,7 @@ class Doctrine_Sequence_Mysql_TestCase extends Doctrine_UnitTestCase
     public function testLastInsertIdCallsPdoLevelEquivalent()
     {
         $id = $this->sequence->lastInsertId('user');
-        
+
         $this->assertEqual($id, 1);
 
         $this->assertEqual($this->adapter->pop(), 'LAST_INSERT_ID()');

--- a/tests/Sequence/OracleTestCase.php
+++ b/tests/Sequence/OracleTestCase.php
@@ -48,7 +48,7 @@ class Doctrine_Sequence_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testLastInsertIdExecutesSql()
     {
         $this->sequence->lastInsertId('user');
-        
+
         $this->assertEqual($this->adapter->pop(), 'SELECT user_seq.currval FROM DUAL');
     }
 }

--- a/tests/Sequence/PgsqlTestCase.php
+++ b/tests/Sequence/PgsqlTestCase.php
@@ -48,7 +48,7 @@ class Doctrine_Sequence_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testLastInsertIdExecutesSql()
     {
         $this->sequence->lastInsertId('user');
-        
+
         $this->assertEqual($this->adapter->pop(), "SELECT CURRVAL('user_seq')");
     }
 }

--- a/tests/Sequence/SqliteTestCase.php
+++ b/tests/Sequence/SqliteTestCase.php
@@ -43,7 +43,7 @@ class Doctrine_Sequence_Sqlite_TestCase extends Doctrine_UnitTestCase
     public function testNextIdExecutesSql()
     {
         $id = $this->sequence->nextId('user');
-        
+
         $this->assertEqual($id, 1);
 
         $this->assertEqual($this->adapter->pop(), 'DELETE FROM user_seq WHERE id < 1');
@@ -53,7 +53,7 @@ class Doctrine_Sequence_Sqlite_TestCase extends Doctrine_UnitTestCase
     public function testLastInsertIdCallsPdoLevelEquivalent()
     {
         $id = $this->sequence->lastInsertId('user');
-        
+
         $this->assertEqual($id, 1);
 
         $this->assertEqual($this->adapter->pop(), 'LAST_INSERT_ID()');

--- a/tests/SequenceTestCase.php
+++ b/tests/SequenceTestCase.php
@@ -44,7 +44,7 @@ class Doctrine_Sequence_TestCase extends Doctrine_UnitTestCase
         $r       = new CustomSequenceRecord;
         $r->name = 'custom seq';
         $r->save();
-        
+
         /**
         // the last profiled event is transaction commit
         $this->assertEqual($this->adapter->pop(), 'COMMIT');

--- a/tests/SluggableTestCase.php
+++ b/tests/SluggableTestCase.php
@@ -31,7 +31,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $item->save();
         $this->assertEqual($item->slug, 'result-of-to-string');
     }
-    
+
     public function testSSluggableWithNoFieldsOptionButGetUniqueSlugMethod()
     {
         $item       = new SluggableItem1();
@@ -56,7 +56,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($index['type'], 'unique');
         $this->assertEqual($index['fields'], array('slug'));
     }
-    
+
     public function testSluggableUniqueSlugOnUpdate()
     {
         parent::prepareTables();
@@ -72,7 +72,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $item->save();
         $this->assertEqual($item->slug, 'New slug');
     }
-    
+
     public function testSluggableWithMultipleFieldsOption()
     {
         parent::prepareTables();
@@ -87,7 +87,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $item->save();
         $this->assertEqual($item->slug, 'my-item-my-ref-1');
     }
-    
+
     public function testSluggableWithFieldsAndNonUniqueOptions()
     {
         parent::prepareTables();
@@ -100,7 +100,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $item->save();
         $this->assertEqual($item->slug, 'my-item');
     }
-    
+
     public function testSluggableWithUniqueByOption()
     {
         parent::prepareTables();
@@ -124,7 +124,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($index['type'], 'unique');
         $this->assertEqual($index['fields'], array('slug', 'user_id'));
     }
-    
+
     public function testSluggableWithUniqueByOptionAndNullValue()
     {
         parent::prepareTables();
@@ -142,7 +142,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $item->save();
         $this->assertEqual($item->slug, 'my-item');
     }
-    
+
     public function testSluggableWithMultipleUniqueByOption()
     {
         parent::prepareTables();
@@ -165,14 +165,14 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $item->save();
         $this->assertEqual($item->slug, 'my-item-1');
     }
-    
+
     public function testSluggableWithFieldsOptionAndNoIndex()
     {
         parent::prepareTables();
         $itemTable = Doctrine_Core::getTable('SluggableItem7');
         $this->assertFalse($itemTable->getIndex('sluggable'));
     }
-    
+
     public function testSluggableUniqueSlugOnUpdateWithOptioncanUpdateSlug()
     {
         parent::prepareTables();
@@ -209,7 +209,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
         $item0->delete(); // muhaha! I don't actually delete it!
 
         // We must have 0 as total of records
-        
+
         $this->assertEqual(Doctrine_Query::create()->from('SluggableItem9')->count(), 0);
 
         $item1       = new SluggableItem9();
@@ -219,7 +219,7 @@ class Doctrine_Sluggable_TestCase extends Doctrine_UnitTestCase
 
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, true);
     }
-    
+
     public function testSluggableWithColumAggregationInheritance()
     {
         parent::prepareTables();
@@ -475,7 +475,7 @@ abstract class SluggableItem10Abstract extends Doctrine_Record
     public function setUp()
     {
         parent::setUp();
-    
+
         $this->actAs('Sluggable', array('unique'  => true,
                                     'uniqueIndex' => true,
                                     'fields'      => array('name'),
@@ -535,11 +535,11 @@ class SluggableItem15 extends Doctrine_Record
         $this->hasColumn('type', 'integer', 1);
         $this->setSubclasses(array('SluggableItem16' => array('type' => 0), 'SluggableItem17' => array('type' => 1)));
     }
- 
+
     public function setUp()
     {
         parent::setUp();
-    
+
         $this->actAs('Sluggable', array('unique'  => true,
                                     'uniqueIndex' => true,
                                     'uniqueBy'    => array('type'),

--- a/tests/SoftDeleteBCTestCase.php
+++ b/tests/SoftDeleteBCTestCase.php
@@ -41,7 +41,7 @@ class Doctrine_SoftDeleteBC_TestCase extends Doctrine_UnitTestCase
     public function testDoctrineRecordDeleteSetsFlag()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, true);
-        
+
         $test            = new SoftDeleteBCTest();
         $test->name      = 'test';
         $test->something = 'test';
@@ -50,14 +50,14 @@ class Doctrine_SoftDeleteBC_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue($test->deleted);
         $test->free();
 
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, false);
     }
 
     public function testDoctrineQueryIsFilteredWithDeleteFlagCondition()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, true);
-        
+
         $q = Doctrine_Query::create()
                     ->from('SoftDeleteBCTest s')
                     ->where('s.name = ?', array('test'));
@@ -69,14 +69,14 @@ class Doctrine_SoftDeleteBC_TestCase extends Doctrine_UnitTestCase
 
         $test = $q->fetchOne();
         $this->assertFalse($test);
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, false);
     }
 
     public function testTicket1132()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, true);
-        
+
         $test            = new SoftDeleteBCTest();
         $test->name      = 'test1';
         $test->something = 'test2';
@@ -91,7 +91,7 @@ class Doctrine_SoftDeleteBC_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($q->getSqlQuery(), 'SELECT s.name AS s__name, s.something AS s__something, s.deleted AS s__deleted FROM soft_delete_bc_test s WHERE (s.name = ? AND s.something = ? AND (s.deleted = 0))');
         $this->assertEqual($q->getFlattenedParams(array('test1', 'test2')), array('test1', 'test2'));
         $this->assertEqual($results->count(), 1);
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, false);
     }
 
@@ -99,7 +99,7 @@ class Doctrine_SoftDeleteBC_TestCase extends Doctrine_UnitTestCase
     public function testTicket1170()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, true);
-        
+
         Doctrine_Query::create()
             ->delete()
             ->from('SoftDeleteBCTest s')

--- a/tests/Table/NamedQueryTestCase.php
+++ b/tests/Table/NamedQueryTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Table_NamedQuery_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('MyFoo');
-        
+
         parent::prepareTables();
     }
 
@@ -56,8 +56,8 @@ class Doctrine_Table_NamedQuery_TestCase extends Doctrine_UnitTestCase
         $f3->value0 = 2;
         $f3->save();
     }
-    
-    
+
+
     public function testNamedQuerySupport()
     {
         $table = Doctrine_Core::getTable('MyFoo');
@@ -66,16 +66,16 @@ class Doctrine_Table_NamedQuery_TestCase extends Doctrine_UnitTestCase
             $table->createNamedQuery('get.by.id')->getSqlQuery(),
             'SELECT m.id AS m__id, m.name AS m__name, m.value0 AS m__value0 FROM my_foo m WHERE (m.id = ?)'
         );
-        
+
         $this->assertEqual(
             $table->createNamedQuery('get.by.similar.names')->getSqlQuery(),
             'SELECT m.id AS m__id, m.value0 AS m__value0 FROM my_foo m WHERE (LOWER(m.name) LIKE LOWER(?))'
         );
-        
+
         $this->assertEqual($table->createNamedQuery('get.by.similar.names')->count(array('%jon%wage%')), 2);
-        
+
         $items = $table->find('get.by.similar.names', array('%jon%wage%'));
-        
+
         $this->assertEqual(count($items), 2);
     }
 }

--- a/tests/TableTestCase.php
+++ b/tests/TableTestCase.php
@@ -41,7 +41,7 @@ class Doctrine_Table_TestCase extends Doctrine_UnitTestCase
     public function testInitializingNewTableWorksWithoutConnection()
     {
         $table = new Doctrine_Table('Test', $this->conn);
-        
+
         $this->assertEqual($table->getComponentName(), 'Test');
     }
 
@@ -50,7 +50,7 @@ class Doctrine_Table_TestCase extends Doctrine_UnitTestCase
         $this->dbh->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
 
         $t = new FieldNameTest();
-        
+
         $t->someColumn = 'abc';
         $t->someEnum   = 'php';
         $t->someInt    = 1;
@@ -73,15 +73,15 @@ class Doctrine_Table_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($t->someObject, $obj);
 
         $t->refresh();
-        
+
         $this->assertEqual($t->someColumn, 'abc');
         $this->assertEqual($t->someEnum, 'php');
         $this->assertEqual($t->someInt, 1);
         $this->assertEqual($t->someArray, array());
         $this->assertEqual($t->someObject, $obj);
-        
+
         $this->connection->clear();
-        
+
         $t = $this->connection->getTable('FieldNameTest')->find(1);
 
         $this->assertEqual($t->someColumn, 'abc');
@@ -89,7 +89,7 @@ class Doctrine_Table_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($t->someInt, 1);
         $this->assertEqual($t->someArray, array());
         $this->assertEqual($t->someObject, $obj);
-        
+
         $this->dbh->setAttribute(PDO::ATTR_CASE, PDO::CASE_NATURAL);
     }
 
@@ -155,7 +155,7 @@ class Doctrine_Table_TestCase extends Doctrine_UnitTestCase
     {
         $record = $this->objTable->find(4);
         $this->assertTrue($record instanceof Doctrine_Record);
-        
+
         try {
             $record = $this->objTable->find('4');
             $this->assertTrue($record instanceof Doctrine_Record);

--- a/tests/TemplateTestCase.php
+++ b/tests/TemplateTestCase.php
@@ -49,7 +49,7 @@ class Doctrine_Template_TestCase extends Doctrine_UnitTestCase
             $this->pass();
         }
     }
-    
+
     public function testAccessingExistingImplementationSupportsAssociations()
     {
         $this->manager->setImpl('UserTemplate', 'ConcreteUser')
@@ -94,7 +94,7 @@ class UserTemplate extends Doctrine_Template
         $this->hasMany('EmailTemplate as Email', array('local'   => 'id',
                                                        'foreign' => 'user_id'));
     }
-    
+
     public function foo()
     {
         return 'foo';

--- a/tests/Ticket/1072TestCase.php
+++ b/tests/Ticket/1072TestCase.php
@@ -31,15 +31,15 @@ class Doctrine_Ticket_1072_TestCase extends Doctrine_UnitTestCase
     {
         $bt       = new T1072BankTransaction();
         $bt->name = 'Test Bank Transaction';
-        
+
         // (additional check: value must be NULL)
         $this->assertEqual(gettype($bt->payment_detail_id), gettype(null));
-        
+
         // If I access this relation...
-        
+
         if ($bt->T1072PaymentDetail) {
         }
-        
+
         // (additional check: value must still be NULL not an object)
         // [romanb]: This is expected behavior currently. Accessing a related record will create
         // a new one if there is none yet. This makes it possible to use syntax like:
@@ -48,12 +48,12 @@ class Doctrine_Ticket_1072_TestCase extends Doctrine_UnitTestCase
         // In addition the foreign key field is set to a reference to the new record (ugh..).
         // No way to change this behavior at the moment for BC reasons.
         $this->assertEqual(gettype($bt->payment_detail_id), gettype(null));
-        
+
         // ...save...
         // [romanb]: Related T1072PaymentDetail will not be saved because its not modified
         // (isModified() == false)
         $bt->save();
-        
+
         try {
             // ...and access the relation column it will throw
             // an exception here but it shouldn't.
@@ -61,18 +61,18 @@ class Doctrine_Ticket_1072_TestCase extends Doctrine_UnitTestCase
             // object as before.
             if ($bt->payment_detail_id) {
             }
-            
+
             // (additional check: value must still be NULL not an object)
             // [romanb]: See above. This is an empty object now, same as before.
             $this->assertEqual(gettype($bt->payment_detail_id), gettype(null));
-            
+
             $this->pass();
         } catch (Doctrine_Record_Exception $e) {
             $this->fail($e->getMessage());
         }
     }
-    
-    
+
+
     public function testTicket2()
     {
         $bt       = new T1072BankTransaction();
@@ -88,12 +88,12 @@ class Doctrine_Ticket_1072_TestCase extends Doctrine_UnitTestCase
             $this->assertEqual(gettype($bt->T1072PaymentDetail), 'object');
             $this->assertEqual(gettype($bt->T1072PaymentDetail->name), 'string');
             $this->assertEqual(gettype($bt->payment_detail_id), gettype(null));
-            
+
             $bt->save();
-            
+
             // After the object gets saved, the foreign key is finally set
             $this->assertEqual($bt->payment_detail_id, 1);
-            
+
             $this->pass();
         } catch (Doctrine_Record_Exception $e) {
             $this->fail($e->getMessage());
@@ -110,7 +110,7 @@ class T1072BankTransaction extends Doctrine_Record
         $this->hasColumn('name', 'string', 255, array('notnull' => true));
         $this->option('charset', 'utf8');
     }
-    
+
     public function setUp()
     {
         parent::setUp();
@@ -127,7 +127,7 @@ class T1072PaymentDetail extends Doctrine_Record
         $this->hasColumn('name', 'string', 255, array('notnull' => true));
         $this->option('charset', 'utf8');
     }
-    
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/Ticket/1077TestCase.php
+++ b/tests/Ticket/1077TestCase.php
@@ -60,7 +60,7 @@ class Doctrine_Ticket_1077_TestCase extends Doctrine_UnitTestCase
 
         $numbers            = new Doctrine_Collection('Phonenumber');
         $user->Phonenumbers = $numbers;
-        
+
         $this->assertIdentical($user->phonenumbersTest, $numbers);
 
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE, $orig);

--- a/tests/Ticket/1106TestCase.php
+++ b/tests/Ticket/1106TestCase.php
@@ -36,43 +36,43 @@ class Doctrine_Ticket_1106_TestCase extends Doctrine_UnitTestCase
     {
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $user                 = new User();
         $user->name           = 'John';
         $user->Group[0]->name = 'Original Group';
         $user->save();
-        
+
         $this->user_id = $user['id'];
     }
-    
+
     public function testAfterOriginalSave()
     {
         $user = Doctrine_Query::create()->from('User u, u.Group')->fetchOne();
         $this->assertEqual($user->name, 'John');
         $this->assertEqual($user->Group[0]->name, 'Original Group');
     }
-    
+
     public function testModifyRelatedRecord()
     {
         $user = Doctrine_Query::create()->from('User u, u.Group')->fetchOne();
-        
+
         // Modify Record
         $user->name           = 'Stephen';
         $user->Group[0]->name = 'New Group';
-        
+
         // Test After change and before save
         $this->assertEqual($user->name, 'Stephen');
         $this->assertEqual($user->Group[0]->name, 'New Group');
-        
+
         $user->save();
-        
+
         // Test after save
         $this->assertEqual($user->name, 'Stephen');
         $this->assertEqual($user->Group[0]->name, 'New Group');
     }
-    
+
     public function testQueryAfterSave()
     {
         $user = Doctrine_Core::getTable('User')->find($this->user_id);

--- a/tests/Ticket/1113TestCase.php
+++ b/tests/Ticket/1113TestCase.php
@@ -7,7 +7,7 @@ class Doctrine_Ticket_1113_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('VIH_Model_Course', 'VIH_Model_Course_Period', 'VIH_Model_Course_SubjectGroup', 'VIH_Model_Subject', 'VIH_Model_Course_SubjectGroup_Subject', 'VIH_Model_Course_Registration', 'VIH_Model_Course_Registration_Subject');
-        
+
         parent::prepareTables();
     }
 
@@ -15,35 +15,35 @@ class Doctrine_Ticket_1113_TestCase extends Doctrine_UnitTestCase
     {
         $course1       = new VIH_Model_Course();
         $course1->navn = 'Course 1';
-        
+
         $period1         = new VIH_Model_Course_Period();
         $period1->name   = 'Period 1';
         $period1->Course = $course1;
         $period1->save();
-        
+
         $group1         = new VIH_Model_Course_SubjectGroup();
         $group1->name   = 'SubjectGroup 1';
         $group1->Period = $period1;
-        
+
         $subject1             = new VIH_Model_Subject();
         $subject1->identifier = 'Subject 1';
-        
+
         $subject2             = new VIH_Model_Subject();
         $subject2->identifier = 'Subject 2';
-        
+
         $group1->Subjects[] = $subject1;
         $group1->Subjects[] = $subject2;
-        
+
         $group1->save();
-                
+
         $group1->Subjects[] = $subject1;
         $group1->Subjects[] = $subject2;
         $group1->save();
-        
+
         $course1->SubjectGroups[] = $group1;
-        
+
         $course1->save();
-                
+
         // saved without Subjects
         try {
             $registrar         = new VIH_Model_Course_Registration();
@@ -63,7 +63,7 @@ class Doctrine_Ticket_1113_TestCase extends Doctrine_UnitTestCase
         }
 
         $reopend->save();
-      
+
         try {
             $subject = $reopend->Subjects[0];
             $this->assertTrue(is_object($subject));

--- a/tests/Ticket/1124TestCase.php
+++ b/tests/Ticket/1124TestCase.php
@@ -51,7 +51,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneBysomethingElse(self::SOMETHING_ELSE);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {
@@ -63,7 +63,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneBydisjoint_alias(self::SOMETHING_ELSE);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {
@@ -75,7 +75,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneByDisjointAlias(self::SOMETHING_ELSE);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {
@@ -87,7 +87,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneBytableizedAlias(self::TABLEIZED_ALIAS);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {
@@ -99,7 +99,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneBytableized_alias(self::TABLEIZED_ALIAS);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {
@@ -111,7 +111,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneByClassifiedAlias(self::CLASSIFIED_ALIAS);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {
@@ -123,7 +123,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneByTest(self::ANOTHER_ALIAS);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {
@@ -135,7 +135,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneBytest(self::ANOTHER_ALIAS);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {
@@ -147,7 +147,7 @@ class Doctrine_Ticket_1124_TestCase extends Doctrine_UnitTestCase
     {
         try {
             $r = Doctrine_Core::getTable('Ticket_1124_Record')->findOneByanother_Alias(self::ANOTHER_ALIAS);	// test currently fails
-        
+
             $this->assertIsSampleRecord($r);
             $this->pass();
         } catch (Exception $e) {

--- a/tests/Ticket/1131TestCase.php
+++ b/tests/Ticket/1131TestCase.php
@@ -40,24 +40,24 @@ class Doctrine_Ticket_1131_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1131_Role';
         parent::prepareTables();
     }
-    
-    
+
+
     public function prepareData()
     {
         parent::prepareData();
-        
+
         $role       = new Ticket_1131_Role();
         $role->name = 'Role One';
         $role->save();
         $this->role_one = $role->id;
         $role->free();
-        
+
         $role       = new Ticket_1131_Role();
         $role->name = 'Role Two';
         $role->save();
         $this->role_two = $role->id;
         $role->free();
-        
+
         $group          = new Ticket_1131_Group();
         $group->role_id = $this->role_one;
         $group->name    = 'Core Dev';
@@ -82,25 +82,25 @@ class Doctrine_Ticket_1131_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($user->Group->id, 1);
         $this->assertFalse($user->get('group_id') instanceof Doctrine_Record);
     }
-    
+
     public function testTicketWithOverloadingAndTwoQueries()
     {
         $orig = Doctrine_Manager::getInstance()->getAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE);
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE, true);
-        
+
         $user = Doctrine_Query::create()
             ->from('Ticket_1131_User u')
             ->where('u.id = ?')->fetchOne(array(1));
-        
+
         $user = Doctrine_Query::create()
             ->from('Ticket_1131_UserWithOverloading u')
             ->leftJoin('u.Group g')
             ->leftJoin('u.Role r')
             ->addWhere('u.id = ?')->fetchOne(array(1));
-        
+
         $this->assertEqual($user->Role->id, 1);
         $this->assertFalse($user->role_id instanceof Doctrine_Record);
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE, $orig);
     }
 }
@@ -124,7 +124,7 @@ class Ticket_1131_User extends Doctrine_Record
             'local'   => 'group_id',
             'foreign' => 'id'
         ));
-        
+
         $this->hasOne('Ticket_1131_Role as Role', array(
             'local'   => 'role_id',
             'foreign' => 'id'));
@@ -137,7 +137,7 @@ class Ticket_1131_UserWithOverloading extends Ticket_1131_User
     {
         return $this->Group->Role;
     }
-    
+
     public function getRoleId()
     {
         return $this->Group->role_id;
@@ -159,7 +159,7 @@ class Ticket_1131_Group extends Doctrine_Record
         $this->hasOne('Ticket_1131_Role as Role', array(
             'local'   => 'role_id',
             'foreign' => 'id'));
-        
+
         $this->hasMany('Ticket_1131_User as Users', array(
             'local'   => 'id',
             'foreign' => 'group_id'

--- a/tests/Ticket/1175TestCase.php
+++ b/tests/Ticket/1175TestCase.php
@@ -31,7 +31,7 @@ class Doctrine_Ticket_1175_TestCase extends Doctrine_UnitTestCase
         $img           = new gUserImage();
         $img->filename = 'user image 1';
         $u->Images[]   = $img;
-        
+
         $img           = new gUserImage();
         $img->filename = 'user image 2';
         $u->Images[]   = $img;
@@ -55,9 +55,9 @@ class Doctrine_Ticket_1175_TestCase extends Doctrine_UnitTestCase
                     ->leftJoin('u.Images i')
                     ->leftJoin('u.Files f')
                     ->where('u.id = ?', array(1));
-   
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT g.id AS g__id, g.first_name AS g__first_name, g.last_name AS g__last_name, g2.id AS g2__id, g2.owner_id AS g2__owner_id, g2.filename AS g2__filename, g2.otype AS g2__otype, g3.id AS g3__id, g3.owner_id AS g3__owner_id, g3.filename AS g3__filename, g3.otype AS g3__otype FROM g_user g LEFT JOIN g_image g2 ON g.id = g2.owner_id AND g2.otype = 1 LEFT JOIN g_file g3 ON g.id = g3.owner_id AND g3.otype = 1 WHERE (g.id = ?)');
-     
+
         $u = $q->fetchOne();
 
         $this->assertTrue(is_object($u));

--- a/tests/Ticket/1205TestCase.php
+++ b/tests/Ticket/1205TestCase.php
@@ -8,21 +8,21 @@ class Doctrine_Ticket_1205_TestCase extends Doctrine_UnitTestCase
         $user->first_name = 'Slick';
         $user->last_name  = 'Rick';
         $user->save();
-  
+
         $address          = new Ticket1205TestAddress();
         $address->id      = 1;
         $address->user_id = 1;
         $address->city    = 'Anywhere';
         $address->save();
     }
-    
+
     public function prepareTables()
     {
         $this->tables[] = 'Ticket1205TestUser';
         $this->tables[] = 'Ticket1205TestAddress';
         parent::prepareTables();
     }
-    
+
     public function testTicket()
     {
         try {

--- a/tests/Ticket/1225TestCase.php
+++ b/tests/Ticket/1225TestCase.php
@@ -6,7 +6,7 @@ class Doctrine_Ticket_1225_TestCase extends Doctrine_UnitTestCase
         $this->tables = array('Ticket_1225_Tree');
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }

--- a/tests/Ticket/1228TestCase.php
+++ b/tests/Ticket/1228TestCase.php
@@ -48,7 +48,7 @@ class Doctrine_Ticket_1228_TestCase extends Doctrine_UnitTestCase
         $e1       = new RelE();
         $e1->name = 'e 1';
         $e1->save();
-        
+
         $d1           = new RelD();
         $d1->name     = 'd 1';
         $d1->rel_e_id = $e1->id;
@@ -117,9 +117,9 @@ class Doctrine_Ticket_1228_TestCase extends Doctrine_UnitTestCase
         $q->orderBy('a.id ASC');
         $res = $q->execute();
         //$res = $q->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
-        
+
         //var_dump($res/*->toArray(true)*/);
-        
+
         $this->assertEqual('a 1', $res->getFirst()->get('name'));
         $this->assertTrue($res->getFirst()->get('b')->exists());
         $this->assertTrue($res->getFirst()->get('b')->get('c')->exists());
@@ -135,15 +135,15 @@ class Doctrine_Ticket_1228_TestCase extends Doctrine_UnitTestCase
         $q->orderBy('a.id ASC');
         $res = $q->execute();
         //$res = $q->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
-        
+
         //var_dump($res/*->toArray(true)*/);
-        
+
         $this->assertEqual('a 1', $res->getFirst()->get('name'));
         $this->assertTrue($res->getFirst()->get('b')->exists());
         $this->assertTrue($res->getFirst()->get('b')->get('c')->exists());
         $this->assertTrue($res->getFirst()->get('b')->get('c')->get('d')->exists());
     }
-    
+
     public function testHydrationSkippingRelationIfNotSetOnSiblingDepth5()
     {
         $q = new Doctrine_Query();
@@ -155,9 +155,9 @@ class Doctrine_Ticket_1228_TestCase extends Doctrine_UnitTestCase
         $q->orderBy('a.id ASC');
         $res = $q->execute();
         //$res = $q->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
-        
+
         //var_dump($res/*->toArray(true)*/);
-        
+
         $this->assertEqual('a 1', $res->getFirst()->get('name'));
         $this->assertTrue($res->getFirst()->get('b')->exists());
         $this->assertTrue($res->getFirst()->get('b')->get('c')->exists());

--- a/tests/Ticket/1250TestCase.php
+++ b/tests/Ticket/1250TestCase.php
@@ -36,7 +36,7 @@ class Doctrine_Ticket_1250_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Doctrine_Ticket_1250_i18n';
         parent::prepareTables();
     }
-  
+
     public function testTicket()
     {
         try {
@@ -52,7 +52,7 @@ class Doctrine_Ticket_1250_TestCase extends Doctrine_UnitTestCase
         } catch (Exception $e) {
             $this->fail($e->getMessage());
         }
-      
+
         $this->assertEqual(1, $r->id);
     }
 }

--- a/tests/Ticket/1251TestCase.php
+++ b/tests/Ticket/1251TestCase.php
@@ -37,14 +37,14 @@ class Doctrine_Ticket_1251_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1251_Record';
         parent::prepareTables();
     }
-    
-    
+
+
     public function testAccessDataNamedField()
     {
         $t       = new Ticket_1251_Record();
         $t->data = 'Foo';
         $t->save();
-        
+
         $this->assertEqual($t->data, 'Foo');
     }
 }

--- a/tests/Ticket/1254TestCase.php
+++ b/tests/Ticket/1254TestCase.php
@@ -53,7 +53,7 @@ class Doctrine_Ticket_1254_TestCase extends Doctrine_UnitTestCase
             $x->category = $cats[$i % 2];
             $x->set('created_at', strftime('%Y-%m-%d %H:%M:%S', $age));
             $x->save();
-        
+
             for ($j = 0; $j < 10; $j++) {
                 $y           = new RelY();
                 $y->name     = 'y ' . ($i * 10 + $j);
@@ -61,7 +61,7 @@ class Doctrine_Ticket_1254_TestCase extends Doctrine_UnitTestCase
                 $y->save();
             }
         }
-        
+
         Doctrine_Manager::getInstance()->getCurrentConnection()->commit();
     }
 

--- a/tests/Ticket/1277TestCase.php
+++ b/tests/Ticket/1277TestCase.php
@@ -44,7 +44,7 @@ class Doctrine_Ticket_1277_TestCase extends Doctrine_UnitTestCase
         $user1->username = 'User1';
         $user1->email    = null;
         $user1->save();
-         
+
         $user2           = new T1277_User();
         $user2->username = 'User2';
         $user2->email    = 'some@email';
@@ -58,30 +58,30 @@ class Doctrine_Ticket_1277_TestCase extends Doctrine_UnitTestCase
     public function testTicket()
     {
         $this->conn->getTable('T1277_User')->clear(); // clear identity map
-        
+
         $q = new Doctrine_Query();
         $u = $q->select('u.id')->from('T1277_User u')->where('u.id=1')->fetchOne();
 
         $this->assertEqual(1, $u->id);
         $this->assertEqual(Doctrine_Record::STATE_PROXY, $u->state());
-        
+
         // In some other part of code I will query this table again and start making modifications to found records:
         $q     = new Doctrine_Query();
         $users = $q->select('u.*')->from('T1277_User u')->execute();
-        
+
         $this->assertEqual(2, count($users));
 
         foreach ($users as $u) {
             $this->assertEqual(Doctrine_Record::STATE_CLEAN, $u->state());
-            
+
             $u->username = 'new username' . $u->id;
             $u->email    = 'some' . $u->id . '@email';
-            
+
             $this->assertEqual('new username' . $u->id, $u->username);
             $this->assertEqual('some' . $u->id . '@email', $u->email);
         }
     }
-    
+
     /**
      * Tests that:
      * 1) a record in PROXY state is still in PROXY state when he is queries again but not with all props
@@ -92,32 +92,32 @@ class Doctrine_Ticket_1277_TestCase extends Doctrine_UnitTestCase
     public function testTicket2()
     {
         $this->conn->getTable('T1277_User')->clear(); // clear identity map
-        
+
         $q = new Doctrine_Query();
         $u = $q->select('u.id')->from('T1277_User u')->where('u.id=1')->fetchOne();
 
         $this->assertEqual(1, $u->id);
         $this->assertEqual(Doctrine_Record::STATE_PROXY, $u->state());
-        
+
         // In some other part of code I will query this table again and start making modifications to found records:
         $q     = new Doctrine_Query();
         $users = $q->select('u.id, u.username')->from('T1277_User u')->execute();
-        
+
         $this->assertEqual(2, count($users));
 
         foreach ($users as $u) {
             $this->assertEqual(Doctrine_Record::STATE_PROXY, $u->state());
-            
+
             $u->username = 'new username' . $u->id; // modify
             $u->email    = 'some' . $u->id . '@email'; // triggers load() to fill uninitialized props
-            
+
             $this->assertEqual('new username' . $u->id, $u->username);
             $this->assertEqual('some' . $u->id . '@email', $u->email);
-            
+
             $this->assertEqual(Doctrine_Record::STATE_DIRTY, $u->state());
         }
     }
-    
+
     /**
      * Tests that:
      * 1) a record in PROXY state is still in PROXY state when he is queries again but not with all props
@@ -127,13 +127,13 @@ class Doctrine_Ticket_1277_TestCase extends Doctrine_UnitTestCase
     public function testTicket3()
     {
         $this->conn->getTable('T1277_User')->clear(); // clear identity map
-        
+
         $q = new Doctrine_Query();
         $u = $q->select('u.id')->from('T1277_User u')->where('u.id=1')->fetchOne();
 
         $this->assertEqual(1, $u->id);
         $this->assertEqual(Doctrine_Record::STATE_PROXY, $u->state());
-        
+
         // In some other part of code I will query this table again and start making modifications to found records:
         $q     = new Doctrine_Query();
         $users = $q->select('u.id, u.username')->from('T1277_User u')->execute();
@@ -142,7 +142,7 @@ class Doctrine_Ticket_1277_TestCase extends Doctrine_UnitTestCase
 
         foreach ($users as $u) {
             $this->assertEqual(Doctrine_Record::STATE_PROXY, $u->state());
-            
+
             if ($u->id == 1) {
                 $this->assertEqual('User1', $u->username);
                 $u->email; // triggers load()
@@ -150,11 +150,11 @@ class Doctrine_Ticket_1277_TestCase extends Doctrine_UnitTestCase
                 $this->assertEqual('User2', $u->username);
                 $this->assertEqual('some@email', $u->email);
             }
-            
+
             $this->assertEqual(Doctrine_Record::STATE_CLEAN, $u->state());
         }
     }
-    
+
     /**
      * Fails due to the PROXY concept being flawed by design.
      *

--- a/tests/Ticket/1280TestCase.php
+++ b/tests/Ticket/1280TestCase.php
@@ -52,11 +52,11 @@ class Doctrine_Ticket_1280_TestCase extends Doctrine_UnitTestCase
         $user->save();
 
         $this->assertEqual($user->group_id, $group->id);
-        
+
         try {
             $user->Group = null;
             $user->save();
-            
+
             $this->assertEqual($user->group_id, null);
 
             $this->pass();

--- a/tests/Ticket/1296TestCase.php
+++ b/tests/Ticket/1296TestCase.php
@@ -37,7 +37,7 @@ class Doctrine_Ticket_1296_TestCase extends Doctrine_UnitTestCase
         $org->name = 'Inc.';
         $org->save();
     }
-    
+
     public function prepareTables()
     {
         $this->tables = array(
@@ -46,7 +46,7 @@ class Doctrine_Ticket_1296_TestCase extends Doctrine_UnitTestCase
                 );
         parent::prepareTables();
     }
-    
+
     public function testAddDuplicateOrganisation()
     {
         $this->assertEqual(0, $this->conn->transaction->getTransactionLevel());
@@ -56,10 +56,10 @@ class Doctrine_Ticket_1296_TestCase extends Doctrine_UnitTestCase
         } catch (Exception $e) {
             $this->fail('Transaction failed to start.');
         }
-        
+
         $this->assertEqual(1, $this->conn->transaction->getTransactionLevel());
         $this->assertEqual(0, $this->conn->transaction->getInternalTransactionLevel());
-        
+
         $org       = new NewTicket_Organization();
         $org->name = 'Inc.';
         try {
@@ -70,10 +70,10 @@ class Doctrine_Ticket_1296_TestCase extends Doctrine_UnitTestCase
             $this->assertEqual(0, $this->conn->transaction->getInternalTransactionLevel());
             $this->conn->rollback();
         }
-        
+
         $this->assertEqual(0, $this->conn->transaction->getTransactionLevel());
         $this->assertEqual(0, $this->conn->transaction->getInternalTransactionLevel());
-        
+
         try {
             $this->assertEqual(0, $this->conn->transaction->getTransactionLevel());
             $this->assertEqual(0, $this->conn->transaction->getInternalTransactionLevel());
@@ -91,16 +91,16 @@ class Doctrine_Ticket_1296_TestCase extends Doctrine_UnitTestCase
     {
         $this->assertEqual(0, $this->conn->transaction->getTransactionLevel());
         $this->assertEqual(0, $this->conn->transaction->getInternalTransactionLevel());
-        
+
         try {
             $this->conn->beginTransaction();
         } catch (Exception $e) {
             $this->fail('Transaction failed to start.');
         }
-        
+
         $this->assertEqual(1, $this->conn->transaction->getTransactionLevel());
         $this->assertEqual(0, $this->conn->transaction->getInternalTransactionLevel());
-        
+
         $r       = new NewTicket_Role();
         $r->name = 'foo';
         try {
@@ -124,7 +124,7 @@ class Doctrine_Ticket_1296_TestCase extends Doctrine_UnitTestCase
         }
     }
 }
-        
+
 class NewTicket_Organization extends Doctrine_Record
 {
     public function setTableDefinition()

--- a/tests/Ticket/1304TestCase.php
+++ b/tests/Ticket/1304TestCase.php
@@ -36,7 +36,7 @@ class Doctrine_Ticket_1304_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Doctrine_Ticket_1304_Slug';
         parent::prepareTables();
     }
-  
+
     public function testTicket()
     {
         // run 1

--- a/tests/Ticket/1305TestCase.php
+++ b/tests/Ticket/1305TestCase.php
@@ -44,17 +44,17 @@ class Doctrine_Ticket_1305_TestCase extends Doctrine_UnitTestCase
     {
         $t = new Ticket_1305_Record();
         $t->save();
-        
+
         $this->assertEqual($t['name'], 'test');
 
         $t->name = 'foo';
         $t->save();
-        
+
         $this->assertEqual($t['name'], 'foo');
 
         $t->name = null;
         $t->save();
-        
+
         $this->assertEqual($t['name'], 'test');
     }
 }

--- a/tests/Ticket/1323TestCase.php
+++ b/tests/Ticket/1323TestCase.php
@@ -9,7 +9,7 @@ class Doctrine_Ticket_1323_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'T1323UserReference';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
@@ -39,45 +39,45 @@ class Doctrine_Ticket_1323_TestCase extends Doctrine_UnitTestCase
         $gm       = new T1323User();
         $gm->name = 'Grandmother';
         $gm->save();
-      
+
         $f->Children[] = $s;
         $f->Children[] = $d;
-      
+
         $f->Parents[] = $gf;
         $f->Parents[] = $gm;
-      
+
         $f->save();
-      
+
         $m->Children[] = $s;
         $m->Children[] = $d;
-      
+
         $m->save();
     }
-    
+
     public function testRelationsAreCorrect()
     {
         $this->resetData();
-        
+
         $f          = Doctrine_Core::getTable('T1323User')->findOneByName('Father');
         $childLinks = $f->childLinks;
         $this->assertEqual(2, count($childLinks));
         $this->assertEqual($f->id, $childLinks[0]->parent_id);
         $this->assertEqual($f->id, $childLinks[1]->parent_id);
-        
+
         $parentLinks = $f->parentLinks;
         $this->assertEqual(2, count($parentLinks));
         $this->assertEqual($f->id, $parentLinks[0]->child_id);
         $this->assertEqual($f->id, $parentLinks[1]->child_id);
-        
+
         $m          = Doctrine_Core::getTable('T1323User')->findOneByName('Mother');
         $childLinks = $m->childLinks;
         $this->assertEqual(2, count($childLinks));
         $this->assertEqual($m->id, $childLinks[0]->parent_id);
         $this->assertEqual($m->id, $childLinks[1]->parent_id);
-        
+
         $parentLinks = $m->parentLinks;
         $this->assertEqual(0, count($parentLinks));
-        
+
         $s          = Doctrine_Core::getTable('T1323User')->findOneByName('Son');
         $childLinks = $s->childLinks;
         $this->assertEqual(0, count($childLinks));
@@ -85,7 +85,7 @@ class Doctrine_Ticket_1323_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(2, count($parentLinks));
         $this->assertEqual($s->id, $parentLinks[0]->child_id);
         $this->assertEqual($s->id, $parentLinks[1]->child_id);
-        
+
         $d          = Doctrine_Core::getTable('T1323User')->findOneByName('Daughter');
         $childLinks = $d->childLinks;
         $this->assertEqual(0, count($childLinks));
@@ -93,14 +93,14 @@ class Doctrine_Ticket_1323_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(2, count($parentLinks));
         $this->assertEqual($d->id, $parentLinks[0]->child_id);
         $this->assertEqual($d->id, $parentLinks[1]->child_id);
-        
+
         $gm         = Doctrine_Core::getTable('T1323User')->findOneByName('Grandmother');
         $childLinks = $gm->childLinks;
         $this->assertEqual(1, count($childLinks));
         $this->assertEqual($gm->id, $childLinks[0]->parent_id);
         $parentLinks = $gm->parentLinks;
         $this->assertEqual(0, count($parentLinks));
-        
+
         $gf         = Doctrine_Core::getTable('T1323User')->findOneByName('Grandfather');
         $childLinks = $gf->childLinks;
         $this->assertEqual(1, count($childLinks));
@@ -115,7 +115,7 @@ class Doctrine_Ticket_1323_TestCase extends Doctrine_UnitTestCase
     public function testWithShow()
     {
         $this->resetData();
-      
+
         T1323User::showAllRelations();
         $this->runTests();
     }
@@ -126,25 +126,25 @@ class Doctrine_Ticket_1323_TestCase extends Doctrine_UnitTestCase
     public function testWithoutShow()
     {
         $this->resetData();
-      
+
         $this->runTests();
     }
 
-    
+
     public function runTests()
     {
-        
+
       // change "Father"'s name...
         $f       = Doctrine_Core::getTable('T1323User')->findOneByName('Father');
         $f->name = 'Dad';
         $f->save();
-      
+
         /*  just playing; makes no difference:
             remove "Dad"'s relation to "Son"... */
         //$s = Doctrine_Core::getTable("T1323User")->findOneByName("Son");
         //$f->unlink("Children", array($s->id));
         //$f->save();
-      
+
         $relations = Doctrine_Core::getTable('T1323UserReference')->findAll();
         foreach ($relations as $relation) {
             /*  never directly touched any relation; so no user should have
@@ -153,9 +153,9 @@ class Doctrine_Ticket_1323_TestCase extends Doctrine_UnitTestCase
         }
     }
 }
-  
 
-  
+
+
 class T1323User extends Doctrine_Record
 {
     public function setTableDefinition()
@@ -177,22 +177,22 @@ class T1323User extends Doctrine_Record
                                                  'refClassRelationAlias' => 'parentLinks'
                                                  ));
     }
-    
+
     /**
      * just a little function to show all users and their relations
      */
     public static function showAllRelations()
     {
         $users = Doctrine_Core::getTable('T1323User')->findAll();
-        
+
         //echo "=========================================<br/>".PHP_EOL;
         //echo "list of all existing users and their relations:<br/> ".PHP_EOL;
         //echo "=========================================<br/><br/>".PHP_EOL.PHP_EOL;
-        
+
         foreach ($users as $user) {
             $parents  = $user->Parents;
             $children = $user->Children;
-            
+
             /*echo "user: ";
             echo $user->name;
             echo PHP_EOL."<br/>";

--- a/tests/Ticket/1323b2TestCase.php
+++ b/tests/Ticket/1323b2TestCase.php
@@ -13,7 +13,7 @@ class Doctrine_Ticket_1323b2_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     /**
      * setting some polyhierarchical relations
      */
@@ -50,30 +50,30 @@ class Doctrine_Ticket_1323b2_TestCase extends Doctrine_UnitTestCase
         $wd  = Doctrine_Core::getTable('Concept')->findOneByIdentifier('welded');
         $t   = Doctrine_Core::getTable('Concept')->findOneByIdentifier('turned');
         $s   = Doctrine_Core::getTable('Concept')->findOneByIdentifier('Surfaceworking');
-        
+
         $w->narrowerConcepts[] = $sw1;
         $w->narrowerConcepts[] = $sw2;
         $w->save();
-        
+
         $sw1->narrowerConcepts[] = $s;
         $sw1->narrowerConcepts[] = $d;
         $sw1->narrowerConcepts[] = $t;
         $sw1->save();
-        
+
         $sw2->narrowerConcepts[] = $d;
         $sw2->save();
-        
+
         $m->narrowerConcepts[] = $sm1;
         $m->narrowerConcepts[] = $sm2;
         $m->save();
-        
+
         $sm1->narrowerConcepts[] = $wd;
         $sm1->narrowerConcepts[] = $s;
         $sm1->save();
-        
+
         $sm2->narrowerConcepts[] = $t;
         $sm2->save();
-        
+
         $s->narrowerConcepts[] = $t;
         $s->narrowerConcepts[] = $d;
         $s->save();
@@ -89,13 +89,13 @@ class Doctrine_Ticket_1323b2_TestCase extends Doctrine_UnitTestCase
         ConceptRelation::showAllRelations();
         //lets count all relations
         $relCount = ConceptRelation::countAll();
-        
+
         $oRecord             = Doctrine_Core::getTable('Concept')->findOneByIdentifier('Surfaceworking');
         $oRecord->identifier = 'MySurfaceworking';
         $oRecord->save();
-        
+
         ConceptRelation::showAllRelations();
-      
+
         // we did not change any relations, so we assume this test to be passed
         $this->assertEqual(ConceptRelation::countAll(), $relCount);
         // -> where do the additional relations come from ???
@@ -107,22 +107,22 @@ class Doctrine_Ticket_1323b2_TestCase extends Doctrine_UnitTestCase
     public function testOK()
     {
         $this->resetData();
-        
+
         ConceptRelation::showAllRelations();
         //lets count all relations
         $relCount = ConceptRelation::countAll();
-        
+
         $oRecord             = Doctrine_Core::getTable('Concept')->findOneByIdentifier('Surfaceworking');
         $oRecord->identifier = 'MySurfaceworking';
         // $oRecord->save();  --> only this line differs !!!
-        
+
         ConceptRelation::showAllRelations();
-        
+
         // we did not change any relations, so we assume this test to be passed
         $this->assertEqual(ConceptRelation::countAll(), $relCount);
     }
 }
-  
+
 
 
 
@@ -214,7 +214,7 @@ class ConceptRelation extends BaseConceptRelation
         }
         echo "\n\n<br/><br/>";*/
     }
-    
+
     public static function countAll()
     {
         return Doctrine_Core::getTable('ConceptRelation')->count();

--- a/tests/Ticket/1325TestCase.php
+++ b/tests/Ticket/1325TestCase.php
@@ -44,7 +44,7 @@ class Doctrine_Ticket_1325_TestCase extends Doctrine_UnitTestCase
         $elem     = new Ticket_1325_TableName_NoAlias();
         $elem->id = 1;
         $elem->save();
-        
+
         $res = Doctrine_Query::create()
             ->from('Ticket_1325_TableName_NoAlias')
             ->fetchOne(array(), Doctrine_Core::HYDRATE_ARRAY);
@@ -59,7 +59,7 @@ class Doctrine_Ticket_1325_TestCase extends Doctrine_UnitTestCase
         $elem     = new Ticket_1325_TableName_Aliased();
         $elem->id = 1;
         $elem->save();
-        
+
         $res = Doctrine_Query::create()
             ->from('Ticket_1325_TableName_Aliased')
             ->fetchOne(array(), Doctrine_Core::HYDRATE_ARRAY);

--- a/tests/Ticket/1365TestCase.php
+++ b/tests/Ticket/1365TestCase.php
@@ -79,7 +79,7 @@ class T1365_Person extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('la__person');
-        
+
         $this->hasColumn('name', 'string', 255);
     }
 
@@ -95,7 +95,7 @@ class T1365_Skill extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('la__skill');
-        
+
         $this->hasColumn('name', 'string', 255);
     }
 
@@ -111,7 +111,7 @@ class T1365_PersonHasSkill extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('la__person_has_skill');
-        
+
         $this->hasColumn('fk_person_id', 'integer', 8, array(
             'type' => 'integer', 'length' => '8'
         ));
@@ -132,7 +132,7 @@ class T1365_PersonHasSkill extends Doctrine_Record
             ), 'default' => 0, 'notnull' => true, 'length' => '3'
         ));
     }
-    
+
     public function setUp()
     {
         $this->hasOne('T1365_Person', array('local' => 'fk_person_id', 'foreign' => 'id'));

--- a/tests/Ticket/1381TestCase.php
+++ b/tests/Ticket/1381TestCase.php
@@ -39,14 +39,14 @@ class Doctrine_Ticket_1381_TestCase extends Doctrine_UnitTestCase
 
         parent::prepareTables();
     }
-    
-    
+
+
     public function prepareData()
     {
         $a        = new T1381_Article();
         $a->title = 'When cleanData worked as expected!';
         $a->save();
-        
+
         $c             = new T1381_Comment();
         $c->article_id = $a->id;
         $c->body       = 'Yeah! It will work one day.';
@@ -56,12 +56,12 @@ class Doctrine_Ticket_1381_TestCase extends Doctrine_UnitTestCase
         $c->article_id = $a->id;
         $c->body       = 'It will!';
         $c->save();
-        
+
         // Cleaning up IdentityMap
         Doctrine_Core::getTable('T1381_Article')->clear();
         Doctrine_Core::getTable('T1381_Comment')->clear();
     }
-    
+
     public function testTicket()
     {
         try {
@@ -71,7 +71,7 @@ class Doctrine_Ticket_1381_TestCase extends Doctrine_UnitTestCase
 
             // This should result in false, since we didn't fetch for this column
             $this->assertFalse(array_key_exists('ArticleTitle', $items[0]['T1381_Article']));
-            
+
             // We fetch for data including new columns
             $dql     = 'SELECT c.*, a.title as ArticleTitle FROM T1381_Comment c INNER JOIN c.T1381_Article a WHERE c.id = ?';
             $items   = Doctrine_Query::create()->query($dql, array(1), Doctrine_Core::HYDRATE_ARRAY);
@@ -110,7 +110,7 @@ class Doctrine_Ticket_1381_TestCase extends Doctrine_UnitTestCase
 
             // Assert that new calculated column with different content do not override the already fetched one
             $this->assertTrue(array_key_exists('ArticleTitle', $items[0]));
-            
+
             // Assert that our existent component still has the column, even after new hydration on same object
             $this->assertTrue(array_key_exists('ArticleTitle', $comment));
             $this->assertTrue($comment, 'When cleanData worked as expected!');
@@ -128,7 +128,7 @@ class T1381_Article extends Doctrine_Record
         $this->hasColumn('id', 'integer', null, array('primary' => true, 'autoincrement' => true));
         $this->hasColumn('title', 'string', 255, array('notnull' => true));
     }
-    
+
     public function setUp()
     {
         $this->hasMany(

--- a/tests/Ticket/1383TestCase.php
+++ b/tests/Ticket/1383TestCase.php
@@ -85,7 +85,7 @@ class Ticket_1383_Brand extends Doctrine_Record
         $this->hasColumn('id', 'integer', null, array('primary' => true, 'autoincrement' => true));
         $this->hasColumn('name', 'string', 255, array('notnull' => true));
     }
-    
+
     public function setUp()
     {
         $this->hasMany(

--- a/tests/Ticket/1390TestCase.php
+++ b/tests/Ticket/1390TestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Ticket_1390_TestCase extends Doctrine_UnitTestCase
     public function testTest()
     {
         $user = new User();
-        
+
         $record1 = $user->getTable()->find(4);
         $record2 = Doctrine_Core::getTable('User')->find(4);
 

--- a/tests/Ticket/1395TestCase.php
+++ b/tests/Ticket/1395TestCase.php
@@ -79,16 +79,16 @@ class T1395_Listener extends Doctrine_Record_Listener
     public function preHydrate(Doctrine_Event $event)
     {
         $data = $event->data;
-        
+
         // Calculate days since creation
         $days             = (strtotime('now') - strtotime($data['dt_created'])) / (24 * 60 * 60);
         $data['days_old'] = number_format($days, 2);
 
         self::addSomeData($data);
-        
+
         $event->data = $data;
     }
-    
+
     public static function addSomeData(&$data)
     {
         $data['dt_created_tx'] = date('M d, Y', strtotime($data['dt_created']));

--- a/tests/Ticket/1436TestCase.php
+++ b/tests/Ticket/1436TestCase.php
@@ -36,30 +36,30 @@ class Doctrine_Ticket_1436_TestCase extends Doctrine_UnitTestCase
     {
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $user       = new User();
         $user->name = 'John';
         $user->save();
-        
+
         # Create existing groups
         $group       = new Group();
         $group->name = 'Group One';
         $group->save();
         $this->group_one = $group['id'];
-        
+
         $group       = new Group();
         $group->name = 'Group Two';
         $group->save();
         $this->group_two = $group['id'];
-        
+
         $group       = new Group();
         $group->name = 'Group Three';
         $group->save();
         $this->group_three = $group['id'];
     }
-    
+
     public function testSynchronizeAddMNLinks()
     {
         $user      = Doctrine_Query::create()->from('User u')->fetchOne();
@@ -94,20 +94,20 @@ class Doctrine_Ticket_1436_TestCase extends Doctrine_UnitTestCase
                 $this->group_three
             )
         );
-        
+
         $user->synchronizeWithArray($userArray);
-        
+
         $this->assertTrue(!isset($user->Groups));
-        
+
         try {
             $user->save();
         } catch (Exception $e) {
             $this->fail('Failed saving with ' . $e->getMessage());
         }
-        
+
         $user->refresh();
         $user->loadReference('Group');
-        
+
         $this->assertEqual($user->Group[0]->name, 'Group Two');
         $this->assertEqual($user->Group[1]->name, 'Group Three');
         $this->assertTrue(!isset($user->Group[2]));
@@ -125,7 +125,7 @@ class Doctrine_Ticket_1436_TestCase extends Doctrine_UnitTestCase
     public function testSynchronizeMNRecordsDontDeleteAfterUnlink()
     {
         $group = Doctrine_Core::getTable('Group')->find($this->group_one);
-        
+
         $this->assertTrue(!empty($group));
         $this->assertEqual($group->name, 'Group One');
     }

--- a/tests/Ticket/1454TestCase.php
+++ b/tests/Ticket/1454TestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Ticket_1454_TestCase extends Doctrine_UnitTestCase
             ->leftJoin('u.Phonenumber p')
             ->where('p.id = (SELECT MAX(p2.id) FROM Phonenumber p2 LIMIT 1)')
             ->orWhere('p.id = (SELECT MIN(p3.id) FROM Phonenumber p3 LIMIT 1)');
-            
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT e.id AS e__id, e.name AS e__name, e.loginname AS e__loginname, e.password AS e__password, e.type AS e__type, e.created AS e__created, e.updated AS e__updated, e.email_id AS e__email_id, p.id AS p__id, p.phonenumber AS p__phonenumber, p.entity_id AS p__entity_id FROM entity e LEFT JOIN phonenumber p ON e.id = p.entity_id WHERE (p.id = (SELECT MAX(p2.id) AS p2__0 FROM phonenumber p2 LIMIT 1) OR p.id = (SELECT MIN(p3.id) AS p3__0 FROM phonenumber p3 LIMIT 1) AND (e.type = 0))');
     }
 }

--- a/tests/Ticket/1461TestCase.php
+++ b/tests/Ticket/1461TestCase.php
@@ -40,14 +40,14 @@ class Doctrine_Ticket_1461_TestCase extends Doctrine_UnitTestCase
         ->from('User u')
         ->innerJoin('u.Phonenumber p')
         ->where("u.name = 'zYne'");
-        
+
         $users = $q->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
 
         $this->assertEqual($users[0]['concat1'], 'zYne_1');
 
         $this->assertEqual($users[0]['concat2'], 'zYne_2');
     }
-    
+
     public function testFetchArraySupportsTwoAggregatesInRelation()
     {
         $q = new Doctrine_Query();
@@ -56,11 +56,11 @@ class Doctrine_Ticket_1461_TestCase extends Doctrine_UnitTestCase
         ->from('User u')
         ->innerJoin('u.Phonenumber p')
         ->where("u.name = 'zYne'");
-        
+
         $users = $q->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
 
         $this->assertEqual($users[0]['concat2'], '123 123_2');
-        
+
         $this->assertEqual($users[0]['concat1'], '123 123_1');
     }
 
@@ -72,7 +72,7 @@ class Doctrine_Ticket_1461_TestCase extends Doctrine_UnitTestCase
         ->from('User u')
         ->innerJoin('u.Phonenumber p')
         ->where("u.name = 'zYne'");
-        
+
         $users = $q->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
 
         $this->assertEqual($users[0]['concat1'], 'zYne_1');
@@ -80,7 +80,7 @@ class Doctrine_Ticket_1461_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual($users[0]['concat2'], 'zYne_2');
 
         $this->assertEqual($users[0]['concat3'], '123 123_3');
-        
+
         $this->assertTrue(isset($users[0]['concat4']));
     }
 }

--- a/tests/Ticket/1483TestCase.php
+++ b/tests/Ticket/1483TestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Ticket_1483_TestCase extends Doctrine_UnitTestCase
             ->leftJoin('u.Groups g WITH g.id = (SELECT g2.id FROM Ticket_1483_Group g2 WHERE (g2.name = \'Test\' OR g2.name = \'Test2\'))');
         $this->assertEqual($q->getSqlQuery(), 'SELECT t.id AS t__id, t.username AS t__username, t2.id AS t2__id, t2.name AS t2__name FROM ticket_1483__user t LEFT JOIN ticket_1483__user_group t3 ON (t.id = t3.user_id) LEFT JOIN ticket_1483__group t2 ON t2.id = t3.group_id AND (t2.id = (SELECT t4.id AS t4__id FROM ticket_1483__group t4 WHERE (t4.name = \'Test\' OR t4.name = \'Test2\')))');
     }
-    
+
     public function testTest2()
     {
         $q = Doctrine_Query::create()
@@ -47,7 +47,7 @@ class Doctrine_Ticket_1483_TestCase extends Doctrine_UnitTestCase
             ->leftJoin('u.Groups g WITH g.id = (SELECT g2.id FROM Ticket_1483_Group g2 WHERE (g2.name = \'Test\' OR (g2.name = \'Test2\')))');
         $this->assertEqual($q->getSqlQuery(), 'SELECT t.id AS t__id, t.username AS t__username, t2.id AS t2__id, t2.name AS t2__name FROM ticket_1483__user t LEFT JOIN ticket_1483__user_group t3 ON (t.id = t3.user_id) LEFT JOIN ticket_1483__group t2 ON t2.id = t3.group_id AND (t2.id = (SELECT t4.id AS t4__id FROM ticket_1483__group t4 WHERE (t4.name = \'Test\' OR t4.name = \'Test2\')))');
     }
-    
+
     public function testTest3()
     {
         $q = Doctrine_Query::create()

--- a/tests/Ticket/1507TestCase.php
+++ b/tests/Ticket/1507TestCase.php
@@ -35,57 +35,57 @@ class Doctrine_Ticket_1507_TestCase extends Doctrine_UnitTestCase
     public function testInitiallyEmpty()
     {
         $c = new Doctrine_Ticket_1507_TestCase_TestConfigurable();
-        
+
         $this->assertEqual(null, $c->getParam('foo'));
         $this->assertEqual(null, $c->getParam('foo', 'bar'));
         $this->assertEqual(null, $c->getParams());
         $this->assertEqual(null, $c->getParams('bar'));
         $this->assertEqual(array(), $c->getParamNamespaces());
     }
-    
+
     public function testSetGetParamWithNamespace()
     {
         $c = new Doctrine_Ticket_1507_TestCase_TestConfigurable();
-        
+
         $c->setParam('foo', 'bar', 'namespace');
-        
+
         $this->assertEqual(array('foo' => 'bar'), $c->getParams('namespace'));
         $this->assertEqual('bar', $c->getParam('foo', 'namespace'));
-        
+
         $this->assertEqual(array('namespace'), $c->getParamNamespaces());
     }
-    
+
     public function testSetGetParamWithoutNamespace()
     {
         $c = new Doctrine_Ticket_1507_TestCase_TestConfigurable();
-        
+
         $c->setParam('foo', 'bar');
-        
+
         $this->assertEqual(array('foo' => 'bar'), $c->getParams());
         $this->assertEqual('bar', $c->getParam('foo'));
-        
+
         $this->assertEqual(array($c->getAttribute(Doctrine_Core::ATTR_DEFAULT_PARAM_NAMESPACE)), $c->getParamNamespaces());
     }
-    
+
     public function testSetGetParamWithNamespaceParent()
     {
         $p = new Doctrine_Ticket_1507_TestCase_TestConfigurable();
         $c = new Doctrine_Ticket_1507_TestCase_TestConfigurable();
         $c->setParent($p);
-        
+
         $p->setParam('foo', 'bar', 'namespace');
-        
+
         $this->assertEqual('bar', $c->getParam('foo', 'namespace'));
     }
-    
+
     public function testSetGetParamWithoutNamespaceParent()
     {
         $p = new Doctrine_Ticket_1507_TestCase_TestConfigurable();
         $c = new Doctrine_Ticket_1507_TestCase_TestConfigurable();
         $c->setParent($p);
-        
+
         $p->setParam('foo', 'bar');
-        
+
         $this->assertEqual('bar', $c->getParam('foo'));
     }
 }

--- a/tests/Ticket/1527TestCase.php
+++ b/tests/Ticket/1527TestCase.php
@@ -52,7 +52,7 @@ END;
 
         $path = dirname(__FILE__) . '/../tmp';
         $import->importSchema($yml, 'yml', $path);
-        
+
         require_once($path . '/generated/BaseTicket_1527_User.php');
         require_once($path . '/Ticket_1527_User.php');
         $username = Doctrine_Core::getTable('Ticket_1527_User')->getDefinitionOf('username');

--- a/tests/Ticket/1540TestCase.php
+++ b/tests/Ticket/1540TestCase.php
@@ -37,7 +37,7 @@ class Doctrine_Ticket_1540_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1540_TableName';
         parent::prepareTables();
     }
-    
+
     public function testShouldNotConvertToAmpersandsInSelect()
     {
         $q = Doctrine_Query::create()
@@ -45,7 +45,7 @@ class Doctrine_Ticket_1540_TestCase extends Doctrine_UnitTestCase
             ->from('Ticket_1540_TableName t');
         $this->assertEqual($q->getSqlQuery(), 'SELECT if(1 AND 2, 1, 2) AS t__0 FROM ticket_1540__table_name t');
     }
-    
+
     public function testShouldNotConvertToAmpersandsInWhere()
     {
         $q = Doctrine_Query::create()

--- a/tests/Ticket/1567TestCase.php
+++ b/tests/Ticket/1567TestCase.php
@@ -50,7 +50,7 @@ class Doctrine_Ticket_1567_TestCase extends Doctrine_UnitTestCase
         $query->from('Ticket_1567_Project p');
         $query->addWhere('p.user_id = ?', 1);
         $query->addWhere('p.deleted = ?', true);
-        
+
         $this->assertEqual($query->count(), 1);
         $this->assertEqual($query->execute()->count(), 1);
     }

--- a/tests/Ticket/1604TestCase.php
+++ b/tests/Ticket/1604TestCase.php
@@ -41,17 +41,17 @@ class Doctrine_Ticket_1604_TestCase extends Doctrine_UnitTestCase
             'CREATE TABLE ticket_1604__email_adresses (id BIGINT AUTO_INCREMENT, user_id BIGINT, address VARCHAR(30), INDEX user_id_idx (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = INNODB',
             'ALTER TABLE ticket_1604__email_adresses ADD CONSTRAINT ticket_1604__email_adresses_user_id_ticket_1604__user_id FOREIGN KEY (user_id) REFERENCES ticket_1604__user(id)'
         );
-        
+
         $this->assertEqual($sql, $def);
     }
 }
-    
+
 class Ticket_1604_User extends Doctrine_Record
 {
     public function setTableDefinition()
     {
         $this->hasColumn('name', 'string', 30);
-        
+
         $this->option('type', 'INNODB');
         $this->option('collate', 'utf8_unicode_ci');
         $this->option('charset', 'utf8');
@@ -69,12 +69,12 @@ class Ticket_1604_EmailAdresses extends Doctrine_Record
     {
         $this->hasColumn('user_id as userId', 'integer');
         $this->hasColumn('address', 'string', 30);
-        
+
         $this->option('type', 'INNODB');
         $this->option('collate', 'utf8_unicode_ci');
         $this->option('charset', 'utf8');
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_1604_User as user', array('local' => 'userId', 'foreign' => 'id'));

--- a/tests/Ticket/1619TestCase.php
+++ b/tests/Ticket/1619TestCase.php
@@ -45,7 +45,7 @@ class Doctrine_Ticket_1619_TestCase extends Doctrine_UnitTestCase
         $a->Translation['en']->name        = 'english article';
         $a->Translation['en']->description = 'english description';
         $a->save();
-        
+
         $b                                 = new Ticket_1619_Article();
         $a->Translation['fr']->name        = 'maison';
         $a->Translation['fr']->description = 'habitation';

--- a/tests/Ticket/1621TestCase.php
+++ b/tests/Ticket/1621TestCase.php
@@ -43,7 +43,7 @@ class Doctrine_Ticket_1621_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1621_GroupUser';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
@@ -56,27 +56,27 @@ class Doctrine_Ticket_1621_TestCase extends Doctrine_UnitTestCase
             $group       = new Ticket_1621_Group();
             $group->name = 'group1';
             $group->save();
-            
+
             $group2       = new Ticket_1621_Group();
             $group2->name = 'group2';
             $group2->save();
-            
+
             $user                             = new Ticket_1621_User();
             $user->name                       = 'floriank';
             $user->groups[]                   = $group;
             $user->emailAddresses[0]->address = 'floriank@localhost';
             $user->save();
-            
+
             $user2                             = new Ticket_1621_User();
             $user2->name                       = 'test2';
             $user2->emailAddresses[0]->address = 'test2@localhost';
             $user2->save();
-            
+
             $user3                             = new Ticket_1621_User();
             $user3->name                       = 'test3';
             $user3->emailAddresses[0]->address = 'test3@localhost';
             $user3->save();
-    
+
             $user4                             = new Ticket_1621_User();
             $user4->name                       = 'test';
             $user4->groups[]                   = $group2;
@@ -87,29 +87,29 @@ class Doctrine_Ticket_1621_TestCase extends Doctrine_UnitTestCase
         } catch (Exception $e) {
             $this->fail($e);
         }
-        
-        
-        
+
+
+
         //here is the testcode
         try {
             $user      = Doctrine_Core::getTable('Ticket_1621_User')->findOneByName('floriank');
             $newChild  = Doctrine_Core::getTable('Ticket_1621_User')->findOneByName('test');
             $newFriend = Doctrine_Core::getTable('Ticket_1621_User')->findOneByName('test2');
             $newGroup  = Doctrine_Core::getTable('Ticket_1621_Group')->findOneByName('group2');
-            
+
             $user->children[] = $newChild;
             $user->groups[]   = $newGroup;
             $user->friends[]  = $newFriend;
-    
+
             $user->save();
-            
+
             $this->assertEqual(count($user->children), 1);
         } catch (Exception $e) {
             $this->fail($e);
         }
     }
 }
-    
+
 class Ticket_1621_User extends Doctrine_Record
 {
     public function setTableDefinition()
@@ -137,9 +137,9 @@ class Ticket_1621_User extends Doctrine_Record
                                                  'refClassRelationAlias' => 'parentLinks'
                                                  )
         );
-                                                 
+
         $this->hasMany(
-                                                 
+
             'Ticket_1621_User as friends',
                                                  array('local'           => 'leftId',
                                                  'foreign'               => 'rightId',
@@ -147,9 +147,9 @@ class Ticket_1621_User extends Doctrine_Record
                                                  'refClass'              => 'Ticket_1621_UserReferenceFriends',
                                                  'refClassRelationAlias' => 'friendLinks'
                                                  )
-                                                 
+
         );
-                                                 
+
         $this->hasMany('Ticket_1621_EmailAdresses as emailAddresses', array('local' => 'id', 'foreign' => 'userId'));
 
         $this->hasMany('Ticket_1621_Group as groups', array('local' => 'userId',
@@ -182,12 +182,12 @@ class Ticket_1621_EmailAdresses extends Doctrine_Record
     {
         $this->hasColumn('user_id as userId', 'integer', null);
         $this->hasColumn('address', 'string', 30);
-        
+
         $this->option('type', 'INNODB');
         $this->option('collate', 'utf8_unicode_ci');
         $this->option('charset', 'utf8');
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_1621_User as user', array('local' => 'userId', 'foreign' => 'id'));

--- a/tests/Ticket/1621bTestCase.php
+++ b/tests/Ticket/1621bTestCase.php
@@ -33,7 +33,7 @@
 class Doctrine_Ticket_1621b_TestCase extends Doctrine_UnitTestCase
 {
     const LANG = 'deu';
-    
+
     public function prepareTables()
     {
         $this->tables   = array();
@@ -46,7 +46,7 @@ class Doctrine_Ticket_1621b_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1621b_ConceptHierarchicalRelation';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $lang                                 = new Ticket_1621b_Language();
@@ -55,82 +55,82 @@ class Doctrine_Ticket_1621b_TestCase extends Doctrine_UnitTestCase
         $lang->Translation['de']->description = 'Die Sprache Deutsch';
         $lang->Translation['en']->display     = 'german';
         $lang->Translation['en']->description = 'The german language';
-        
+
         $lang->save();
-        
+
         $lang                                 = new Ticket_1621b_Language();
         $lang->id                             = 'eng';
         $lang->Translation['de']->display     = 'Englisch';
         $lang->Translation['de']->description = 'Die Sprache Englisch';
         $lang->Translation['en']->display     = 'german';
         $lang->Translation['en']->description = 'The english language';
-                
+
         $lang->save();
-        
-        
-        
-                
+
+
+
+
         $plant             = new Ticket_1621b_Concept();
         $plant->identifier = '1';
-        
+
         $pref_de               = new Ticket_1621b_PrefTerm();
         $pref_de->lexicalValue = 'Pflanze';
         $pref_de->langId       = 'deu';
-        
+
         $pref_en               = new Ticket_1621b_PrefTerm();
         $pref_en->lexicalValue = 'plant';
         $pref_en->langId       = 'eng';
-        
+
         $plant->preferedTerm    = $pref_de;
         $plant->preferedTerms[] = $pref_en;
-        
+
         $plant->save();
-        
-        
-        
-        
+
+
+
+
         $tree             = new Ticket_1621b_Concept();
         $tree->identifier = '1.1';
-        
+
         $pref_de               = new Ticket_1621b_PrefTerm();
         $pref_de->lexicalValue = 'Baum';
         $pref_de->langId       = 'deu';
-        
+
         $pref_en               = new Ticket_1621b_PrefTerm();
         $pref_en->lexicalValue = 'tree';
         $pref_en->langId       = 'eng';
-        
+
         $alt               = new Ticket_1621b_AltTerm();
         $alt->lexicalValue = 'bush';
         $alt->langId       = 'eng';
-        
+
         $tree->preferedTerm    = $pref_de;
         $tree->preferedTerms[] = $pref_en;
         $tree->altTerms[]      = $alt;
-        
+
         $tree->broaderConcepts[] = $plant;
-        
+
         $tree->save();
-             
-        
-        
-        
+
+
+
+
         $oak             = new Ticket_1621b_Concept();
         $oak->identifier = '1.1';
-        
+
         $pref_de               = new Ticket_1621b_PrefTerm();
         $pref_de->lexicalValue = 'Eiche';
         $pref_de->langId       = 'deu';
-        
+
         $pref_en               = new Ticket_1621b_PrefTerm();
         $pref_en->lexicalValue = 'oak';
         $pref_en->langId       = 'eng';
-        
+
         $oak->preferedTerm    = $pref_de;
         $oak->preferedTerms[] = $pref_en;
-        
+
         $oak->broaderConcepts[] = $tree;
-        
+
         $oak->save();
     }
 
@@ -143,14 +143,14 @@ class Doctrine_Ticket_1621b_TestCase extends Doctrine_UnitTestCase
                     ->leftJoin('c.narrowerConcepts n')
                     ->where('c.id = ?', 2);
             $rs = $q->fetchOne();
-            
+
             $this->assertEqual($rs->preferedTerm->lexicalValue, 'Baum');
         } catch (Exception $e) {
             $this->fail($e);
         }
     }
 }
-    
+
 
 
 class Ticket_1621b_Concept extends Doctrine_Record
@@ -174,7 +174,7 @@ class Ticket_1621b_Concept extends Doctrine_Record
         $this->hasMany('Ticket_1621b_AltTerm as altTerms', array('local' => 'id',
                                                        'foreign'         => 'conceptId',
                                                        'onDelete'        => 'CASCADE'));
-    
+
         $this->hasMany('Ticket_1621b_Concept as broaderConcepts', array('refClass' => 'Ticket_1621b_ConceptHierarchicalRelation',
                                                        'refClassRelationAlias'     => 'narrowerLinks',
                                                        'local'                     => 'conceptIdSource',

--- a/tests/Ticket/1622TestCase.php
+++ b/tests/Ticket/1622TestCase.php
@@ -39,13 +39,13 @@ class Doctrine_Ticket_1622_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1622_UserReference';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $user       = new Ticket_1622_User();
         $user->name = 'floriank';
         $user->save();
-            
+
         $user2            = new Ticket_1622_User();
         $user2->name      = 'test';
         $user2->parents[] = $user;
@@ -56,13 +56,13 @@ class Doctrine_Ticket_1622_TestCase extends Doctrine_UnitTestCase
     {
         $user  = Doctrine_Core::getTable('Ticket_1622_User')->findOneByName('floriank');
         $child = Doctrine_Core::getTable('Ticket_1622_User')->findOneByName('test');
-        
+
         $user->unlink('children', $child->id);
-        
+
         $this->assertTrue($user->hasReference('children'));
         $this->assertTrue($user->hasRelation('children'));
         $this->assertEqual(count($user->children), 0);
-        
+
         $user->save();
 
         $user->refresh();
@@ -70,7 +70,7 @@ class Doctrine_Ticket_1622_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual(count($user->children), 0);
     }
 }
-    
+
 class Ticket_1622_User extends Doctrine_Record
 {
     public function setTableDefinition()
@@ -89,16 +89,16 @@ class Ticket_1622_User extends Doctrine_Record
                                                 'refClassRelationAlias' => 'childrenLinks'
                                                 )
         );
-                                                
+
         $this->hasMany(
-                                                
+
             'Ticket_1622_User as children',
                                                  array('local'           => 'child_id',
                                                  'foreign'               => 'parent_id',
                                                  'refClass'              => 'Ticket_1622_UserReference',
                                                  'refClassRelationAlias' => 'parentLinks'
                                                  )
-                                                
+
         );
     }
 }

--- a/tests/Ticket/1623TestCase.php
+++ b/tests/Ticket/1623TestCase.php
@@ -39,12 +39,12 @@ class Doctrine_Ticket_1623_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1623_UserReference';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $firstUser = null;
         $oldUser   = null;
-        
+
         for ($i = 1; $i <= 20; $i++) {
             $userI       = $user       = new Ticket_1623_User();
             $userI->name = "test$i";
@@ -69,14 +69,14 @@ class Doctrine_Ticket_1623_TestCase extends Doctrine_UnitTestCase
     public function testPerformance()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         $newChild       = new Ticket_1623_User();
         $newChild->name = 'myChild';
         $newChild->save();
-        
+
         $user             = Doctrine_Core::getTable('Ticket_1623_User')->findOneByName('floriank');
         $user->children[] = $newChild;
-        
+
         $start = microtime(true);
         $user->save();
         $end  = microtime(true);
@@ -84,7 +84,7 @@ class Doctrine_Ticket_1623_TestCase extends Doctrine_UnitTestCase
         //assuming save() should not take longer than one second
         $this->assertTrue($diff < 1);
     }
-    
+
     public function testImplicitSave()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
@@ -92,12 +92,12 @@ class Doctrine_Ticket_1623_TestCase extends Doctrine_UnitTestCase
 
         $newChild       = new Ticket_1623_User();
         $newChild->name = 'myGrandGrandChild';
-        
+
         $user                                       = Doctrine_Core::getTable('Ticket_1623_User')->findOneByName('floriank');
         $user->children[0]->children[0]->children[] = $newChild;
-        
+
         $user->save();
-        
+
         $user = Doctrine_Core::getTable('Ticket_1623_User')->findByName('myGrandGrandChild');
         //as of Doctrine's default behaviour $newChild should have
         //been implicitly saved with $user->save()
@@ -107,7 +107,7 @@ class Doctrine_Ticket_1623_TestCase extends Doctrine_UnitTestCase
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_CASCADE_SAVES, true);
     }
 }
-    
+
 class Ticket_1623_User extends Doctrine_Record
 {
     public function setTableDefinition()
@@ -126,19 +126,19 @@ class Ticket_1623_User extends Doctrine_Record
                                                 'refClassRelationAlias' => 'childrenLinks'
                                                 )
         );
-                                                
+
         $this->hasMany(
-                                                
+
             'Ticket_1623_User as children',
                                                  array('local'           => 'childId',
                                                  'foreign'               => 'parentId',
                                                  'refClass'              => 'Ticket_1623_UserReference',
                                                  'refClassRelationAlias' => 'parentLinks'
                                                  )
-                                                
+
         );
     }
-    
+
     protected function validate()
     {
         // lets get some silly load in the validation:
@@ -149,13 +149,13 @@ class Ticket_1623_User extends Doctrine_Record
                 $unwantedName = true;
             }
         }
-        
+
         foreach ($this->children as $child) {
             if ($child->name == 'caesar') {
                 $unwantedName = true;
             }
         }
-        
+
         if ($unwantedName) {
             $this->errorStack()->add('children', 'no child should have the name \'caesar\'');
         }

--- a/tests/Ticket/1629TestCase.php
+++ b/tests/Ticket/1629TestCase.php
@@ -53,9 +53,9 @@ class Doctrine_Ticket_1629_TestCase extends Doctrine_UnitTestCase
         $q = Doctrine_Query::create()
             ->from('Ticket_1629_User u')
             ->leftJoin('u.Phonenumbers p');
-            
+
         $this->assertEqual($q->getSqlQuery(), 'SELECT t.id AS t__id, t.username AS t__username, t.password AS t__password, t.deleted_at AS t__deleted_at, t2.id AS t2__id, t2.user_id AS t2__user_id, t2.phonenumber AS t2__phonenumber, t2.deleted_at AS t2__deleted_at FROM ticket_1629__user t LEFT JOIN ticket_1629__phonenumber t2 ON t.id = t2.user_id AND (t2.deleted_at IS NULL) WHERE (t.deleted_at IS NULL)');
-            
+
         $users = $q->fetchArray();
         $this->assertEqual(count($users), 1);
         $this->assertEqual(count($users[0]['Phonenumbers']), 0);

--- a/tests/Ticket/1641TestCase.php
+++ b/tests/Ticket/1641TestCase.php
@@ -58,7 +58,7 @@ class Doctrine_Ticket_1641_TestCase extends Doctrine_UnitTestCase
         $table = Doctrine_Core::getTable('T1641_User');
 
         $this->assertEqual($table->createQuery()->getCountSqlQuery(), 'SELECT COUNT(*) AS num_results FROM t1641__user t WHERE (t.deleted_at IS NULL)');
-    
+
         $this->assertEqual($table->count(), 1);
         $this->assertEqual($table->createQuery()->execute()->count(), 1);
         $this->assertEqual($table->createQuery()->count(), 1);

--- a/tests/Ticket/1652TestCase.php
+++ b/tests/Ticket/1652TestCase.php
@@ -38,7 +38,7 @@ class Doctrine_Ticket_1652_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1652_User';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $user       = new Ticket_1652_User();
@@ -59,7 +59,7 @@ class Doctrine_Ticket_1652_TestCase extends Doctrine_UnitTestCase
                                                     Doctrine_Core::VALIDATE_ALL & ~Doctrine_Core::VALIDATE_LENGTHS & ~Doctrine_Core::VALIDATE_CONSTRAINTS & ~Doctrine_Core::VALIDATE_TYPES
             );
         }
-        
+
         $user       = Doctrine_Core::getTable('Ticket_1652_User')->findOneById(1);
         $user->name = 'test';
         if ($user->isValid()) {
@@ -71,13 +71,13 @@ class Doctrine_Ticket_1652_TestCase extends Doctrine_UnitTestCase
         }
 
         $user = Doctrine_Core::getTable('Ticket_1652_User')->findOneById(1);
-        
+
         $this->assertNotEqual($user->name, 'test');
         //reset validation to default for further testcases
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
 }
-    
+
 class Ticket_1652_User extends Doctrine_Record
 {
     public function setTableDefinition()

--- a/tests/Ticket/1653TestCase.php
+++ b/tests/Ticket/1653TestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Ticket_1653_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1653_Email';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
@@ -47,14 +47,14 @@ class Doctrine_Ticket_1653_TestCase extends Doctrine_UnitTestCase
     public function testValidate()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         $user = new Ticket_1653_User();
         $mail = new Ticket_1653_Email();
-        
+
         $user->id       = 1;
         $user->name     = 'floriank';
         $user->emails[] = $mail;
-        
+
         //explicit call of isValid() should return false since $mail->address is null
 
         $this->assertFalse($user->isValid(true));
@@ -86,14 +86,14 @@ class Ticket_1653_User extends Doctrine_Record
     {
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_1653_Email as emails', array('local' => 'id',
                                                   'foreign'         => 'user_id',
                                                   'cascade'         => array('delete')));
     }
-    
+
     protected function validate()
     {
         if ($this->name == 'test') {
@@ -110,7 +110,7 @@ class Ticket_1653_Email extends Doctrine_Record
         $this->hasColumn('user_id', 'integer');
         $this->hasColumn('address', 'string', 255, array('notnull' => true));
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_1653_User as user', array('local' => 'user_id',

--- a/tests/Ticket/1674TestCase.php
+++ b/tests/Ticket/1674TestCase.php
@@ -43,7 +43,7 @@ class Doctrine_Ticket_1674_TestCase extends Doctrine_UnitTestCase
             ->execute();
 
         $xml = $users->exportTo('xml');
-    
+
         // Enforce NOEMPTYTAG for backwards compatibility
         $doc = new DOMDocument();
         $doc->loadXML($xml);

--- a/tests/Ticket/1706TestCase.php
+++ b/tests/Ticket/1706TestCase.php
@@ -61,7 +61,7 @@ class Doctrine_Ticket_1706_TestCase extends Doctrine_UnitTestCase
         $user       = new Ticket_1706_User();
         $user->name = 'Bob';
         $user->save();
-        
+
         $manager->setCurrentConnection('conn_1');
         $u1 = Doctrine_Query::create()
             ->from('Ticket_1706_User u')

--- a/tests/Ticket/1713TestCase.php
+++ b/tests/Ticket/1713TestCase.php
@@ -21,7 +21,7 @@ class Doctrine_Ticket_1713_TestCase extends Doctrine_UnitTestCase
     public function testInheritanceSubclasses()
     {
         $records = Doctrine_Query::create()->query('FROM Parent1713 m');
-    
+
         foreach ($records as $rec) {
             $this->assertEqual(get_class($rec), $rec['title']);
         }

--- a/tests/Ticket/1745TestCase.php
+++ b/tests/Ticket/1745TestCase.php
@@ -34,7 +34,7 @@ class Doctrine_Ticket_1745_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('locality');
-        
+
         parent::prepareTables();
     }
 
@@ -44,18 +44,18 @@ class Doctrine_Ticket_1745_TestCase extends Doctrine_UnitTestCase
         $locality->postal_code = '1920';
         $locality->city        = 'Martigny';
         $locality->save();
-        
+
         $locality              = new Locality();
         $locality->postal_code = '1965';
         $locality->city        = 'Savièse';
         $locality->save();
-        
+
         $locality              = new Locality();
         $locality->postal_code = '2300';
         $locality->city        = 'Neuchâtel';
         $locality->save();
     }
-    
+
     public function testSearchable()
     {
         $query = Doctrine_Query::create()
@@ -63,13 +63,13 @@ class Doctrine_Ticket_1745_TestCase extends Doctrine_UnitTestCase
         $query   = Doctrine_Core::getTable('Locality')->search('martigny', $query);
         $results = $query->fetchArray();
         $this->assertEqual($results[0]['city'], 'Martigny');
-      
+
         $query = Doctrine_Query::create()
           ->from('Locality l');
         $query   = Doctrine_Core::getTable('Locality')->search('saviese', $query);
         $results = $query->fetchArray();
         $this->assertEqual($results[0]['city'], 'Savièse');
-      
+
         $query = Doctrine_Query::create()
           ->from('Locality l');
         $query   = Doctrine_Core::getTable('Locality')->search('neuchatel', $query);

--- a/tests/Ticket/1783TestCase.php
+++ b/tests/Ticket/1783TestCase.php
@@ -6,14 +6,14 @@ class Doctrine_Ticket_1783_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_1783';
         parent::prepareTables();
     }
-    
+
     public function testValidateLargeIntegers()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
 
         $test         = new Ticket_1783();
         $test->bigint = PHP_INT_MAX + 1;
-        
+
         $this->assertTrue($test->isValid());
 
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);

--- a/tests/Ticket/1821TestCase.php
+++ b/tests/Ticket/1821TestCase.php
@@ -42,17 +42,17 @@ class Doctrine_Ticket_1821_TestCase extends Doctrine_UnitTestCase
         );
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
-    
+
     public function execTest($klass)
     {
         //stores old validation setting
         $validation = Doctrine_Manager::getInstance()->getAttribute(Doctrine_Core::ATTR_VALIDATE);
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         $record       = new $klass();
         $record->name = 'test';
         try {
@@ -64,31 +64,31 @@ class Doctrine_Ticket_1821_TestCase extends Doctrine_UnitTestCase
             );
         }
         $this->pass();
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_VALIDATE, $validation);
     }
-    
+
     public function testShouldAllowNotUsingAliases()
     {
         $this->execTest('Doctrine_Ticket_1821_Record');
     }
-    
+
     public function testShouldAllowUsingAliasesOnId()
     {
         $this->execTest('Doctrine_Ticket_1821_Record_ID_Aliased');
     }
-    
+
     public function testShouldAllowUsingAliasesOnColumn()
     {
         $this->execTest('Doctrine_Ticket_1821_Record_Column_Aliased');
     }
-    
+
     public function testShouldAllowUsingAliasesOnBoth()
     {
         $this->execTest('Doctrine_Ticket_1821_Record_Full_Aliased');
     }
 }
-        
+
 class Doctrine_Ticket_1821_Record_Full_Aliased extends Doctrine_Record
 {
     public function setTableDefinition()

--- a/tests/Ticket/1830TestCase.php
+++ b/tests/Ticket/1830TestCase.php
@@ -22,7 +22,7 @@ class Doctrine_Ticket_1830_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function prepareTables()
     {
         try {

--- a/tests/Ticket/1858TestCase.php
+++ b/tests/Ticket/1858TestCase.php
@@ -51,7 +51,7 @@ class Doctrine_Ticket_1858_TestCase extends Doctrine_UnitTestCase
                 array(':adjustment' => $adjustment)
             )
             ->where('id = :id', array(':id' => $foo_id));
-            
+
         $this->assertEqual($query->getSqlQuery(), 'UPDATE t1858__foo SET quantity = GREATEST(CAST(quantity AS SIGNED + :adjustment,0)) WHERE (id = :id)');
     }
 }

--- a/tests/Ticket/1860TestCase.php
+++ b/tests/Ticket/1860TestCase.php
@@ -72,7 +72,7 @@ class Doctrine_Ticket_1860_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual(count($pager->execute()->toArray()), 0);
         $this->assertEqual($pager->getQuery()->getSqlQuery(), 'SELECT t.id AS t__id, t.username AS t__username, t.password AS t__password, t.deleted_at AS t__deleted_at FROM ticket_1860_users t WHERE (t.deleted_at IS NULL) LIMIT 5');
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, false);
     }
 }

--- a/tests/Ticket/1865TestCase.php
+++ b/tests/Ticket/1865TestCase.php
@@ -50,11 +50,11 @@ class Doctrine_Ticket_1865_TestCase extends Doctrine_UnitTestCase
         $user->password  = '!';
         $user->Profile;
         $user->save();
-        
+
         $this->assertNotEqual($user->Profile->id, null); // Ticket_1865_Profile is saved
         $user->delete();
     }
-    
+
     public function testSaveWithRelatedWithPreInsert()
     {
         $user            = new Ticket_1865_User();
@@ -62,7 +62,7 @@ class Doctrine_Ticket_1865_TestCase extends Doctrine_UnitTestCase
         $user->loginname = 'world';
         $user->password  = '!';
         $user->save(); // $user->Ticket_1865_Profile must be called in Ticket_1865_User::preInsert
-        
+
         $this->assertNotEqual($user->Profile->id, null); // Ticket_1865_Profile is NOT saved - test failure
         $user->delete();
     }

--- a/tests/Ticket/1876TestCase.php
+++ b/tests/Ticket/1876TestCase.php
@@ -41,7 +41,7 @@ class Doctrine_Ticket_1876_TestCase extends Doctrine_UnitTestCase
         );
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         for ($i = 0; $i < 2; $i++) {
@@ -49,33 +49,33 @@ class Doctrine_Ticket_1876_TestCase extends Doctrine_UnitTestCase
             $company->name = 'Test Company ' . ($i + 1);
             $company->save();
         }
-        
+
         for ($i = 0; $i < 10; $i++) {
             $recipe = new T1876_Recipe();
-            
+
             $recipe->name                      = 'test ' . $i;
             $recipe->company_id                = ($i % 3 == 0) ? 1 : 2;
             $recipe->RecipeIngredients[]->name = 'test';
-            
+
             $recipe->save();
-            
+
             if ($i % 2 == 0) {
                 $recipe->delete();
             }
         }
     }
-    
+
     public function testTicket()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, true);
-        
+
         try {
             $q = Doctrine_Query::create()
                 ->from('T1876_Recipe r')
                 ->leftJoin('r.Company c')
                 ->leftJoin('r.RecipeIngredients')
                 ->addWhere('c.id = ?', 2);
-            
+
             $this->assertEqual(
                 $q->getCountSqlQuery(),
                 'SELECT COUNT(*) AS num_results ' .
@@ -89,11 +89,11 @@ class Doctrine_Ticket_1876_TestCase extends Doctrine_UnitTestCase
         } catch (Exception $e) {
             $this->fail($e->getMessage());
         }
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_USE_DQL_CALLBACKS, false);
     }
 }
-        
+
 class T1876_Recipe extends Doctrine_Record
 {
     public function setTableDefinition()
@@ -102,12 +102,12 @@ class T1876_Recipe extends Doctrine_Record
         $this->hasColumn('company_id', 'integer', null);
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasOne('T1876_Company as Company', array('local' => 'company_id', 'foreign' => 'id'));
         $this->hasMany('T1876_RecipeIngredient as RecipeIngredients', array('local' => 'id', 'foreign' => 'recipe_id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }
@@ -119,11 +119,11 @@ class T1876_Company extends Doctrine_Record
         $this->hasColumn('id', 'integer', null, array('autoincrement' => true, 'primary' => true));
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('T1876_Recipe as Recipes', array('local' => 'id', 'foreign' => 'company_id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }
@@ -136,11 +136,11 @@ class T1876_RecipeIngredient extends Doctrine_Record
         $this->hasColumn('recipe_id', 'integer', null);
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasOne('T1876_Recipe as Recipe', array('local' => 'recipe_id', 'foreign' => 'id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }

--- a/tests/Ticket/1876bTestCase.php
+++ b/tests/Ticket/1876bTestCase.php
@@ -21,7 +21,7 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function prepareTables()
     {
         try {
@@ -30,11 +30,11 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
             $this->conn->exec('DROP TABLE t1876b_company');
         } catch (Doctrine_Connection_Exception $e) {
         }
-        
+
         $this->tables = array(
             'T1876b_Recipe', 'T1876b_Company', 'T1876b_RecipeIngredient'
         );
-        
+
         parent::prepareTables();
     }
 
@@ -47,16 +47,16 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
             $company->name = 'Test Company ' . ($i + 1);
             $company->save($this->connection);
         }
-        
+
         for ($i = 0; $i < 10; $i++) {
             $recipe = new T1876b_Recipe();
-            
+
             $recipe->name                      = 'test ' . $i;
             $recipe->company_id                = ($i % 3 == 0) ? 1 : 2;
             $recipe->RecipeIngredients[]->name = 'test';
-            
+
             $recipe->save($this->connection);
-            
+
             if ($i % 2 == 0) {
                 $recipe->delete($this->connection);
             }
@@ -68,7 +68,7 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
                 ->leftJoin('r.Company c')
                 ->leftJoin('r.RecipeIngredients')
                 ->addWhere('c.id = ?', 2);
-            
+
             $this->assertEqual(
                 $q->getCountSqlQuery(),
                 'SELECT COUNT(*) AS num_results FROM ('
@@ -96,12 +96,12 @@ class T1876b_Recipe extends Doctrine_Record
         $this->hasColumn('company_id', 'integer', null);
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasOne('T1876b_Company as Company', array('local' => 'company_id', 'foreign' => 'id'));
         $this->hasMany('T1876b_RecipeIngredient as RecipeIngredients', array('local' => 'id', 'foreign' => 'recipe_id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }
@@ -113,11 +113,11 @@ class T1876b_Company extends Doctrine_Record
         $this->hasColumn('id', 'integer', null, array('autoincrement' => true, 'primary' => true));
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('T1876b_Recipe as Recipes', array('local' => 'id', 'foreign' => 'company_id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }
@@ -130,11 +130,11 @@ class T1876b_RecipeIngredient extends Doctrine_Record
         $this->hasColumn('recipe_id', 'integer', null);
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasOne('T1876b_Recipe as Recipe', array('local' => 'recipe_id', 'foreign' => 'id'));
-        
+
         $this->actAs('SoftDelete');
     }
 }

--- a/tests/Ticket/1986TestCase.php
+++ b/tests/Ticket/1986TestCase.php
@@ -99,7 +99,7 @@ class Testing_Ticket_1986Link extends Doctrine_Record
         $this->hasColumn('id_1', 'integer', null, array());
         $this->hasColumn('id_2', 'integer', null, array());
     }
-    
+
     public function setUp()
     {
         // setup relations

--- a/tests/Ticket/1991TestCase.php
+++ b/tests/Ticket/1991TestCase.php
@@ -44,7 +44,7 @@ class Doctrine_Ticket_1991_TestCase extends Doctrine_UnitTestCase
         $tag       = new NewTag();
         $tag->name = 'name';
         $tag->save();
-        
+
         $tag       = new NewTag();
         $tag->name = 'foobar';
         $tag->save();

--- a/tests/Ticket/2032TestCase.php
+++ b/tests/Ticket/2032TestCase.php
@@ -18,7 +18,7 @@
  * and is licensed under the LGPL. For more information, see
  * <http://www.doctrine-project.org>.
  */
- 
+
 /**
  * Doctrine_Ticket_2032_TestCase
  *
@@ -40,7 +40,7 @@ class Doctrine_Ticket_2032_TestCase extends Doctrine_UnitTestCase
                 ->select('u.*')
                 ->from('User u')
                 ->orderby('u.name,u.id,u.password');
- 
+
         try {
             $u = $q->execute();
             $this->pass();

--- a/tests/Ticket/2105TestCase.php
+++ b/tests/Ticket/2105TestCase.php
@@ -48,7 +48,7 @@ class Doctrine_Ticket_2105_TestCase extends Doctrine_UnitTestCase
                 ;
             $q->execute();
             //echo $q->getSqlQuery().PHP_EOL;
-            
+
             $this->assertEqual(
                 $q->getSqlQuery(),
                 'SELECT t.id AS t__id, t2.id AS t2__id, t2.lang AS t2__lang ' .
@@ -56,12 +56,12 @@ class Doctrine_Ticket_2105_TestCase extends Doctrine_UnitTestCase
                 'INNER JOIN ticket_2105__article_translation t2 ' .
                 'ON t.id = t2.id AND (t2.name != ?)'
             );
-            
+
             // we need to modify the query here - it can be anything, I've chosen addSelect
             $q->addSelect('t.name');
             $q->execute();
             //echo $q->getSqlQuery().PHP_EOL;
-            
+
             $this->assertEqual(
                 $q->getSqlQuery(),
                 'SELECT t.id AS t__id, t2.id AS t2__id, t2.lang AS t2__lang, t2.name AS t2__name ' .
@@ -69,7 +69,7 @@ class Doctrine_Ticket_2105_TestCase extends Doctrine_UnitTestCase
                 'INNER JOIN ticket_2105__article_translation t2 ' .
                 'ON t.id = t2.id AND (t2.name != ?)'
             );
-            
+
             //$this->pass();
         } catch (Exception $e) {
             $this->fail($e->getMessage());

--- a/tests/Ticket/2158TestCase.php
+++ b/tests/Ticket/2158TestCase.php
@@ -42,7 +42,7 @@ class T2158_Model2 extends Doctrine_Record
     public function setTableDefinition()
     {
     }
-    
+
 
     public function setUp()
     {

--- a/tests/Ticket/2229TestCase.php
+++ b/tests/Ticket/2229TestCase.php
@@ -37,19 +37,19 @@ class Doctrine_Ticket_2229_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_2229_SlugBug';
         parent::prepareTables();
     }
-  
+
     public function testTicket()
     {
         $d       = new Ticket_2229_SlugBug();
         $d->name = 'String with UpperLowerCase';
         $d->save();
         $this->assertEqual($d->slug, 'string-with-upperlowercase');
-    
+
         $d       = new Ticket_2229_SlugBug();
         $d->name = 'Custom name OPACs';
         $d->save();
         $this->assertEqual($d->slug, 'custom-name-opacs');
-    
+
         $d       = new Ticket_2229_SlugBug();
         $d->name = 'Présentation unifiée OPACs';
         $d->save();
@@ -66,7 +66,7 @@ class Ticket_2229_SlugBug extends Doctrine_Record
         $this->hasColumn('id', 'integer', 11, array('primary' => true, 'notnull' => true, 'autoincrement' => true));
         $this->hasColumn('name', 'string');
     }
-    
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/Ticket/2251TestCase.php
+++ b/tests/Ticket/2251TestCase.php
@@ -47,7 +47,7 @@ class Doctrine_Ticket_2251_TestCase extends Doctrine_UnitTestCase
             'oracle',
             'mssql'
         );
-        
+
         $expected = array(
             'mysql'  => 'CREATE TABLE test_string_length (id BIGINT AUTO_INCREMENT, test_string TEXT, PRIMARY KEY(id)) ENGINE = INNODB',
             'sqlite' => 'CREATE TABLE test_string_length (id INTEGER PRIMARY KEY AUTOINCREMENT, test_string TEXT)',

--- a/tests/Ticket/2292TestCase.php
+++ b/tests/Ticket/2292TestCase.php
@@ -39,15 +39,15 @@ class Doctrine_Ticket_2292_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'mkContent';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
-    
+
     public function testOwningSideRelationToArray()
     {
         $article = new mkArticle();
-        
+
         $this->assertEqual($article->content->toArray(false), array('id' => null, 'body' => null));
     }
 }
@@ -60,7 +60,7 @@ class mkArticle extends Doctrine_Record
         $this->hasColumn('id', 'integer', 4, array('type' => 'integer', 'autoincrement' => true, 'primary' => true, 'length' => 4));
         $this->hasColumn('title', 'string', 200);
     }
-    
+
     public function setup()
     {
         $this->hasOne('mkContent as content', array('local'      => 'id',
@@ -77,7 +77,7 @@ class mkContent extends Doctrine_Record
         $this->hasColumn('id', 'integer', 4, array('type' => 'integer', 'autoincrement' => false, 'primary' => true, 'length' => 4));
         $this->hasColumn('body', 'string');
     }
-    
+
     public function setup()
     {
         $this->hasOne('mkArticle as article', array('local'      => 'id',

--- a/tests/Ticket/2377TestCase.php
+++ b/tests/Ticket/2377TestCase.php
@@ -45,9 +45,9 @@ class Doctrine_Ticket_2377_TestCase extends Doctrine_UnitTestCase
             $author          = new Ticket_2377_Author();
             $article         = new Ticket_2377_Article();
             $article->Author = $author;
-        
+
             $array = $article->toArray(true);
-                
+
             $article2 = new Ticket_2377_Article();
             $article2->synchronizeWithArray($array);
 

--- a/tests/Ticket/2398TestCase.php
+++ b/tests/Ticket/2398TestCase.php
@@ -35,14 +35,14 @@ class Doctrine_Ticket_2398_TestCase extends Doctrine_UnitTestCase
     // Since this file is the subject of the test, we need to add some utf-8 chars to mess up
     // the non-binary-safe count.
     private $randomUtf8 = 'øåæØÅÆØÅæøåøæØÅæøåØÆØåøÆØÅøæøåøæøåÅØÆØ';
-  
+
     public function testIsValidLength()
     {
         $binaryValue = fread(fopen(__FILE__, 'r'), filesize(__FILE__));
 
         //Should pass with size the same size as maximum size
         $this->assertTrue(Doctrine_Validator::validateLength($binaryValue, 'blob', filesize(__FILE__)));
-        
+
         //Should fail with maximum size 1 less than actual file size
         $this->assertFalse(Doctrine_Validator::validateLength($binaryValue, 'blob', filesize(__FILE__) - 1));
     }

--- a/tests/Ticket/381TestCase.php
+++ b/tests/Ticket/381TestCase.php
@@ -40,7 +40,7 @@ class Doctrine_Ticket_381_TestCase extends Doctrine_UnitTestCase
         $this->tables = array('Book');
         parent::prepareTables();
     }
-    
+
     public function testTicket()
     {
         $obj = new Book();

--- a/tests/Ticket/384TestCase.php
+++ b/tests/Ticket/384TestCase.php
@@ -49,7 +49,7 @@ class Doctrine_Ticket_384_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'ticket384_ResumeHasLanguage';
         $this->tables[] = 'ticket384_LanguageLevel';
         $this->tables[] = 'ticket384_Language';
-        
+
         parent :: prepareTables();
     }
 
@@ -63,7 +63,7 @@ class Doctrine_Ticket_384_TestCase extends Doctrine_UnitTestCase
           ->leftJoin('Resume.KnownLanguages KnownLanguages')
           ->leftJoin('KnownLanguages.Level Level')
           ->leftJoin('KnownLanguages.Language Language');
-        
+
         try {
             // get the wrong resultset
             $aResult = $q->fetchArray();
@@ -72,7 +72,7 @@ class Doctrine_Ticket_384_TestCase extends Doctrine_UnitTestCase
             $this->pass();
         }
         $q->free();
-        
+
         // now correct
         // we have to select at least KnownLanguages.id in order to get the Levels,
         // which are only reachable through the KnownLanguages, hydrated properly.
@@ -82,12 +82,12 @@ class Doctrine_Ticket_384_TestCase extends Doctrine_UnitTestCase
           ->leftJoin('Resume.KnownLanguages KnownLanguages')
           ->leftJoin('KnownLanguages.Level Level')
           ->leftJoin('KnownLanguages.Language Language');
-        
+
         $aResult = $q->fetchArray();
         // should be setted
         $bSuccess = isset($aResult[0]['KnownLanguages'][0]['Level']);
         $this->assertTrue($bSuccess);
-          
+
         if (! $bSuccess) {
             $this->fail('fetchArray doesnt hydrate nested child relations, if parent doesnt have a column selected');
         }
@@ -104,7 +104,7 @@ class ticket384_Resume extends Doctrine_Record
           'autoincrement' => true,
           'unsigned'      => true,
           ));
-          
+
         $this->hasColumn('title', 'string', 255);
     }
 
@@ -137,7 +137,7 @@ class ticket384_ResumeHasLanguage extends Doctrine_Record
         $this->hasColumn('language_level_id', 'integer', 2, array(
       'unsigned' => true,
       ));
-    
+
         $this->hasColumn('comments', 'string', 4000, array());
     }
 
@@ -173,7 +173,7 @@ class ticket384_Language extends Doctrine_Record
 
         $this->hasColumn('label', 'string', 100, array('notnull' => true));
     }
-  
+
     public function setUp()
     {
         $this->hasMany('ticket384_Resume as Resumes', array('local' => 'id', 'foreign' => 'language_id'));

--- a/tests/Ticket/428TestCase.php
+++ b/tests/Ticket/428TestCase.php
@@ -14,7 +14,7 @@
 class Doctrine_Ticket_428_TestCase extends Doctrine_UnitTestCase
 {
     private $_albums;
-    
+
     public function prepareData()
     {
     }
@@ -40,7 +40,7 @@ class Doctrine_Ticket_428_TestCase extends Doctrine_UnitTestCase
         foreach ($this->_albums as $album) {
             $album->clearRelated();
         }
-        
+
         $q = new Doctrine_Query();
 
         $q->select('a.name, COUNT(s.id) count')->from('Album a')->leftJoin('a.Song s')->groupby('a.id');

--- a/tests/Ticket/438TestCase.php
+++ b/tests/Ticket/438TestCase.php
@@ -117,7 +117,7 @@ class T438_Student extends Doctrine_Record
         $this->hasColumn('s_id as id', 'varchar', 30, array(  'primary' => true,));
         $this->hasColumn('s_name as name', 'varchar', 50, array());
     }
-  
+
     public function setUp()
     {
         $this->hasMany('T438_Course as StudyCourses', array('refClass' => 'T438_StudentCourse', 'local' => 'sc_student_id', 'foreign' => 'sc_course_id'));
@@ -134,7 +134,7 @@ class T438_Course extends Doctrine_Record
         $this->hasColumn('c_id as id', 'varchar', 20, array(  'primary' => true,));
         $this->hasColumn('c_name as name', 'varchar', 50, array());
     }
-  
+
     public function setUp()
     {
         $this->hasMany('T438_Student as Students', array('refClass' => 'T438_StudentCourse', 'local' => 'sc_course_id', 'foreign' => 'sc_student_id'));
@@ -151,7 +151,7 @@ class T438_StudentCourse extends Doctrine_Record
         $this->hasColumn('sc_course_id as course_id', 'varchar', 20, array(  'primary' => true,));
         $this->hasColumn('sc_remark  as remark', 'varchar', 500, array());
     }
-  
+
     public function setUp()
     {
         $this->hasOne('T438_Student as Student', array('local' => 'sc_student_id', 'foreign' => 's_id'));

--- a/tests/Ticket/480TestCase.php
+++ b/tests/Ticket/480TestCase.php
@@ -30,7 +30,7 @@
  * @since       1.0
  * @version     $Revision$
  */
- 
+
 class stComment extends Doctrine_Record
 {
     public function setTableDefinition()
@@ -48,12 +48,12 @@ class Doctrine_Ticket_480_TestCase extends Doctrine_UnitTestCase
         $this->dbh  = new Doctrine_Adapter_Mock('oracle');
         $this->conn = Doctrine_Manager::getInstance()->openConnection($this->dbh);
     }
-    
+
     public function testTicket()
     {
         $this->conn->export->exportClasses(array('stComment'));
         $queries = $this->dbh->getAll();
-        
+
         // (2nd|1st except transaction init.) executed query must be CREATE TABLE or CREATE SEQUENCE, not CREATE TRIGGER
         // Trigger can be created after both CREATE TABLE and CREATE SEQUENCE
         $this->assertFalse(preg_match('~^CREATE TRIGGER.*~', $queries[1]));

--- a/tests/Ticket/574TestCase.php
+++ b/tests/Ticket/574TestCase.php
@@ -44,35 +44,35 @@ class Doctrine_Ticket_574_TestCase extends Doctrine_UnitTestCase
             $oAuthor->save();
         }
     }
-    
+
     /**
      * prepareTables
      */
-    
+
     public function prepareTables()
     {
         $this->tables   = array();
         $this->tables[] = 'Author';
         $this->tables[] = 'Book';
-      
+
         parent :: prepareTables();
     }
-    
-    
+
+
     /**
      * Test the existence expected indexes
      */
-    
+
     public function testTicket()
     {
         $q = new Doctrine_Query();
 
         // simple query with 1 column selected
         $cAuthors = $q->select('book_id')->from('Author')->groupBy('book_id')->where('book_id = 2')->execute();
-        
+
         // simple query, with 1 join and all columns selected
         $cAuthors = $q->from('Author, Author.Book')->execute();
-        
+
         foreach ($cAuthors as $oAuthor) {
             if (! $oAuthor->name) {
                 $this->fail('Querying the same table multiple times triggers hydration/caching(?) bug');

--- a/tests/Ticket/626BTestCase.php
+++ b/tests/Ticket/626BTestCase.php
@@ -70,7 +70,7 @@ class Doctrine_Ticket_626B_TestCase extends Doctrine_UnitTestCase
 
         $this->newStudentCourse($student1, $course1);
         $this->newStudentCourse($student1, $course2);
-      
+
         try {
             $group = $student1->get('Group');
             $this->pass();
@@ -98,7 +98,7 @@ class T626B_Student extends Doctrine_Record
         $this->hasColumn('s_g_id as group_id', 'varchar', 30, array('notnull' => true));
         $this->hasColumn('s_name as name', 'varchar', 50, array());
     }
-  
+
     public function setUp()
     {
         $this->hasMany('T626_Course as StudyCourses', array('refClass' => 'T626B_StudentCourse', 'local' => 'sc_student_id', 'foreign' => 'sc_course_id'));
@@ -115,7 +115,7 @@ class T626_Group extends Doctrine_Record
         $this->hasColumn('g_id as id', 'varchar', 30, array(  'primary' => true,));
         $this->hasColumn('g_name as name', 'varchar', 50, array());
     }
-  
+
     public function setUp()
     {
         $this->hasMany(
@@ -135,7 +135,7 @@ class T626_Course extends Doctrine_Record
         $this->hasColumn('c_id as id', 'varchar', 20, array(  'primary' => true,));
         $this->hasColumn('c_name as name', 'varchar', 50, array());
     }
-  
+
     public function setUp()
     {
         $this->hasMany('T626B_Student as Students', array('refClass' => 'T626B_StudentCourse', 'local' => 'sc_course_id', 'foreign' => 'sc_student_id'));
@@ -152,7 +152,7 @@ class T626B_StudentCourse extends Doctrine_Record
         $this->hasColumn('sc_course_id as course_id', 'varchar', 20, array(  'primary' => true,));
         $this->hasColumn('sc_remark  as remark', 'varchar', 500, array());
     }
-  
+
     public function setUp()
     {
         $this->hasOne('T626B_Student as Student', array('local' => 'sc_student_id', 'foreign' => 's_id'));

--- a/tests/Ticket/638TestCase.php
+++ b/tests/Ticket/638TestCase.php
@@ -104,7 +104,7 @@ class T638_Student extends Doctrine_Record
         $this->hasColumn('s_g_id as group_id', 'varchar', 30, array('notnull' => true));
         $this->hasColumn('s_name as name', 'varchar', 50, array('notnull' => true));
     }
-  
+
     public function setUp()
     {
     }
@@ -119,7 +119,7 @@ class T638_Course extends Doctrine_Record
         $this->hasColumn('c_id as id', 'varchar', 20, array(  'primary' => true,));
         $this->hasColumn('c_name as name', 'varchar', 50, array('notnull' => true));
     }
-  
+
     public function setUp()
     {
     }
@@ -140,7 +140,7 @@ class T638_StudentCourse extends Doctrine_Record
         $this->hasColumn('sc_course_id as course_id', 'varchar', 20, array(  'primary' => true,));
         $this->hasColumn('sc_remark  as remark', 'varchar', 500, array('notnull' => true));
     }
-  
+
     public function setUp()
     {
         $this->hasOne('T638_Student as Student', array('local' => 'sc_student_id', 'foreign' => 's_id'));

--- a/tests/Ticket/673TestCase.php
+++ b/tests/Ticket/673TestCase.php
@@ -30,10 +30,10 @@ class Doctrine_Ticket_673_TestCase extends Doctrine_UnitTestCase
         ->update('T673_Student s')
         ->set('s.foo', 's.foo + 1')
         ->where('s.id = 2');
-      
+
         $this->assertTrue(preg_match_all('/(s_foo)/', $q->getSqlQuery(), $m) === 2);
         $this->assertTrue(preg_match_all('/(s_id)/', $q->getSqlQuery(), $m) === 1);
-      
+
         try {
             $q->execute();
             $this->pass();
@@ -45,7 +45,7 @@ class Doctrine_Ticket_673_TestCase extends Doctrine_UnitTestCase
         ->delete()
         ->from('T673_Student s')
         ->where('s.name = ? AND s.foo < ?', 'foo', 3);
-      
+
         $this->assertTrue(preg_match_all('/(s_name)/', $q->getSqlQuery(), $m) === 1);
         $this->assertTrue(preg_match_all('/(s_foo)/', $q->getSqlQuery(), $m) === 1);
 

--- a/tests/Ticket/736TestCase.php
+++ b/tests/Ticket/736TestCase.php
@@ -18,11 +18,11 @@ class Doctrine_Ticket_736_TestCase extends Doctrine_UnitTestCase
 
         $module                   = new T736_Module();
         $module->moduledelegateid = $delegate->id;
-        
+
         $delegate->parent = $module;
         $delegate->save();
     }
-    
+
     public function prepareTables()
     {
         $this->tables   = array();
@@ -62,13 +62,13 @@ class T736_ModuleDelegate extends Doctrine_Record
         $this->hasColumn('moduleid', 'integer', 4, array());
         $this->hasColumn('content', 'string', 2000);
     }
-    
+
     public function setUp()
     {
         $this->hasOne('T736_Module as parent', array('local' => 'moduleid', 'foreign' => 'id'));
     }
-    
-    
+
+
     public function preUpdate($event)
     {
         $this->parent->lastchange = date('Y-m-d H:i:s', time());

--- a/tests/Ticket/749TestCase.php
+++ b/tests/Ticket/749TestCase.php
@@ -46,10 +46,10 @@ class Doctrine_Ticket_749_TestCase extends Doctrine_UnitTestCase
     public function testSelectDataFromSubclassAsCollection()
     {
         $records = Doctrine_Query::create()->query('FROM Record749 r ORDER BY r.title', array());
-        
+
         $this->verifyRecords($records);
     }
-    
+
     public function testSelectDataFromParentClassAsCollection()
     {
         $records = Doctrine_Query::create()->query('FROM Parent749 p ORDER BY p.title', array());

--- a/tests/Ticket/7745TestCase.php
+++ b/tests/Ticket/7745TestCase.php
@@ -53,7 +53,7 @@ class Doctrine_Ticket_7745_TestCase extends Doctrine_UnitTestCase
         $test1->name        = 'test';
         $test1->RecordTest2 = $test2;
         $test1->save();
-        
+
         $id = $test2->id;
         $test2->free();
 

--- a/tests/Ticket/786TestCase.php
+++ b/tests/Ticket/786TestCase.php
@@ -38,15 +38,15 @@ class Doctrine_Ticket_786_TestCase extends Doctrine_UnitTestCase
         // So you can access User->Phonenumber instanceof Doctrine_Collection
         $query = new Doctrine_Query();
         $query->from('User u, u.Phonenumber p');
-    
+
         $user1 = $query->execute()->getFirst();
-    
+
         // Now query for the same data, without the Phonenumber
         $query = new Doctrine_Query();
         $query->from('User u');
-    
+
         $user2 = $query->execute()->getFirst();
-    
+
         // Now if we try and see if Phonenumber is present in $user1 after the 2nd query
         if (! isset($user1->Phonenumber)) {
             $this->fail('Phonenumber overwritten by 2nd query hydrating');

--- a/tests/Ticket/838TestCase.php
+++ b/tests/Ticket/838TestCase.php
@@ -21,7 +21,7 @@ class Doctrine_Ticket_838_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     /**
      * Test that the old root is placed correctly under the new root
      */
@@ -31,40 +31,40 @@ class Doctrine_Ticket_838_TestCase extends Doctrine_UnitTestCase
         $node->name = 'oldroot';
         $tree       = $this->conn->getTable('NestedSetTest_SingleRootNode')->getTree();
         $tree->createRoot($node);
-        
+
         $oldRoot = $node->copy();
         // detach the node, so that it can be inserted as a new node
         $oldRoot->getNode()->detach();
-        
+
         $node->getNode()->delete();
-        
+
         $this->assertTrue($oldRoot !== $node);
         $this->assertEqual(0, $oldRoot['lft']);
         $this->assertEqual(0, $oldRoot['rgt']);
         $this->assertEqual(0, $oldRoot['level']);
-        
+
         $newRoot       = new NestedSetTest_SingleRootNode();
         $newRoot->name = 'newroot';
         $tree->createRoot($newRoot);
         $this->assertEqual(1, $newRoot['lft']);
         $this->assertEqual(2, $newRoot['rgt']);
         $this->assertEqual(0, $newRoot['level']);
-        
+
         $oldRoot->getNode()->insertAsFirstChildOf($newRoot);
-        
+
         $this->assertEqual(2, $oldRoot['lft']);
         $this->assertEqual(3, $oldRoot['rgt']);
         $this->assertEqual(1, $oldRoot['level']);
-        
+
         $newRoot->refresh();
-        
+
         $this->assertEqual(1, $newRoot['lft']);
         $this->assertEqual(4, $newRoot['rgt']);
         $this->assertEqual(0, $newRoot['level']);
-        
+
         $children = $newRoot->getNode()->getChildren();
         $oldRoot  = $children[0];
-    
+
         $this->assertEqual(2, $oldRoot['lft']);
         $this->assertEqual(3, $oldRoot['rgt']);
         $this->assertEqual(1, $oldRoot['level']);

--- a/tests/Ticket/867TestCase.php
+++ b/tests/Ticket/867TestCase.php
@@ -37,7 +37,7 @@ class Doctrine_Ticket_867_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'T867_Section';
         parent::prepareTables();
     }
-  
+
     public function testTicket()
     {
         try {
@@ -46,7 +46,7 @@ class Doctrine_Ticket_867_TestCase extends Doctrine_UnitTestCase
             $s->Translation['en']->title   = 'Test title';
             $s->Translation['en']->summary = 'Test summary';
             $s->save();
-          
+
             $this->assertTrue($s->id > 0);
             $this->assertEqual($s->name, 'Test name');
             $this->assertEqual($s->Translation['en']->title, 'Test title');
@@ -71,12 +71,12 @@ class T867_Section extends Doctrine_Record
         $this->hasColumn('name', 'string', 60, array('notnull' => true));
         $this->hasColumn('title', 'string', 60, array('notnull' => true));
         $this->hasColumn('summary', 'string', 255);
-    
+
         $this->option('type', 'INNODB');
         $this->option('collate', 'utf8_unicode_ci');
         $this->option('charset', 'utf8');
     }
-  
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/Ticket/876TestCase.php
+++ b/tests/Ticket/876TestCase.php
@@ -64,9 +64,9 @@ class Doctrine_Ticket_876_TestCase extends Doctrine_UnitTestCase
 
         $guardUser = $person->get('sfGuardUser');
         $id        = $guardUser->get('id');
-      
+
         $guardUser->free();
-      
+
         $query = new Doctrine_Query();
 
         $query->select('s.*, p.*, ps.*');
@@ -77,7 +77,7 @@ class Doctrine_Ticket_876_TestCase extends Doctrine_UnitTestCase
 
         $user  = $query->fetchOne();
         $array = $user->toArray(true);
-      
+
         $this->assertEqual($array['id'], 1);
         $this->assertEqual($array['name'], 'Fixe');
         $this->assertTrue(isset($array['Person']['Profiles'][0]));

--- a/tests/Ticket/889TestCase.php
+++ b/tests/Ticket/889TestCase.php
@@ -82,7 +82,7 @@ class Doctrine_Ticket_889_TestCase extends Doctrine_UnitTestCase
         $test             = new Ticket_889();
         $test->table_name = 'Feature';
         $test->save();
-        
+
         $test3             = new Ticket_889();
         $test3->table_name = 'Application';
         $test3->save();

--- a/tests/Ticket/904TestCase.php
+++ b/tests/Ticket/904TestCase.php
@@ -37,7 +37,7 @@ class Doctrine_Ticket_904_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'T904_Section';
         parent::prepareTables();
     }
-  
+
     public function testTicket()
     {
         try {
@@ -46,7 +46,7 @@ class Doctrine_Ticket_904_TestCase extends Doctrine_UnitTestCase
             $s->Translation['en']->title   = 'Test title';
             $s->Translation['en']->summary = 'Test summary';
             $s->save();
-          
+
             $this->assertTrue($s->id > 0);
             $this->assertEqual($s->Translation['en']->title, 'Test title');
             $this->assertEqual($s->Translation['en']->summary, 'Test summary');
@@ -65,7 +65,7 @@ class T904_Section extends Doctrine_Record
         $this->hasColumn('title', 'string', 60, array('notnull' => true));
         $this->hasColumn('summary', 'string', 255);
     }
-  
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/Ticket/912TestCase.php
+++ b/tests/Ticket/912TestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Ticket_912_TestCase extends Doctrine_UnitTestCase
   /**
    * prepareData
    */
-    
+
     public function prepareData()
     {
         $oResume                                     = new ticket912_Resume;
@@ -46,11 +46,11 @@ class Doctrine_Ticket_912_TestCase extends Doctrine_UnitTestCase
         $oResume->KnownLanguages[0]->Level->label    = 'Fluent';
         $oResume->save();
     }
-    
+
     /**
      * prepareTables
      */
-    
+
     public function prepareTables()
     {
         $this->tables   = array();
@@ -59,15 +59,15 @@ class Doctrine_Ticket_912_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'ticket912_ResumeHasLanguage';
         $this->tables[] = 'ticket912_LanguageLevel';
         $this->tables[] = 'ticket912_Language';
-        
+
         parent :: prepareTables();
     }
-    
-    
+
+
     /**
      * Test the existence expected indexes
      */
-    
+
     public function testTicket()
     {
         $q = new Doctrine_Query();
@@ -79,13 +79,13 @@ class Doctrine_Ticket_912_TestCase extends Doctrine_UnitTestCase
           ->leftJoin('Resume.KnownLanguages KnownLanguages')
           ->leftJoin('KnownLanguages.Level Level')
           ->leftJoin('KnownLanguages.Language Language');
-        
+
         $aResult = $q->fetchArray();
 
         // should be setted..
         $issetLevel    = isset($aResult[0]['KnownLanguages'][0]['Level']);
         $issetLanguage = isset($aResult[0]['KnownLanguages'][0]['Language']);
-        
+
         $this->assertTrue($issetLevel);
         $this->assertTrue($issetLanguage);
     }
@@ -101,7 +101,7 @@ class ticket912_Resume extends Doctrine_Record
     /**
    * setTableDefinition
    */
-    
+
     public function setTableDefinition()
     {
         $this->setTableName('resume');
@@ -118,11 +118,11 @@ class ticket912_Resume extends Doctrine_Record
     /**
      * setUp
      */
-  
+
     public function setUp()
     {
         $this->hasMany('ticket912_ResumeHasLanguage as KnownLanguages', array('local' => 'id', 'foreign' => 'resume_id'));
-    
+
         $this->hasOne('ticket912_Person as Person', array(
       'local'    => 'person_id',
       'foreign'  => 'id',
@@ -140,7 +140,7 @@ class ticket912_Person extends Doctrine_Record
     /**
      * setTableDefinition
      */
- 
+
     public function setTableDefinition()
     {
         $this->setTableName('person');
@@ -164,7 +164,7 @@ class ticket912_ResumeHasLanguage extends Doctrine_Record
     /**
      * setTableDefinition
      */
-    
+
     public function setTableDefinition()
     {
         $this->setTableName('resume_has_language');
@@ -186,14 +186,14 @@ class ticket912_ResumeHasLanguage extends Doctrine_Record
         $this->hasColumn('language_level_id', 'integer', 2, array(
       'unsigned' => true,
       ));
-    
+
         $this->hasColumn('comments', 'string', 4000, array());
     }
 
     /**
      * setUp
      */
-  
+
     public function setUp()
     {
         $this->hasOne('ticket912_Resume as Resume', array('local' => 'resume_id',
@@ -223,7 +223,7 @@ class ticket912_Language extends Doctrine_Record
     /**
      * setTableDefinition
      */
-    
+
     public function setTableDefinition()
     {
         $this->setTableName('language');
@@ -239,7 +239,7 @@ class ticket912_Language extends Doctrine_Record
     /**
      * setup
      */
-  
+
     public function setUp()
     {
         $this->hasMany('ticket912_Resume as Resumes', array('local' => 'id', 'foreign' => 'language_id'));
@@ -256,7 +256,7 @@ class ticket912_LanguageLevel extends Doctrine_Record
     /**
      * setTableDefinition
      */
-    
+
     public function setTableDefinition()
     {
         $this->setTableName('language_level');
@@ -272,7 +272,7 @@ class ticket912_LanguageLevel extends Doctrine_Record
     /**
      * setUp
      */
-  
+
     public function setUp()
     {
         $this->hasMany('ticket912_ResumeHasLanguage as ResumeKnownLanguages', array(

--- a/tests/Ticket/923TestCase.php
+++ b/tests/Ticket/923TestCase.php
@@ -77,7 +77,7 @@ class Doctrine_Ticket_923_TestCase extends Doctrine_UnitTestCase
           ->limit(20)
           ->offset(0)
           ->execute();
-          
+
             $this->assertEqual($result->count(), 3);
         } catch (Exception $e) {
             $this->fail($e->getMessage());

--- a/tests/Ticket/929TestCase.php
+++ b/tests/Ticket/929TestCase.php
@@ -42,7 +42,7 @@ class Doctrine_Ticket_929_TestCase extends Doctrine_UnitTestCase
 
         parent::prepareData();
     }
- 
+
     public function prepareTables()
     {
         $this->tables   = array();
@@ -53,7 +53,7 @@ class Doctrine_Ticket_929_TestCase extends Doctrine_UnitTestCase
 
         parent::prepareTables();
     }
-  
+
     public function testTicket()
     {
         try {

--- a/tests/Ticket/930TestCase.php
+++ b/tests/Ticket/930TestCase.php
@@ -45,10 +45,10 @@ class Doctrine_Ticket_930_TestCase extends Doctrine_UnitTestCase
         $oCategory->code                    = '1234';
         $oCategory->Translation['fr']->name = 'Developpement';
         $oCategory->Translation['en']->name = 'Development';
-     
+
         $oPerson->JobPositions[0]->name     = 'Webdeveloper';
         $oPerson->JobPositions[0]->Category = $oCategory;
-     
+
         $oPerson->JobPositions[1]->name     = 'Webmaster';
         $oPerson->JobPositions[1]->Category = $oCategory;
 
@@ -65,7 +65,7 @@ class Doctrine_Ticket_930_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'T930_Person';
         $this->tables[] = 'T930_JobPosition';
         $this->tables[] = 'T930_JobCategory';
-     
+
         parent :: prepareTables();
     }
 

--- a/tests/Ticket/935TestCase.php
+++ b/tests/Ticket/935TestCase.php
@@ -57,13 +57,13 @@ class Doctrine_Ticket_935_TestCase extends Doctrine_UnitTestCase
         } catch (Exception $e) {
             $this->fail($e->getMessage());
         }
-        
+
         $q   = new Doctrine_Query();
         $row = $q->select('a.*')
                  ->from('EnumUpdateBug a')
                  ->where('a.id = 1')
                  ->fetchOne();
-        
+
         $this->assertEqual($row->bla_id, 5);
     }
 }

--- a/tests/Ticket/941TestCase.php
+++ b/tests/Ticket/941TestCase.php
@@ -64,10 +64,10 @@ class Doctrine_Ticket_941_TestCase extends Doctrine_UnitTestCase
         $query = $query->from('Site s LEFT JOIN s.Variables v LEFT JOIN v.Values vv WITH vv.site_id = s.site_id');
 
         $sites = $query->execute();
-      
+
         $this->assertEqual('site1', $sites[0]->site_domain);
         $this->assertEqual(2, count($sites));
-      
+
         // this is important for the understanding of the behavior
         $this->assertIdentical($sites[0]->Variables[0], $sites[1]->Variables[0]);
         $this->assertIdentical($sites[0]->Variables[1], $sites[1]->Variables[1]);
@@ -81,22 +81,22 @@ class Doctrine_Ticket_941_TestCase extends Doctrine_UnitTestCase
         $this->assertEqual('val3 dom2 var1', $sites[0]->Variables[0]->Values[1]->varvalue_value);
         $this->assertEqual('val2 dom1 var2', $sites[0]->Variables[1]->Values[0]->varvalue_value);
         $this->assertEqual('val4 dom2 var2', $sites[0]->Variables[1]->Values[1]->varvalue_value);
-      
+
         $this->assertEqual('var1', $sites[0]->Variables[0]->variable_name);
         $this->assertEqual('var1', $sites[1]->Variables[0]->variable_name);
-      
+
         $this->assertEqual('var2', $sites[0]->Variables[1]->variable_name);
         $this->assertEqual('var2', $sites[1]->Variables[1]->variable_name);
-      
-      
+
+
         // now array hydration
-      
+
         $sites = $query->fetchArray();
-      
+
         $this->assertEqual('site1', $sites[0]['site_domain']);
         $this->assertEqual('site2', $sites[1]['site_domain']);
         $this->assertEqual(2, count($sites));
-      
+
         // this is important for the understanding of the behavior
         $this->assertEqual(1, count($sites[0]['Variables'][0]['Values']));
         $this->assertEqual(1, count($sites[1]['Variables'][0]['Values']));
@@ -110,10 +110,10 @@ class Doctrine_Ticket_941_TestCase extends Doctrine_UnitTestCase
         // different contents when hydrating arrays
         $this->assertEqual('val2 dom1 var2', $sites[0]['Variables'][1]['Values'][0]['varvalue_value']);
         $this->assertEqual('val4 dom2 var2', $sites[1]['Variables'][1]['Values'][0]['varvalue_value']);
-      
+
         $this->assertEqual('var1', $sites[0]['Variables'][0]['variable_name']);
         $this->assertEqual('var1', $sites[1]['Variables'][0]['variable_name']);
-      
+
         $this->assertEqual('var2', $sites[0]['Variables'][1]['variable_name']);
         $this->assertEqual('var2', $sites[1]['Variables'][1]['variable_name']);
     }

--- a/tests/Ticket/966TestCase.php
+++ b/tests/Ticket/966TestCase.php
@@ -46,7 +46,7 @@ class Doctrine_Ticket_966_TestCase extends Doctrine_UnitTestCase
 
         $semesters = $query->execute(array(), Doctrine_Core::HYDRATE_ARRAY);
         $semester  = $semesters[0];
-    
+
         $this->assertAllWeekdaysArePopulated($semester);
     }
 
@@ -58,7 +58,7 @@ class Doctrine_Ticket_966_TestCase extends Doctrine_UnitTestCase
       ->leftJoin('c.Weekdays cw');
 
         $semester = $query->execute()->getFirst();
-    
+
         $weekdayOids = array();
         foreach ($semester->Courses as $course) {
             foreach ($course->Weekdays as $weekday) {
@@ -71,7 +71,7 @@ class Doctrine_Ticket_966_TestCase extends Doctrine_UnitTestCase
         }
         // should be only 3 weekday objects in total
         $this->assertEqual(3, count($weekdayOids));
-    
+
         $queryCountBefore = $this->conn->count();
         $this->assertAllWeekdaysArePopulated($semester);
         $this->assertEqual($queryCountBefore, $this->conn->count());

--- a/tests/Ticket/969TestCase.php
+++ b/tests/Ticket/969TestCase.php
@@ -38,12 +38,12 @@ class Doctrine_Ticket_969_TestCase extends Doctrine_UnitTestCase
         $d->t1_id = 1;
         $d->t2_id = 1;
         $d->save();
-      
+
         $d           = new T2();
         $d->t2_id    = 1;
         $d->hello_id = 10;
         $d->save();
-      
+
         for ($i = 0; $i < 10; $i++) {
             $t3           = new T3();
             $t3->hello_id = 10;
@@ -57,7 +57,7 @@ class Doctrine_Ticket_969_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'T1';
         $this->tables[] = 'T2';
         $this->tables[] = 'T3';
-      
+
         parent::prepareTables();
     }
 
@@ -70,10 +70,10 @@ class Doctrine_Ticket_969_TestCase extends Doctrine_UnitTestCase
                 ->leftJoin('b.T3 c')
                 ->setHydrationMode(Doctrine_Core::HYDRATE_ARRAY)
                 ->fetchOne();
-      
+
         // there are 10 rows in T3, and they all have hello_id = 10, so we should have 10 rows here
         $this->assertEqual(10, count($result['T2']['T3']));
-      
+
         // now with object hydration.
         $q      = new Doctrine_Query;
         $result = $q->select('a.*, b.*, c.*')
@@ -81,7 +81,7 @@ class Doctrine_Ticket_969_TestCase extends Doctrine_UnitTestCase
                 ->leftJoin('a.T2 b')
                 ->leftJoin('b.T3 c')
                 ->fetchOne();
-      
+
         // test that no additional queries are executed when accessing the relations (lazy-loading).
         $queryCountBefore = $this->conn->count();
         // there are 10 rows in T3, and they all have hello_id = 10, so we should have 10 rows here

--- a/tests/Ticket/982TestCase.php
+++ b/tests/Ticket/982TestCase.php
@@ -18,12 +18,12 @@ class Doctrine_Ticket_982_TestCase extends Doctrine_UnitTestCase
         $myModelZero->parentid = 0;
         $myModelZero->save();
         $this->assertIdentical(0, $myModelZero->id);
-      
+
         $this->myModelOne           = new T982_MyModel();
         $this->myModelOne->id       = 1;
         $this->myModelOne->parentid = 0;
         $this->myModelOne->save();
-      
+
         $this->myModelTwo           = new T982_MyModel();
         $this->myModelTwo->id       = 2;
         $this->myModelTwo->parentid = 1;
@@ -33,9 +33,9 @@ class Doctrine_Ticket_982_TestCase extends Doctrine_UnitTestCase
     public function testTicket()
     {
         $this->conn->getTable('T982_MyModel')->clear();
-        
+
         $myModelZero = $this->conn->getTable('T982_MyModel')->find(0);
-        
+
         $this->assertIdentical($myModelZero->id, '0');
         $this->assertIdentical($myModelZero->parentid, '0');
         $this->assertTrue($myModelZero->parent->exists());
@@ -43,16 +43,16 @@ class Doctrine_Ticket_982_TestCase extends Doctrine_UnitTestCase
         $this->assertIdentical($myModelZero, $myModelZero->parent);
         $this->assertIdentical($myModelZero->parent->id, '0');
         $this->assertIdentical($myModelZero->parent->parentid, '0');
-        
+
         $myModelOne = $this->conn->getTable('T982_MyModel')->find(1);
-        
+
         $this->assertIdentical($myModelOne->id, '1');
         $this->assertIdentical($myModelOne->parentid, '0');
         $this->assertTrue($myModelOne->parent->exists());
         $this->assertTrue(ctype_digit($myModelOne->parent->id));
         $this->assertIdentical($myModelOne->parent->id, '0');
         $this->assertIdentical($myModelOne->parent->parentid, '0');
-        
+
         $myModelTwo = $this->conn->getTable('T982_MyModel')->find(2);
 
         $this->assertIdentical($myModelTwo->id, '2');

--- a/tests/Ticket/990TestCase.php
+++ b/tests/Ticket/990TestCase.php
@@ -43,11 +43,11 @@ class Doctrine_Ticket_990_TestCase extends Doctrine_UnitTestCase
         $person            = new Ticket_990_Person();
         $person->firstname = 'John';
         $person->save();
-        
+
         $person->firstname = 'Alice';
-        
+
         $person = Doctrine_Core::getTable('Ticket_990_Person')->find($person->id);
-        
+
         $this->assertEqual('John', $person->firstname);
     }
 
@@ -60,41 +60,41 @@ class Doctrine_Ticket_990_TestCase extends Doctrine_UnitTestCase
         $user       = Doctrine_Core::getTable('User')->find($user->id);
         $this->assertEqual($user->name, 'test');
 
-        
+
         $person            = new Ticket_990_Person();
         $person->firstname = 'John';
         $person->save();
-        
+
         $person->firstname = 'Alice';
-        
+
         $this->assertEqual(Doctrine_Record::STATE_DIRTY, $person->state());
         $this->assertTrue($person->isModified());
         $this->assertEqual(array('firstname' => 'Alice'), $person->getModified());
-        
+
         $person = Doctrine_Core::getTable('Ticket_990_Person')->find($person->id);
-        
+
         $this->assertEqual('Alice', $person->firstname);
         $this->assertEqual(Doctrine_Record::STATE_DIRTY, $person->state());
         $this->assertTrue($person->isModified());
         $this->assertEqual(array('firstname' => 'Alice'), $person->getModified());
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_HYDRATE_OVERWRITE, true);
     }
 
     public function testRefreshAlwaysOverwrites()
     {
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_HYDRATE_OVERWRITE, false);
-        
+
         $person            = new Ticket_990_Person();
         $person->firstname = 'John';
         $person->save();
-        
+
         $person->firstname = 'Alice';
-        
+
         $person->refresh();
-        
+
         $this->assertEqual('John', $person->firstname);
-        
+
         Doctrine_Manager::getInstance()->setAttribute(Doctrine_Core::ATTR_HYDRATE_OVERWRITE, true);
     }
 }

--- a/tests/Ticket/DC1056TestCase.php
+++ b/tests/Ticket/DC1056TestCase.php
@@ -37,7 +37,7 @@ class Doctrine_Ticket_DC1056_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_DC1056_Test';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $r           = new Ticket_DC1056_Test();

--- a/tests/Ticket/DC169TestCase.php
+++ b/tests/Ticket/DC169TestCase.php
@@ -74,7 +74,7 @@ class Ticket_DC169_User extends Doctrine_Record
     public function setUp()
     {
         $this->actAs('Timestampable');
-        
+
         $this->hasOne('Ticket_DC169_Profile as Profile', array(
             'local'   => 'id',
             'foreign' => 'user_id'

--- a/tests/Ticket/DC198TestCase.php
+++ b/tests/Ticket/DC198TestCase.php
@@ -46,7 +46,7 @@ class Doctrine_Ticket_DC198_TestCase extends Doctrine_UnitTestCase
     {
         $this->tables[] = 'Ticket_DC198_User';
         $this->tables[] = 'Ticket_DC198_Email';
-        
+
         parent::prepareTables();
     }
 

--- a/tests/Ticket/DC240TestCase.php
+++ b/tests/Ticket/DC240TestCase.php
@@ -60,7 +60,7 @@ class Ticket_DC240_User extends Doctrine_Record
         $this->hasColumn('username', 'string', 64, array('notnull' => true));
         $this->hasColumn('password', 'string', 128, array('notnull' => true));
     }
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_DC240_Role as Roles', array('local' => 'id_user', 'foreign' => 'id_role', 'refClass' => 'Ticket_DC240_UserRole', 'orderBy' => 'position ASC'));
@@ -73,7 +73,7 @@ class Ticket_DC240_Role extends Doctrine_Record
     {
         $this->hasColumn('name', 'string', 64);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_DC240_User as Users', array('local' => 'id_role', 'foreign' => 'id_user', 'refClass' => 'Ticket_DC240_UserRole', 'orderBy' => 'position ASC'));
@@ -90,7 +90,7 @@ class Ticket_DC240_UserRole extends Doctrine_Record
         $this->hasColumn('id_role', 'integer', null, array('primary' => true));
         $this->hasColumn('position', 'integer', null, array('notnull' => true));
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_DC240_User as User', array('local' => 'id_user', 'foreign' => 'id', 'onDelete' => 'CASCADE'));
@@ -106,7 +106,7 @@ class Ticket_DC240_RoleReference extends Doctrine_Record
         $this->hasColumn('id_role_child', 'integer', null, array('primary' => true));
         $this->hasColumn('position', 'integer', null, array('notnull' => true));
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_DC240_Role as Parent', array('local' => 'id_role_parent', 'foreign' => 'id', 'onDelete' => 'CASCADE'));

--- a/tests/Ticket/DC241TestCase.php
+++ b/tests/Ticket/DC241TestCase.php
@@ -70,7 +70,7 @@ class Ticket_DC241_Poll extends Doctrine_Record
         $this->hasColumn('id_category', 'integer', null, array('notnull' => true));
         $this->hasColumn('question', 'string', 256);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_DC241_PollAnswer as Answers', array('local' => 'id', 'foreign' => 'id_poll', 'orderBy' => 'position'));
@@ -82,13 +82,13 @@ class Ticket_DC241_PollAnswer extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('module_polls_answers');
-        
+
         $this->hasColumn('id_poll', 'integer', null, array('notnull' => true));
         $this->hasColumn('answer', 'string', 256);
         $this->hasColumn('votes', 'integer', null, array('notnull' => true, 'default' => 0));
         $this->hasColumn('position', 'integer');
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_DC241_Poll as Poll', array('local' => 'id_poll', 'foreign' => 'id', 'onDelete' => 'CASCADE'));

--- a/tests/Ticket/DC24TestCase.php
+++ b/tests/Ticket/DC24TestCase.php
@@ -38,21 +38,21 @@ class Doctrine_Ticket_DC24_TestCase extends Doctrine_UnitTestCase
         $this->tables = array('ticket_DC24_master', 'ticket_DC24_servant');
         parent::prepareTables();
     } // end prepareTables();
-    
+
     public function prepareData()
     {
         $servant      = new Ticket_DC24_Servant;
         $servant->bar = 6;
         $servant->save();
-        
+
         $servantId = $servant->identifier();
-        
+
         $master             = new Ticket_DC24_Master;
         $master->foo        = 6;
         $master->servant_id = $servantId['id'];
         $master->save();
     } // end prepareData();
-    
+
     public function testTest()
     {
         try {
@@ -62,10 +62,10 @@ class Doctrine_Ticket_DC24_TestCase extends Doctrine_UnitTestCase
                 ->innerJoin('m.Ticket_DC24_Servant s')
                 ->where('m.id = 1')
                 ->fetchOne();
-                
+
             $master->foo = 5;
             $master->save();
-            
+
             $master2 = Doctrine_Query::create()
                 ->select('m.*')
                 ->from('Ticket_DC24_Master m')
@@ -124,7 +124,7 @@ class Ticket_DC24_Servant extends Doctrine_Record
              'length'  => '4',
              ));
     } // end setTableDefinition();
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_DC24_Master as Masters', array(

--- a/tests/Ticket/DC28TestCase.php
+++ b/tests/Ticket/DC28TestCase.php
@@ -48,7 +48,7 @@ class Doctrine_Ticket_DC28_TestCase extends Doctrine_UnitTestCase
                 ;
             $q->execute();
             //echo $q->getSqlQuery().PHP_EOL;
-            
+
             $this->assertEqual(
                 $q->getSqlQuery(),
                 'SELECT t.id AS t__id, t2.id AS t2__id, t2.lang AS t2__lang ' .
@@ -56,13 +56,13 @@ class Doctrine_Ticket_DC28_TestCase extends Doctrine_UnitTestCase
                 'INNER JOIN ticket__d_c28__tree_translation t2 ' .
                 'ON t.id = t2.id AND (t2.name != ?)'
             );
-            
+
             //echo $q->getSqlQuery().PHP_EOL;
             $tree_table = Doctrine_Core::getTable('Ticket_DC28_Tree');
             $tree       = $tree_table->getTree();
             $tree->setBaseQuery($q);
             //echo $q->getSqlQuery().PHP_EOL;
-            
+
             $this->assertEqual(
                 $q->getSqlQuery(),
                 'SELECT t.id AS t__id, t.lft AS t__lft, t.rgt AS t__rgt, t.level AS t__level, t2.id AS t2__id, t2.lang AS t2__lang ' .
@@ -70,7 +70,7 @@ class Doctrine_Ticket_DC28_TestCase extends Doctrine_UnitTestCase
                 'INNER JOIN ticket__d_c28__tree_translation t2 ' .
                 'ON t.id = t2.id AND (t2.name != ?)'
             );
-            
+
             //$this->pass();
         } catch (Exception $e) {
             $this->fail($e->getMessage());

--- a/tests/Ticket/DC300TestCase.php
+++ b/tests/Ticket/DC300TestCase.php
@@ -88,7 +88,7 @@ class Ticket_DC300_Group extends Doctrine_Record
     {
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_DC300_User as Users', array(

--- a/tests/Ticket/DC302TestCase.php
+++ b/tests/Ticket/DC302TestCase.php
@@ -40,31 +40,31 @@ class Doctrine_Ticket_DC302_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_DC302_UserRole';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $role1       = new Ticket_DC302_Role();
         $role1->name = 'admin'; // id: 1
         $role1->save();
-        
+
         $role2       = new Ticket_DC302_Role();
         $role2->name = 'publisher'; // id: 2
         $role2->save();
-        
+
         $role3       = new Ticket_DC302_Role();
         $role3->name = 'reviewer'; // id: 3
         $role3->save();
-        
+
         $role4       = new Ticket_DC302_Role();
         $role4->name = 'mod'; // id: 4
         $role4->save();
-        
+
         // reviewer inherits from admin, mod, publisher - in that order
         $role3->Parents[] = $role1;
         $role3->Parents[] = $role4;
         $role3->Parents[] = $role2;
         $role3->save();
-        
+
         // update positions
         $query = Doctrine_Query::create()
             ->update('Ticket_DC302_RoleReference')
@@ -84,8 +84,8 @@ class Doctrine_Ticket_DC302_TestCase extends Doctrine_UnitTestCase
             ->where('id_role_child = ?', 3)
             ->andWhere('id_role_parent = ?', 2)
             ->execute();
-            
-            
+
+
         $user           = new Ticket_DC302_User();
         $user->username = 'test';
         $user->password = 'test';
@@ -105,7 +105,7 @@ class Doctrine_Ticket_DC302_TestCase extends Doctrine_UnitTestCase
             ->andWhere('id_role = ?', 2)
             ->execute();
     }
-    
+
     public function testTest()
     {
         $profiler = new Doctrine_Connection_Profiler();
@@ -113,7 +113,7 @@ class Doctrine_Ticket_DC302_TestCase extends Doctrine_UnitTestCase
 
         $role    = Doctrine::getTable('Ticket_DC302_Role')->find(3);
         $parents = $role->Parents->toArray();
-        
+
         $this->assertEqual($parents[1]['Ticket_DC302_RoleReference'][0]['position'], 1);
 
         $events = $profiler->getAll();
@@ -128,7 +128,7 @@ class Ticket_DC302_Role extends Doctrine_Record
     {
         $this->hasColumn('name', 'string', 64);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_DC302_User as Users', array('local' => 'id_role', 'foreign' => 'id_user', 'refClass' => 'Ticket_DC302_UserRole'));
@@ -145,7 +145,7 @@ class Ticket_DC302_RoleReference extends Doctrine_Record
         $this->hasColumn('id_role_child', 'integer', null, array('primary' => true));
         $this->hasColumn('position', 'integer', null, array('notnull' => true, 'default' => 0));
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_DC302_Role as Parent', array('local' => 'id_role_parent', 'foreign' => 'id', 'onDelete' => 'CASCADE'));
@@ -160,7 +160,7 @@ class Ticket_DC302_User extends Doctrine_Record
         $this->hasColumn('username', 'string', 64, array('notnull' => true));
         $this->hasColumn('password', 'string', 128, array('notnull' => true));
     }
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_DC302_Role as Roles', array('local' => 'id_user', 'foreign' => 'id_role', 'refClass' => 'Ticket_DC302_UserRole', 'orderBy' => 'position'));
@@ -175,7 +175,7 @@ class Ticket_DC302_UserRole extends Doctrine_Record
         $this->hasColumn('id_role', 'integer', null, array('primary' => true));
         $this->hasColumn('position', 'integer', null, array('notnull' => true, 'default' => 0));
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_DC302_User as User', array('local' => 'id_user', 'foreign' => 'id', 'onDelete' => 'CASCADE'));

--- a/tests/Ticket/DC399TestCase.php
+++ b/tests/Ticket/DC399TestCase.php
@@ -49,7 +49,7 @@ class Doctrine_Ticket_DC399_TestCase extends Doctrine_UnitTestCase
     {
         $user = Doctrine_Core::getTable('User')->findOneByName('sacho');
         $user->refreshRelated('Phonenumber');
-      
+
         //Unlinking(even with now=true) removes the connection between User and Phonenumber, but does not delete the phone number
         //Only updates phonenumber's user_id to null
         //However, if we unlink and then save the $user, the phonenumber is deleted from the database

--- a/tests/Ticket/DC39TestCase.php
+++ b/tests/Ticket/DC39TestCase.php
@@ -85,7 +85,7 @@ class Ticket_DC39_Group extends Doctrine_Record
     {
         $this->hasColumn('name', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('Ticket_DC39_User as Users', array(

--- a/tests/Ticket/DC57TestCase.php
+++ b/tests/Ticket/DC57TestCase.php
@@ -55,7 +55,7 @@ class Doctrine_Ticket_DC57_TestCase extends Doctrine_UnitTestCase
         $test            = new Ticket_DC57_Article();
         $test->timestamp = '1776-07-04';
         $test->save();
-        
+
         $test->timestamp = '1492-09-01';
         $this->assertTrue($test->isModified());
     }

--- a/tests/Ticket/DC709TestCase.php
+++ b/tests/Ticket/DC709TestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Ticket_DC709_TestCase extends Doctrine_UnitTestCase
     public function testTest()
     {
         $dbh = new Doctrine_Adapter_Mock('mysql');
-        
+
         $conn = Doctrine_Manager::getInstance()->connection($dbh, 'mysql', false);
 
         $sql = $conn->export->createTableSql('mytable', array(

--- a/tests/Ticket/DC74TestCase.php
+++ b/tests/Ticket/DC74TestCase.php
@@ -37,14 +37,14 @@ class Doctrine_Ticket_DC74_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_DC74_Test';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $r        = new Ticket_DC74_Test();
         $r->test1 = 'test1';
         $r->test2 = 'test2';
         $r->save();
-        
+
         // following clear should be done automatically, as noted in DC73 ticket
         $r->getTable()->clear();
     }
@@ -56,16 +56,16 @@ class Doctrine_Ticket_DC74_TestCase extends Doctrine_UnitTestCase
             ->select('id, test1')
             ->from('Ticket_DC74_Test')
             ->fetchOne();
-            
+
         // so we have object in PROXY state
         $this->assertEqual(Doctrine_Record::STATE_PROXY, $r1->state());
 
         // now we are modifing one of loaded properties "test1"
         $r1->test1 = 'testx';
-        
+
         // so record is in DIRTY state
         $this->assertEqual(Doctrine_Record::STATE_DIRTY, $r1->state());
-        
+
         // when accessing to not loaded field "test2" no additional loading
         // currently such loading is performed is executed only in PROXY state
         $this->assertEqual('test2', $r1->test2);

--- a/tests/Ticket/DC794TestCase.php
+++ b/tests/Ticket/DC794TestCase.php
@@ -41,7 +41,7 @@ class Doctrine_Ticket_DC794_TestCase extends Doctrine_UnitTestCase
     public function testTest()
     {
         $table = Doctrine::getTable('Ticket_DC794_Model');
-        
+
         $this->assertEqual($table->buildFindByWhere('IdOrigenOportunidadClienteOrId'), '(dctrn_find.idOrigenOportunidadCliente = ? OR dctrn_find.id = ?)');
         $this->assertEqual($table->buildFindByWhere('IdAndIdOrIdOrigenOportunidadCliente'), 'dctrn_find.id = ? AND (dctrn_find.id = ? OR dctrn_find.idOrigenOportunidadCliente = ?)');
         $this->assertEqual($table->buildFindByWhere('UsernameOrIdOrIdOrigenOportunidadCliente'), '(dctrn_find.Username = ? OR dctrn_find.id = ? OR dctrn_find.idOrigenOportunidadCliente = ?)');

--- a/tests/Ticket/DC828TestCase.php
+++ b/tests/Ticket/DC828TestCase.php
@@ -33,7 +33,7 @@
 class Doctrine_Ticket_DC828_TestCase extends Doctrine_UnitTestCase
 {
     private $sqlStackCounter = 0;
-    
+
     public function prepareTables()
     {
         $this->tables[] = 'Ticket_DC828_Model';
@@ -59,14 +59,14 @@ class Doctrine_Ticket_DC828_TestCase extends Doctrine_UnitTestCase
     public function testLimitOffsetWithoutOrderBy()
     {
         $exception = false;
-        
+
         try {
             Doctrine_Query::create()->select()->from('Ticket_DC828_Model')->limit(10)->offset(5)->execute();
         } catch (Doctrine_Connection_Exception $e) {
             $exception = true;
             $this->assertEqual($e->getMessage(), 'OFFSET cannot be used in MSSQL without ORDER BY due to emulation reasons.');
         }
-        
+
         $this->assertTrue($exception);
     }
 

--- a/tests/Ticket/DC82TestCase.php
+++ b/tests/Ticket/DC82TestCase.php
@@ -36,7 +36,7 @@ class Doctrine_Ticket_DC82_TestCase extends Doctrine_UnitTestCase
     {
         $this->dbh  = new Doctrine_Adapter_Mock('pgsql');
         $this->conn = $this->manager->openConnection($this->dbh);
-        
+
         $sql = $this->conn->export->exportClassesSql(array('Ticket_DC82_Article'));
         $this->assertEqual($sql, array(
             'CREATE UNIQUE INDEX model_unique_title ON ticket__d_c82__article (title) WHERE deleted = false',

--- a/tests/Ticket/DC840TestCase.php
+++ b/tests/Ticket/DC840TestCase.php
@@ -33,7 +33,7 @@
 class Doctrine_Ticket_DC840_TestCase extends Doctrine_UnitTestCase
 {
     private $sqlStackCounter = 0;
-  
+
     public function prepareTables()
     {
         $this->tables[] = 'Ticket_DC840_Model';
@@ -59,7 +59,7 @@ class Doctrine_Ticket_DC840_TestCase extends Doctrine_UnitTestCase
             ->andWhere('modified_at >= ?', '2010-01-01')
         ;
         $q->execute();
-         
+
         $expected = "SELECT [t].[id] AS [t__id] FROM [ticket__d_c840__model] [t] WHERE ([t].[password] = 'abc' AND [t].[modified_at] > '2010-01-01' AND [t].[modified_at] < '2010-01-01' AND [t].[modified_at] <> '2010-01-01' AND [t].[modified_at] <= '2010-01-01' AND [t].[modified_at] >= '2010-01-01')";
         $sql      = current(array_slice($this->dbh->getAll(), $this->sqlStackCounter++, 1));
 

--- a/tests/Ticket/DC841TestCase.php
+++ b/tests/Ticket/DC841TestCase.php
@@ -33,7 +33,7 @@
 class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
 {
     private $sqlStackCounter = 0;
-    
+
     public function prepareTables()
     {
         $this->tables[] = 'Ticket_DC841_Model';
@@ -45,7 +45,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
         $this->dbh  = new Doctrine_Adapter_Mock('mssql');
         $this->conn = Doctrine_Manager::getInstance()->openConnection($this->dbh, 'DC841');
     }
-    
+
     public function testSelect()
     {
         Doctrine::getTable('Ticket_DC841_Model')
@@ -61,7 +61,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($expected, $sql);
     }
-    
+
     public function testSelectJoinWith()
     {
         Doctrine::getTable('Ticket_DC841_Model')
@@ -75,7 +75,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($expected, $sql);
     }
-    
+
     public function testSelectWithStaticParameter()
     {
         return; // doesn't work
@@ -91,7 +91,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($expected, $sql);
     }
-    
+
     public function testSelectWithIn()
     {
         Doctrine::getTable('Ticket_DC841_Model')
@@ -104,7 +104,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($expected, $sql);
     }
-    
+
     public function testInsert()
     {
         try {
@@ -118,7 +118,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
         }
 
         $this->sqlStackCounter += 1;
-        
+
         $expected = "INSERT INTO [ticket__d_c841__model] ([username], [password], [foo]) VALUES ('abc', 'abc', 'abc')";
         $sql      = current(array_slice($this->dbh->getAll(), $this->sqlStackCounter++, 1));
 
@@ -135,7 +135,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
         $o->state(Doctrine_Record::STATE_CLEAN);
 
         $this->sqlStackCounter += 7;
-            
+
         $o->password = 'foobar';
         $o->save();
 
@@ -155,7 +155,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
         $o->state(Doctrine_Record::STATE_CLEAN);
 
         $this->sqlStackCounter += 5;
-            
+
         $o->delete();
 
         $expected = 'DELETE FROM [ticket__d_c841__model] WHERE [id] = 33';
@@ -179,7 +179,7 @@ class Ticket_DC841_Model extends Doctrine_Record
         $this->hasColumn('password', 'string', 255);
         $this->hasColumn('foo', 'string', 255);
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Ticket_DC841_Model', array(

--- a/tests/Ticket/DC843TestCase.php
+++ b/tests/Ticket/DC843TestCase.php
@@ -33,7 +33,7 @@
 class Doctrine_Ticket_DC843_TestCase extends Doctrine_UnitTestCase
 {
     private $sqlStackCounter = 0;
-    
+
     public function prepareTables()
     {
         $this->tables[] = 'Ticket_DC843_Model';
@@ -55,7 +55,7 @@ class Doctrine_Ticket_DC843_TestCase extends Doctrine_UnitTestCase
 
         $this->assertEqual($expected, $sql);
     }
-    
+
     public function testQuery()
     {
         Doctrine::getTable('Ticket_DC843_Model')

--- a/tests/Ticket/DC86TestCase.php
+++ b/tests/Ticket/DC86TestCase.php
@@ -37,7 +37,7 @@ class Doctrine_Ticket_DC86_TestCase extends Doctrine_UnitTestCase
         $this->tables[] = 'Ticket_DC86_Test';
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
         $r       = new Ticket_DC86_Test();

--- a/tests/Ticket/NjeroTestCase.php
+++ b/tests/Ticket/NjeroTestCase.php
@@ -16,7 +16,7 @@ class Doctrine_Ticket_Njero_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function prepareTables()
     {
         $this->tables[] = 'CoverageCodeN';
@@ -34,12 +34,12 @@ class Doctrine_Ticket_Njero_TestCase extends Doctrine_UnitTestCase
         $policy_code->code        = 1;
         $policy_code->description = 'Special Policy';
         $policy_code->save();
-      
+
         $coverage_code              = new CoverageCodeN();
         $coverage_code->code        = 1;
         $coverage_code->description = 'Full Coverage';
         $coverage_code->save();
-      
+
         $coverage_code              = new CoverageCodeN();
         $coverage_code->code        = 3; # note we skip 2
         $coverage_code->description = 'Partial Coverage';
@@ -56,12 +56,12 @@ class Doctrine_Ticket_Njero_TestCase extends Doctrine_UnitTestCase
         $rate->liability_code = 1;
         $rate->total_rate     = 123.45;
         $rate->save();
-      
+
         $policy                = new PolicyN();
         $policy->rate_id       = 1;
         $policy->policy_number = '123456789';
         $policy->save();
-        
+
         $q = new Doctrine_Query();
 
         # If I use

--- a/tests/Transaction/OracleTestCase.php
+++ b/tests/Transaction/OracleTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Transaction_Oracle_TestCase extends Doctrine_UnitTestCase
     public function testCreateSavePointExecutesSql()
     {
         $this->transaction->beginTransaction('mypoint');
-        
+
         $this->assertEqual($this->adapter->pop(), 'SAVEPOINT mypoint');
     }
     public function testReleaseSavePointAlwaysReturnsTrue()

--- a/tests/Transaction/PgsqlTestCase.php
+++ b/tests/Transaction/PgsqlTestCase.php
@@ -35,7 +35,7 @@ class Doctrine_Transaction_Pgsql_TestCase extends Doctrine_UnitTestCase
     public function testCreateSavePointExecutesSql()
     {
         $this->transaction->beginTransaction('mypoint');
-        
+
         $this->assertEqual($this->adapter->pop(), 'SAVEPOINT mypoint');
     }
     public function testReleaseSavePointExecutesSql()

--- a/tests/Transaction/SqliteTestCase.php
+++ b/tests/Transaction/SqliteTestCase.php
@@ -47,7 +47,7 @@ class Doctrine_Transaction_Sqlite_TestCase extends Doctrine_UnitTestCase
         $this->transaction->setIsolation('READ COMMITTED');
         $this->transaction->setIsolation('REPEATABLE READ');
         $this->transaction->setIsolation('SERIALIZABLE');
-        
+
         $this->assertEqual($this->adapter->pop(), 'PRAGMA read_uncommitted = 1');
         $this->assertEqual($this->adapter->pop(), 'PRAGMA read_uncommitted = 1');
         $this->assertEqual($this->adapter->pop(), 'PRAGMA read_uncommitted = 1');

--- a/tests/TransactionTestCase.php
+++ b/tests/TransactionTestCase.php
@@ -162,7 +162,7 @@ class Doctrine_Transaction_TestCase extends Doctrine_UnitTestCase
     {
         $this->assertEqual($this->transaction->getTransactionLevel(), 0);
     }
-    
+
     public function testSubsequentTransactionsAfterRollback()
     {
         try {
@@ -183,7 +183,7 @@ class Doctrine_Transaction_TestCase extends Doctrine_UnitTestCase
             $this->assertEqual(0, $this->transaction->getTransactionLevel());
             $this->assertEqual(0, $this->transaction->getInternalTransactionLevel());
         }
-        
+
         $i = 0;
         while ($i < 5) {
             $this->assertEqual(0, $this->transaction->getTransactionLevel());
@@ -243,10 +243,10 @@ class Doctrine_Transaction_TestCase extends Doctrine_UnitTestCase
     public function testNestedTransaction()
     {
         $conn = Doctrine_Manager::connection();
-        
+
         try {
             $conn->beginTransaction();
-        
+
             // Create new client
             $user = new User();
             $user->set('name', 'Test User');
@@ -262,7 +262,7 @@ class Doctrine_Transaction_TestCase extends Doctrine_UnitTestCase
         } catch (Exception $e) {
             $conn->rollback();
         }
-        
+
         $this->assertTrue($user->id > 0);
         $this->assertTrue($phonenumber->id > 0);
     }
@@ -348,7 +348,7 @@ class TransactionListener extends Doctrine_EventListener
     {
         $this->_messages[] = __FUNCTION__;
     }
-    
+
     public function pop()
     {
         return array_pop($this->_messages);

--- a/tests/TreeStructureTestCase.php
+++ b/tests/TreeStructureTestCase.php
@@ -38,7 +38,7 @@ class Doctrine_TreeStructure_TestCase extends Doctrine_UnitTestCase
         $this->tables = array('TreeLeaf');
         parent::prepareTables();
     }
-    
+
     public function prepareData()
     {
     }
@@ -107,7 +107,7 @@ class Doctrine_TreeStructure_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue(isset($o2->Parent));
         $this->assertTrue($o2->Parent === $o1);
         $this->assertFalse(isset($o4->Parent));
-      
+
         $this->assertTrue(count($o1->Children) == 2);
         $this->assertTrue(count($o1->get('Children')) == 2);
 

--- a/tests/UnitOfWorkTestCase.php
+++ b/tests/UnitOfWorkTestCase.php
@@ -62,7 +62,7 @@ class Doctrine_UnitOfWork_TestCase extends Doctrine_UnitTestCase
 
         $tree = $this->unitOfWork->buildFlushTree(array('Forum_Board'));
         $this->assertEqual($tree, array('Forum_Board'));
-        
+
         $tree = $this->unitOfWork->buildFlushTree(array('Forum_Category','Forum_Board'));
         $this->assertEqual($tree, array('Forum_Category', 'Forum_Board'));
     }
@@ -72,7 +72,7 @@ class Doctrine_UnitOfWork_TestCase extends Doctrine_UnitTestCase
 
         $tree = $this->unitOfWork->buildFlushTree(array('Forum_Entry','Forum_Board'));
         $this->assertEqual($tree, array('Forum_Entry','Forum_Board'));
-        
+
         $tree = $this->unitOfWork->buildFlushTree(array('Forum_Board','Forum_Entry'));
         $this->assertEqual($tree, array('Forum_Board','Forum_Entry'));
     }

--- a/tests/Validator/ForeignKeysTestCase.php
+++ b/tests/Validator/ForeignKeysTestCase.php
@@ -5,7 +5,7 @@ class Doctrine_Validator_ForeignKeys_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables = array('TestPerson', 'TestAddress');
-        
+
         parent::prepareTables();
     }
 
@@ -13,24 +13,24 @@ class Doctrine_Validator_ForeignKeys_TestCase extends Doctrine_UnitTestCase
     {
         $person  = new TestPerson();
         $address = new TestAddress();
-        
+
         $address->Person = $person;
-        
+
         $table  = $address->getTable();
         $errors = $table->validateField('person_id', $address->person_id, $address);
-        
+
         $this->assertEqual(0, $errors->count());
     }
-    
+
     public function testForeignKeyIsValidIfForeignRelationIsSet()
     {
         $person               = new TestPerson();
         $person->Addresses[0] = new TestAddress();
-        
+
         $address = $person->Addresses[0];
         $table   = $address->getTable();
         $errors  = $table->validateField('person_id', $address->person_id, $address);
-        
+
         $this->assertEqual(0, $errors->count());
     }
 
@@ -41,7 +41,7 @@ class Doctrine_Validator_ForeignKeys_TestCase extends Doctrine_UnitTestCase
 
         $address = $person->Addresses[0];
         $table   = $address->getTable();
-        
+
         $errors = $table->validateField('person_id', $address->person_id, $address);
         $this->assertEqual(0, $errors->count());
     }
@@ -66,7 +66,7 @@ class TestPerson extends Doctrine_Record
         $this->hasColumn('last_name', 'string');
         $this->hasColumn('favorite_color_id', 'integer');
     }
-    
+
     public function setUp()
     {
         $this->hasMany('TestAddress as Addresses', array('local' => 'id', 'foreign' => 'person_id'));
@@ -84,7 +84,7 @@ class TestAddress extends Doctrine_Record
         $this->hasColumn('state', 'string');
         $this->hasColumn('zip', 'string');
     }
-    
+
     public function setUp()
     {
         $this->hasOne('TestPerson as Person', array('local' => 'person_id', 'foreign' => 'id'));

--- a/tests/Validator/FutureTestCase.php
+++ b/tests/Validator/FutureTestCase.php
@@ -41,28 +41,28 @@ class Doctrine_Validator_Future_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function testValidFutureDates()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         // one year ahead
         $user1        = new ValidatorTest_DateModel();
         $user1->death = date('Y-m-d', time() + 365 * 24 * 60 * 60);
         $this->assertTrue($user1->trySave());
-        
+
         // one month ahead
         $user1        = new ValidatorTest_DateModel();
         $user1->death = date('Y-m-d', time() + 30 * 24 * 60 * 60);
         $this->assertTrue($user1->trySave());
-        
+
         // one day ahead
         $user1->death = date('Y-m-d', time() + 24 * 60 * 60);
         $this->assertTrue($user1->trySave());
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
-    
+
     public function testInvalidFutureDates()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
@@ -70,13 +70,13 @@ class Doctrine_Validator_Future_TestCase extends Doctrine_UnitTestCase
         $user1        = new ValidatorTest_DateModel();
         $user1->death = date('Y-m-d', 42);
         $this->assertFalse($user1->trySave());
-        
+
         $user1->death = date('Y-m-d', time());
         $this->assertFalse($user1->trySave());
-        
+
         $user1->death = date('Y-m-d', time() + 60);
         $this->assertFalse($user1->trySave());
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
 }

--- a/tests/Validator/PastTestCase.php
+++ b/tests/Validator/PastTestCase.php
@@ -41,42 +41,42 @@ class Doctrine_Validator_Past_TestCase extends Doctrine_UnitTestCase
     public function prepareData()
     {
     }
-    
+
     public function testInvalidPastDates()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         // one year ahead
         $user1           = new ValidatorTest_DateModel();
         $user1->birthday = date('Y-m-d', time() + 365 * 24 * 60 * 60);
         $this->assertFalse($user1->trySave());
-        
+
         // one month ahead
         $user1           = new ValidatorTest_DateModel();
         $user1->birthday = date('Y-m-d', time() + 30 * 24 * 60 * 60);
         $this->assertFalse($user1->trySave());
-        
+
         // one day ahead
         $user1->birthday = date('Y-m-d', time() + 24 * 60 * 60);
         $this->assertFalse($user1->trySave());
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
-    
+
     public function testValidPastDates()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         $user1           = new ValidatorTest_DateModel();
         $user1->birthday = date('Y-m-d', 42);
         $this->assertTrue($user1->trySave());
-        
+
         $user1->birthday = date('Y-m-d', mktime(0, 0, 0, 6, 3, 1981));
         $this->assertTrue($user1->trySave());
-        
+
         $user1->birthday = date('Y-m-d', mktime(0, 0, 0, 3, 9, 1983));
         $this->assertTrue($user1->trySave());
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
 }

--- a/tests/ValidatorTestCase.php
+++ b/tests/ValidatorTestCase.php
@@ -106,7 +106,7 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'float'));
         $this->assertTrue(Doctrine_Validator::isValidType($var, 'array'));
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'object'));
-        
+
         $var = new Exception();
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'string'));
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'integer'));
@@ -121,7 +121,7 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
         $test->mymixed  = 'message';
         $test->myrange  = 1;
         $test->myregexp = '123a';
-        
+
         $validator = new Doctrine_Validator();
         $validator->validateRecord($test);
 
@@ -229,7 +229,7 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
             $this->assertTrue(in_array('email', $emailStack['address']));
             $this->assertTrue(in_array('length', $userStack['name']));
         }
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
 
@@ -240,7 +240,7 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
     public function testValidationHooks()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         // Tests validate() and validateOnInsert()
         $user = new User();
         try {
@@ -258,7 +258,7 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
             $this->assertTrue(in_array('notTheSaint', $stack['name']));  // validate() hook constraint
             $this->assertTrue(in_array('pwNotTopSecret', $stack['password'])); // validateOnInsert() hook constraint
         }
-        
+
         // Tests validateOnUpdate()
         $user = $this->connection->getTable('User')->find(4);
         try {
@@ -270,13 +270,13 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
         } catch (Doctrine_Validator_Exception $e) {
             $invalidRecords = $e->getInvalidRecords();
             $this->assertEqual(count($invalidRecords), 1);
-            
+
             $stack = $invalidRecords[0]->errorStack();
-            
+
             $this->assertEqual($stack->count(), 1);
             $this->assertTrue(in_array('notNobody', $stack['loginname']));  // validateOnUpdate() hook constraint
         }
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
 
@@ -287,10 +287,10 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
     public function testHookValidateOnInsert()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         $user           = new User();
         $user->password = '1234';
-        
+
         try {
             $user->save();
             $this->fail();
@@ -298,7 +298,7 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
             $errors = $user->errorStack();
             $this->assertTrue(in_array('pwNotTopSecret', $errors['password']));
         }
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
 
@@ -332,11 +332,11 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
     public function testSetSameUniqueValueOnSameRecordThrowsNoException()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         $r             = new ValidatorTest_Person();
         $r->identifier = '1234';
         $r->save();
-        
+
         $r             = $this->connection->getTable('ValidatorTest_Person')->findAll()->getFirst();
         $r->identifier = 1234;
         try {
@@ -344,20 +344,20 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
         } catch (Doctrine_Validator_Exception $e) {
             $this->fail('Validator exception raised without reason!');
         }
-        
+
         $r->delete(); // clean up
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
-    
+
     public function testSetSameUniqueValueOnDifferentRecordThrowsException()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
-        
+
         $r             = new ValidatorTest_Person();
         $r->identifier = '1234';
         $r->save();
-        
+
         $r             = new ValidatorTest_Person();
         $r->identifier = 1234;
         try {
@@ -366,10 +366,10 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
         } catch (Doctrine_Validator_Exception $e) {
             $this->pass();
         }
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
-    
+
     public function testValidationOnManyToManyRelations()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
@@ -397,10 +397,10 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
             $this->assertTrue(in_array('notnull', $stack['zip']));
             $this->assertTrue(in_array('notblank', $stack['zip']));
         }
-        
+
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
-    
+
     public function testSaveInTransactionThrowsValidatorException()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);
@@ -460,7 +460,7 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
 
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }
-    
+
     public function testValidationIsTriggeredOnFlush()
     {
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);

--- a/tests/ValueHolderTestCase.php
+++ b/tests/ValueHolderTestCase.php
@@ -6,13 +6,13 @@ class Doctrine_ValueHolder_TestCase extends Doctrine_UnitTestCase
     public function testGetSet()
     {
         $this->valueHolder->data[0] = 'first';
-        
+
         $this->assertEqual($this->valueHolder->data[0], 'first');
         $this->assertEqual($this->valueHolder[0], 'first');
         $this->assertEqual($this->valueHolder->get(0), 'first');
 
         $this->valueHolder->data['key'] = 'second';
-        
+
         $this->assertEqual($this->valueHolder->data['key'], 'second');
         $this->assertEqual($this->valueHolder->key, 'second');
         $this->assertEqual($this->valueHolder['key'], 'second');

--- a/tests/models/ConcreteInheritanceTestParent.php
+++ b/tests/models/ConcreteInheritanceTestParent.php
@@ -12,7 +12,7 @@ class ConcreteInheritanceTestChild extends ConcreteInheritanceTestParent
     public function setTableDefinition()
     {
         $this->hasColumn('age', 'integer');
-        
+
         parent::setTableDefinition();
     }
 }

--- a/tests/models/FooRecord.php
+++ b/tests/models/FooRecord.php
@@ -4,7 +4,7 @@ class FooRecord extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('foo');
-        
+
         $this->hasColumn('name', 'string', 200, array('notnull' => true));
         $this->hasColumn('parent_id', 'integer');
         $this->hasColumn('local_foo', 'integer');
@@ -33,7 +33,7 @@ class FooRecord extends Doctrine_Record
         $this->hasOne('FooRecord as Parent', array('local' => 'parent_id', 'foreign' => 'id', 'onDelete' => 'CASCADE'));
         $this->hasOne('FooForeignlyOwnedWithPk', array('local' => 'id', 'foreign' => 'id', 'constraint' => true));
         $this->hasOne('FooLocallyOwned', array('local' => 'local_foo', 'onDelete' => 'RESTRICT'));
-        
+
         $this->hasMany('BarRecord as Bar', array('local'    => 'fooId',
                                                  'foreign'  => 'barId',
                                                  'refClass' => 'FooBarRecord',

--- a/tests/models/FooReferenceRecord.php
+++ b/tests/models/FooReferenceRecord.php
@@ -4,7 +4,7 @@ class FooReferenceRecord extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('foo_reference');
-        
+
         $this->hasColumn('foo1', 'integer', null, array('primary' => true));
         $this->hasColumn('foo2', 'integer', null, array('primary' => true));
     }

--- a/tests/models/ForeignKeyTest2.php
+++ b/tests/models/ForeignKeyTest2.php
@@ -5,7 +5,7 @@ class ForeignKeyTest2 extends Doctrine_Record
     {
         $this->hasColumn('name', 'string', null);
         $this->hasColumn('foreignkey', 'integer');
-       
+
         $this->hasOne('ForeignKeyTest', array(
             'local' => 'foreignKey', 'foreign' => 'id'
         ));

--- a/tests/models/Forum_Category.php
+++ b/tests/models/Forum_Category.php
@@ -14,7 +14,7 @@ class Forum_Category extends Doctrine_Record
             'local'   => 'id',
             'foreign' => 'parent_category_id'
         ));
-        
+
         $this->hasOne('Forum_Category as Parent', array(
             'local'   => 'parent_category_id',
             'foreign' => 'id'

--- a/tests/models/InheritanceDeal.php
+++ b/tests/models/InheritanceDeal.php
@@ -4,11 +4,11 @@ class InheritanceDeal extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('inheritance_deal');
-        
+
         $this->hasColumn('id', 'integer', 4, array(  'primary' => true,  'autoincrement' => true,));
         $this->hasColumn('name', 'string', 255, array());
     }
-  
+
     public function setUp()
     {
         $this->hasMany('InheritanceUser as Users', array('refClass' => 'InheritanceDealUser', 'local' => 'entity_id', 'foreign' => 'user_id'));

--- a/tests/models/LocationI18n.php
+++ b/tests/models/LocationI18n.php
@@ -7,7 +7,7 @@ class LocationI18n extends Doctrine_Record
         $this->hasColumn('id', 'integer', 10, array('primary' => true));
         $this->hasColumn('culture', 'string', 2);
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Location as Location', array('local' => 'id'));

--- a/tests/models/Log_Entry.php
+++ b/tests/models/Log_Entry.php
@@ -6,7 +6,7 @@ class Log_Entry extends Doctrine_Record
         $this->hasColumn('stamp', 'timestamp');
         $this->hasColumn('status_id', 'integer');
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Log_Status', array(

--- a/tests/models/MyOneThing.php
+++ b/tests/models/MyOneThing.php
@@ -12,7 +12,7 @@ class MyOneThing extends Doctrine_Record
         $this->hasMany('MyUserOneThing', array(
             'local' => 'id', 'foreign' => 'one_thing_id'
         ));
-        
+
         $this->hasOne('MyUser', array(
             'local' => 'user_id', 'foreign' => 'id'
         ));

--- a/tests/models/MyOtherThing.php
+++ b/tests/models/MyOtherThing.php
@@ -11,7 +11,7 @@ class MyOtherThing extends Doctrine_Record
         $this->hasMany('MyUserOtherThing', array(
             'local' => 'id', 'foreign' => 'other_thing_id'
         ));
-        
+
         $this->hasOne('MyUser', array(
             'local' => 'user_id', 'foreign' => 'id'
         ));

--- a/tests/models/MyUser.php
+++ b/tests/models/MyUser.php
@@ -5,7 +5,7 @@ class MyUser extends Doctrine_Record
     {
         $this->hasColumn('name', 'string');
     }
-    
+
     public function setUp()
     {
         $this->hasMany('MyOneThing', array(

--- a/tests/models/MyUserGroup.php
+++ b/tests/models/MyUserGroup.php
@@ -4,12 +4,12 @@ class MyUserGroup extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('my_user_group');
-    
+
         $this->hasColumn('id', 'integer', 4, array(  'primary' => true,  'autoincrement' => true,));
         $this->hasColumn('group_id', 'integer', 4, array());
         $this->hasColumn('user_id', 'integer', 4, array());
     }
-  
+
     public function setUp()
     {
         $this->hasOne('MyGroup as MyGroup', array('local' => 'group_id', 'foreign' => 'id', 'onDelete' => 'CASCADE'));

--- a/tests/models/MyUserOneThing.php
+++ b/tests/models/MyUserOneThing.php
@@ -6,14 +6,14 @@ class MyUserOneThing extends Doctrine_Record
         $this->hasColumn('user_id', 'integer');
         $this->hasColumn('one_thing_id', 'integer');
     }
-    
-    
+
+
     public function setUp()
     {
         $this->hasOne('MyUser', array(
             'local' => 'user_id', 'foreign' => 'id'
         ));
-        
+
         $this->hasOne('MyOneThing', array(
             'local' => 'one_thing_id', 'foreign' => 'id'
         ));

--- a/tests/models/MyUserOtherThing.php
+++ b/tests/models/MyUserOtherThing.php
@@ -6,14 +6,14 @@ class MyUserOtherThing extends Doctrine_Record
         $this->hasColumn('user_id', 'integer');
         $this->hasColumn('other_thing_id', 'integer');
     }
-    
-    
+
+
     public function setUp()
     {
         $this->hasOne('MyUser', array(
             'local' => 'user_id', 'foreign' => 'id'
         ));
-        
+
         $this->hasOne('MyOtherThing', array(
             'local' => 'other_thing_id', 'foreign' => 'id'
         ));

--- a/tests/models/MysqlGroup.php
+++ b/tests/models/MysqlGroup.php
@@ -5,7 +5,7 @@ class MysqlGroup extends Doctrine_Record
     {
         $this->hasColumn('name', 'string', null);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('MysqlUser', array(

--- a/tests/models/MysqlUser.php
+++ b/tests/models/MysqlUser.php
@@ -5,7 +5,7 @@ class MysqlUser extends Doctrine_Record
     {
         $this->hasColumn('name', 'string', null);
     }
-    
+
     public function setUp()
     {
         $this->hasMany('MysqlGroup', array(

--- a/tests/models/NestTest.php
+++ b/tests/models/NestTest.php
@@ -13,7 +13,7 @@ class NestTest extends Doctrine_Record
         $this->hasMany('NestTest as Children', array('local'    => 'parent_id',
                                                      'refClass' => 'NestReference',
                                                      'foreign'  => 'child_id'));
-                                                     
+
         $this->hasMany('NestTest as Relatives', array('local'    => 'child_id',
                                                       'refClass' => 'NestReference',
                                                       'foreign'  => 'parent_id',

--- a/tests/models/ORM_TestEntry.php
+++ b/tests/models/ORM_TestEntry.php
@@ -10,7 +10,7 @@ class ORM_TestEntry extends Doctrine_Record
         $this->hasColumn('amount', 'float');
         $this->hasColumn('itemID', 'integer');
     }
-    
+
     public function setUp()
     {
         $this->hasOne('ORM_TestItem', array(

--- a/tests/models/Phonenumber.php
+++ b/tests/models/Phonenumber.php
@@ -11,11 +11,11 @@ class Phonenumber extends Doctrine_Record
         $this->hasOne('Entity', array('local'    => 'entity_id',
                                       'foreign'  => 'id',
                                       'onDelete' => 'CASCADE'));
-        
+
         $this->hasOne('Group', array('local'     => 'entity_id',
                                       'foreign'  => 'id',
                                       'onDelete' => 'CASCADE'));
-          
+
         $this->hasOne('User', array('local'    => 'entity_id',
                                     'foreign'  => 'id',
                                     'onDelete' => 'CASCADE'));

--- a/tests/models/Policy.php
+++ b/tests/models/Policy.php
@@ -5,7 +5,7 @@ class Policy extends Doctrine_Record
     {
         $this->hasColumn('policy_number', 'integer', 11, array('unique' => true));
     }
-  
+
     public function setUp()
     {
         $this->hasMany('PolicyAsset as PolicyAssets', array('local'   => 'policy_number',

--- a/tests/models/PolicyN.php
+++ b/tests/models/PolicyN.php
@@ -8,7 +8,7 @@ class PolicyN extends Doctrine_Record
         $this->hasColumn('rate_id', 'integer', 4, array( ));
         $this->hasColumn('policy_number', 'integer', 4, array(  'unique' => true, ));
     }
-  
+
     public function setUp()
     {
         $this->hasOne('RateN', array('local' => 'rate_id', 'foreign' => 'id' ));

--- a/tests/models/QueryTest_Rank.php
+++ b/tests/models/QueryTest_Rank.php
@@ -7,14 +7,14 @@ class QueryTest_Rank extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->hasColumn(
-        
+
             'title as title',
-        
+
             'string',
-        
+
             100,
                 array('notnull')
-        
+
         );
         $this->hasColumn(
             'color as color',

--- a/tests/models/QueryTest_User.php
+++ b/tests/models/QueryTest_User.php
@@ -4,14 +4,14 @@ class QueryTest_User extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->hasColumn(
-        
+
             'username as username',
-        
+
             'string',
-        
+
             50,
                 array('notnull')
-        
+
         );
         $this->hasColumn('visibleRankId', 'integer', 4);
         $this->hasColumn('subscriptionId', 'integer', 4);
@@ -25,7 +25,7 @@ class QueryTest_User extends Doctrine_Record
         $this->hasOne('QueryTest_Rank as visibleRank', array(
             'local' => 'visibleRankId', 'foreign' => 'id'
         ));
-        
+
         $this->hasOne('QueryTest_Subscription', array(
             'local' => 'subscriptionId', 'foreign' => 'id'
         ));

--- a/tests/models/RateN.php
+++ b/tests/models/RateN.php
@@ -10,7 +10,7 @@ class RateN extends Doctrine_Record
         $this->hasColumn('liability_code', 'integer', 4, array(  'notnull' => true,  'notblank' => true,));
         $this->hasColumn('total_rate', 'float', null, array(  'notnull' => true,  'notblank' => true,));
     }
-  
+
     public function setUp()
     {
         $this->hasOne('PolicyCodeN', array('local' => 'policy_code', 'foreign' => 'code' ));

--- a/tests/models/Record_City.php
+++ b/tests/models/Record_City.php
@@ -7,7 +7,7 @@ class Record_City extends Doctrine_Record
         $this->hasColumn('country_id', 'integer');
         $this->hasColumn('district_id', 'integer');
     }
-    
+
     public function setUp()
     {
         $this->hasOne('Record_Country as Country', array(

--- a/tests/models/SerializeTest.php
+++ b/tests/models/SerializeTest.php
@@ -4,7 +4,7 @@ class SerializeTest extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('serialize_test');
-    
+
         $this->hasColumn('booltest', 'boolean');
         $this->hasColumn('integertest', 'integer', 4, array('unsigned' => true));
         $this->hasColumn('floattest', 'float');

--- a/tests/models/SoftDeleteBCTest.php
+++ b/tests/models/SoftDeleteBCTest.php
@@ -4,7 +4,7 @@ class SoftDeleteBCTest extends Doctrine_Record
     public function setTableDefinition()
     {
         $this->setTableName('soft_delete_bc_test');
-    
+
         $this->hasColumn('name', 'string', null, array('primary' => true));
         $this->hasColumn('something', 'string', '25', array('notnull' => true, 'unique' => true));
     }

--- a/tests/models/TreeLeaf.php
+++ b/tests/models/TreeLeaf.php
@@ -12,7 +12,7 @@ class TreeLeaf extends Doctrine_Record
         $this->hasOne('TreeLeaf as Parent', array(
             'local' => 'parent_id', 'foreign' => 'id'
         ));
-        
+
         $this->hasMany('TreeLeaf as Children', array(
             'local' => 'id', 'foreign' => 'parent_id'
         ));

--- a/tests/models/ValidatorTest_Person.php
+++ b/tests/models/ValidatorTest_Person.php
@@ -6,7 +6,7 @@ class ValidatorTest_Person extends Doctrine_Record
         $this->hasColumn('identifier', 'integer', 4, array('notblank', 'unique'));
         $this->hasColumn('is_football_player', 'boolean');
     }
-   
+
     public function setUp()
     {
         $this->hasOne('ValidatorTest_FootballPlayer', array(

--- a/tests/models/export/Cms_Category.php
+++ b/tests/models/export/Cms_Category.php
@@ -5,7 +5,7 @@ class Cms_Category extends Doctrine_Record
     {
         $this->hasMany('Cms_CategoryLanguages as langs', array('local' => 'id', 'foreign' => 'category_id'));
     }
- 
+
     public function setTableDefinition()
     {
         $this->hasColumn('created', 'timestamp');

--- a/tests/models/export/Cms_CategoryLanguages.php
+++ b/tests/models/export/Cms_CategoryLanguages.php
@@ -6,7 +6,7 @@ class Cms_CategoryLanguages extends Doctrine_Record
         $this->setAttribute(Doctrine_Core::ATTR_COLL_KEY, 'language_id');
         $this->hasOne('Cms_Category as category', array('local' => 'category_id', 'foreign' => 'id', 'onDelete' => 'CASCADE'));
     }
- 
+
     public function setTableDefinition()
     {
         $this->hasColumn('name', 'string', 256);

--- a/tests/models/gnatUser.php
+++ b/tests/models/gnatUser.php
@@ -10,7 +10,7 @@ class gnatUser extends Doctrine_Record
         $this->hasColumn('name', 'string', 150);
         $this->hasColumn('foreign_id', 'integer', 10, array('unique' => true,));
     }
-    
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/mysql_migration_classes/001_mysql_add_table.php
+++ b/tests/mysql_migration_classes/001_mysql_add_table.php
@@ -6,7 +6,7 @@ class MysqlAddTable extends Doctrine_Migration_Base
         $this->createTable('migration_test', array('field1' => array('type' => 'string')));
         $this->addColumn('migration_test', 'field2', 'integer');
     }
-    
+
     public function down()
     {
         $this->dropTable('migration_test');

--- a/tests/mysql_migration_classes/002_mysql_change_column.php
+++ b/tests/mysql_migration_classes/002_mysql_change_column.php
@@ -5,7 +5,7 @@ class MysqlChangeColumn extends Doctrine_Migration_Base
     {
         $this->renameColumn('migration_test', 'field2', 'field3');
     }
-    
+
     public function down()
     {
         $this->renameColumn('migration_test', 'field3', 'field2');


### PR DESCRIPTION
Fixes #37.

As discussed in the ticket, mysql 5.7 with the only_full_group_by option enabled (which is the default) requires that any fields used in the order by are used in the select (when DISTINCT is used).

Doctrine already has this logic in place for other drivers (as it's standard SQL), so just adding mysql to that list.

Also noticed that there was still some extra whitespace in one of the files I touched (on blank lines), so added the php-cs-fixer rule for that and updated all files (can hide those changes by adding `w=1` to the github query string when viewing the PR's changes).