### PR TITLE
Make tests run in PHP 7.3, add static analysis to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 language: php
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm
-  - nightly
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
 
 env:
   global:
-    - CC_TEST_REPORTER_ID=f424c3957298b215ddff899f624b534dac452ed703b42f70b74188a2edf0b5d0
+    - COMPOSER_ARGS="" CC_TEST_REPORTER_ID=f424c3957298b215ddff899f624b534dac452ed703b42f70b74188a2edf0b5d0
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction --prefer-source $COMPOSER_ARGS
 
 stages:
   - style check
+  - phpstan analysis
   - test
 
 before_script:
@@ -42,10 +42,29 @@ jobs:
     - php: hhvm
     - php: nightly
   include:
+    - php: 5.6
+    - php: 7
+    - php: 7.1
+    - php: 7.2
+    - php: hhvm
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs"
+
     - stage: style check
       php: 7.2
       before_script: skip
       script:
         - ./vendor/bin/php-cs-fixer fix --dry-run -vv
+      after_script: skip
+      after_success: skip
+
+    - stage: phpstan analysis
+      php: 7.2
+      install:
+        - travis_retry composer install --no-interaction --prefer-source $COMPOSER_ARGS
+        - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest phpstan/phpstan:0.9.2
+      before_script: skip
+      script:
+        - ./vendor/bin/phpstan analyze --level 7 -c phpstan.neon ./lib/
       after_script: skip
       after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,9 @@ jobs:
       install:
         - travis_retry composer install --no-interaction --prefer-source $COMPOSER_ARGS
         - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest phpstan/phpstan:0.9.2
-      before_script: skip
+      before_script:
+        - phpenv config-rm xdebug.ini || return 0;
       script:
-        - ./vendor/bin/phpstan analyze --level 7 -c phpstan.neon ./lib/
+        - ./vendor/bin/phpstan analyze --level 7 -c phpstan.neon --memory-limit=768M ./lib/
       after_script: skip
       after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 
 stages:
   - style check
-  - phpstan analysis
+  - static analysis
   - test
 
 before_script:
@@ -58,14 +58,16 @@ jobs:
       after_script: skip
       after_success: skip
 
-    - stage: phpstan analysis
+    - stage: static analysis
       php: 7.2
       install:
         - travis_retry composer install --no-interaction --prefer-source $COMPOSER_ARGS
         - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest phpstan/phpstan:0.9.2
+        - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest vimeo/psalm:1.1.9
       before_script:
         - phpenv config-rm xdebug.ini || return 0;
       script:
         - ./vendor/bin/phpstan analyze --level 7 -c phpstan.neon --memory-limit=768M ./lib/
+        - ./vendor/bin/psalm --show-info=false
       after_script: skip
       after_success: skip

