### PR TITLE
Adding php 7.3 to travis, without failure, removing hhvm from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,13 @@ after_script:
 jobs:
   fast_finish: true
   allow_failures:
-    - php: hhvm
     - php: nightly
   include:
     - php: 5.6
     - php: 7
     - php: 7.1
     - php: 7.2
-    - php: hhvm
+    - php: 7.3
     - php: nightly
       env: COMPOSER_ARGS="--ignore-platform-reqs"
 


### PR DESCRIPTION
Now that PHP 7.3 is officially released, adding to travis build without allowed failure.

Also removing HHVM from travis.