--- a/lib/Doctrine/Cache/Apc.php
+++ b/lib/Doctrine/Cache/Apc.php
@@ -82,7 +82,14 @@ class Doctrine_Cache_Apc extends Doctrine_Cache_Driver
      */
     protected function _doSave($id, $data, $lifeTime = false)
     {
-        return apc_store($id, $data, $lifeTime);
+        if ($lifeTime === false) {
+            $lifeTime = 0;
+        }
+
+        /** @var bool $result */
+        $result = apc_store($id, $data, $lifeTime);
+
+        return $result;
     }
 
     /**
@@ -94,7 +101,10 @@ class Doctrine_Cache_Apc extends Doctrine_Cache_Driver
      */
     protected function _doDelete($id)
     {
-        return apc_delete($id);
+        /** @var bool $result */
+        $result = apc_delete($id);
+
+        return $result;
     }
 
     /**

--- a/lib/Doctrine/Connection/Profiler.php
+++ b/lib/Doctrine/Connection/Profiler.php
@@ -77,7 +77,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      * @param string $m     the name of the method
      * @param array $a      method arguments
      * @see Doctrine_EventListener
-     * @return boolean
+     * @return void
      */
     public function __call($m, $a)
     {

--- a/lib/Doctrine/Formatter.php
+++ b/lib/Doctrine/Formatter.php
@@ -167,35 +167,35 @@ class Doctrine_Formatter extends Doctrine_Connection_Module
      */
     public function quote($input, $type = null)
     {
-        if ($type == null) {
+        if ($type === null) {
             $type = gettype($input);
         }
         switch ($type) {
-        case 'integer':
-        case 'double':
-        case 'float':
-        case 'bool':
-        case 'decimal':
-        case 'int':
-            return $input;
-        case 'array':
-        case 'object':
-            $input = serialize($input);
-            // no break
-        case 'date':
-        case 'time':
-        case 'timestamp':
-        case 'string':
-        case 'char':
-        case 'varchar':
-        case 'text':
-        case 'gzip':
-        case 'blob':
-        case 'clob':
-        case 'enum':
-        case 'set':
-        case 'boolean':
-        return "'" . str_replace("'", "''", $input) . "'";
+            case 'integer':
+            case 'double':
+            case 'float':
+            case 'bool':
+            case 'decimal':
+            case 'int':
+                return $input;
+            case 'array':
+            case 'object':
+                $input = serialize($input);
+                // no break
+            case 'date':
+            case 'time':
+            case 'timestamp':
+            case 'string':
+            case 'char':
+            case 'varchar':
+            case 'text':
+            case 'gzip':
+            case 'blob':
+            case 'clob':
+            case 'enum':
+            case 'set':
+            case 'boolean':
+                return "'" . str_replace("'", "''", $input) . "'";
         }
     }
 

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -143,6 +143,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
         if (! $this->_initialized) {
             $this->_initialized = true;
             $attributes         = array(
+                        // These first two keys have the same value in Doctrine_Core (150)
                         Doctrine_Core::ATTR_CACHE                      => null,
                         Doctrine_Core::ATTR_RESULT_CACHE               => null,
                         Doctrine_Core::ATTR_QUERY_CACHE                => null,

--- a/lib/Doctrine/Parser/sfYaml/sfYamlInline.php
+++ b/lib/Doctrine/Parser/sfYaml/sfYamlInline.php
@@ -27,7 +27,7 @@ class sfYamlInline
      *
      * @param string $value A YAML string
      *
-     * @return array|string A PHP array representing the YAML string
+     * @return array|string|bool|null|int|float A PHP array representing the YAML string
      */
     public static function load($value)
     {
@@ -165,7 +165,7 @@ class sfYamlInline
      * @param integer $i
      * @param boolean $evaluate
      *
-     * @return string A YAML string
+     * @return string|bool|null|int|float A YAML string
      */
     public static function parseScalar($scalar, $delimiters = null, $stringDelimiters = array('"', "'"), &$i = 0, $evaluate = true)
     {
@@ -262,7 +262,7 @@ class sfYamlInline
           $isQuoted = in_array($sequence[$i], array('"', "'"));
           $value    = self::parseScalar($sequence, array(',', ']'), array('"', "'"), $i);
 
-          if (!$isQuoted && false !== strpos($value, ': ')) {
+          if (!$isQuoted && false !== strpos((string) $value, ': ')) {
               // embedded mapping?
               try {
                   $value = self::parseMapping('{' . $value . '}');

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1369,7 +1369,6 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
                 case 'string':
                 case 'clob':
                 case 'float':
-                case 'integer':
                 case 'array':
                 case 'object':
                 case 'blob':

--- a/psalm.xml
+++ b/psalm.xml
@@ -86,6 +86,9 @@
             <errorLevel type="info">
                 <!-- different number of parameters passed depending on the mode -->
                 <file name="lib/Doctrine/Connection/Statement.php" />
+                <!-- I think this one is a bug in psalm, it even shows in the code snippet in the console that the
+                method is only being called with one parameter, not sure why it sees it as 2 -->
+                <file name="lib/Doctrine/Record.php" />
             </errorLevel>
         </TooManyArguments>
 
@@ -225,6 +228,9 @@
             <errorLevel type="info">
                 <!-- scalar|null is probably fine here, will be coerced to be an array key, or could change the docblock -->
                 <file name="lib/Doctrine/Validator/ErrorStack.php" />
+                <!-- This one is odd, Psalm is reporting the line number as "-1", probably worth reporting to psalm
+                project -->
+                <file name="lib/Doctrine/Record.php" />
             </errorLevel>
         </InvalidScalarArgument>
 
@@ -236,12 +242,21 @@
             </errorLevel>
         </NoInterfaceProperties>
 
-        <PossiblyUndefinedArrayOffset>
+        <UnevaluatedCode>
             <errorLevel type="info">
-                <!-- Tokenizer does weird things in a loop -->
-                <file name="lib/Doctrine/Query/Tokenizer.php" />
+                <!-- psalm is complaining about the return value from `gettype`, but in this case, `gettype` is only
+                called if the $type parameter is null, so technically the value of $type could be anything -->
+                <file name="lib/Doctrine/Formatter.php" />
             </errorLevel>
-        </PossiblyUndefinedArrayOffset>
+        </UnevaluatedCode>
+
+        <DuplicateArrayKey>
+            <errorLevel type="info">
+                <!-- This is correct, but I don't want to remove the key in case the values ever change in Doctrine_Core
+                I added a comment about it in Doctrine_Manager -->
+                <file name="lib/Doctrine/Manager.php" />
+            </errorLevel>
+        </DuplicateArrayKey>
 
         <!-- newer version of psalm does not like the @property annotations -->
         <UndefinedThisPropertyFetch errorLevel="info" />


### PR DESCRIPTION
This changes the travis config a bit so that tests will run on php 7.3 (nightly right now). Mainly have to ignore the platform requirements when running composer so that `php-cs-fixer` doesn't abort the install.

I'm also adding phpstan and psalm to a travis stage, I didn't do this before because of php 5.6, but using composer to install phpstan/psalm during the build, rather than defining in the composer requirements.

Some small fixes for phpstan/psalm so they pass on travis.