### PR TITLE
adding a skipped status to tests

### DIFF
--- a/tests/Cache/AbstractTestCase.php
+++ b/tests/Cache/AbstractTestCase.php
@@ -49,6 +49,7 @@ abstract class Doctrine_Cache_Abstract_TestCase extends Doctrine_UnitTestCase
     public function testAsResultCache()
     {
         if (!$this->_isEnabled()) {
+            $this->skip();
             return;
         }
         $this->_clearCache();
@@ -82,6 +83,7 @@ abstract class Doctrine_Cache_Abstract_TestCase extends Doctrine_UnitTestCase
     public function testCacheCore()
     {
         if (!$this->_isEnabled()) {
+            $this->skip();
             return;
         }
         $this->_clearCache();
@@ -100,6 +102,7 @@ abstract class Doctrine_Cache_Abstract_TestCase extends Doctrine_UnitTestCase
     public function testDeleteByPrefix()
     {
         if (!$this->_isEnabled()) {
+            $this->skip();
             return;
         }
         $this->_clearCache();
@@ -119,6 +122,7 @@ abstract class Doctrine_Cache_Abstract_TestCase extends Doctrine_UnitTestCase
     public function testDeleteBySuffix()
     {
         if (!$this->_isEnabled()) {
+            $this->skip();
             return;
         }
         $this->_clearCache();
@@ -138,6 +142,7 @@ abstract class Doctrine_Cache_Abstract_TestCase extends Doctrine_UnitTestCase
     public function testDeleteByRegex()
     {
         if (!$this->_isEnabled()) {
+            $this->skip();
             return;
         }
         $this->_clearCache();

--- a/tests/DoctrineTest/GroupTest.php
+++ b/tests/DoctrineTest/GroupTest.php
@@ -79,8 +79,9 @@ class GroupTest extends UnitTestCase
                 $testCase->addMessage($message);
             }
 
-            $this->_passed += $testCase->getPassCount();
-            $this->_failed += $testCase->getFailCount();
+            $this->_passed  += $testCase->getPassCount();
+            $this->_failed  += $testCase->getFailCount();
+            $this->_skipped += $testCase->getSkipCount();
 
             $this->_testCases[$k] = null;
 

--- a/tests/DoctrineTest/Reporter.php
+++ b/tests/DoctrineTest/Reporter.php
@@ -19,6 +19,8 @@ class DoctrineTest_Reporter
                 $color = 'green';
             } elseif ($type == 'ERROR') {
                 $color = 'red';
+            } elseif ($type == 'COMMENT') {
+                $color = 'yellow';
             } else {
                 $color = 'black';
             }
@@ -37,10 +39,21 @@ class DoctrineTest_Reporter
         $class    = get_class($this->_test);
         $messages = $this->_test->getMessages();
         $failed   = ($this->_test->getFailCount() || count($messages)) ? true:false;
+        $skipped  = $this->_test->getSkipCount() ? true : false;
 
         if ($class != 'GroupTest') {
             $strRepeatLength = $max - strlen($class);
-            echo $class . str_repeat('.', $strRepeatLength) . $this->format($failed ? 'failed':'passed', $failed ? 'ERROR':'INFO') . "\n";
+            $message         = 'passed';
+            $type            = 'INFO';
+            if ($failed) {
+                $message = 'failed';
+                $type    = 'ERROR';
+            } elseif ($skipped) {
+                $message = 'skipped';
+                $type    = 'COMMENT';
+            }
+
+            echo $class . str_repeat('.', $strRepeatLength) . $this->format($message, $type) . "\n";
         }
 
         if (! empty($messages)) {

--- a/tests/DoctrineTest/Reporter/Cli.php
+++ b/tests/DoctrineTest/Reporter/Cli.php
@@ -14,6 +14,7 @@ class DoctrineTest_Reporter_Cli extends DoctrineTest_Reporter
         echo $this->format('Tested: ' . $this->_test->getTestCaseCount() . ' test cases.', 'INFO') . "\n";
         echo $this->format('Successes: ' . $this->_test->getPassCount() . ' passes.', 'INFO') . "\n";
         echo $this->format('Failures: ' . $this->_test->getFailCount() . ' fails.', $this->_test->getFailCount() ? 'ERROR':'INFO') . "\n";
+        echo $this->format('Skips: ' . $this->_test->getSkipCount() . ' skips.', $this->_test->getSkipCount() ? 'COMMENT':'INFO') . "\n";
         echo $this->format('Number of new Failures: ' . $this->_test->getNumNewFails(), $this->_test->getNumNewFails() ? 'ERROR':'INFO') . ' ' . implode(', ', $this->_test->getNewFails()) . "\n";
         echo $this->format('Number of fixed Failures: ' . $this->_test->getNumFixedFails(), $this->_test->getNumFixedFails() ? 'INFO':'HEADER') . ' ' . implode(', ', $this->_test->getFixedFails()) . "\n";
     }

--- a/tests/DoctrineTest/UnitTestCase.php
+++ b/tests/DoctrineTest/UnitTestCase.php
@@ -5,11 +5,13 @@ class UnitTestCase
 
     protected $_failed = 0;
 
+    protected $_skipped = 0;
+
     protected $_messages = array();
 
-    protected static $_passesAndFails = array('passes' => array(), 'fails' => array());
+    protected static $_passesAndFails = array('passes' => array(), 'fails' => array(), 'skips' => array());
 
-    protected static $_lastRunsPassesAndFails = array('passes' => array(), 'fails' => array());
+    protected static $_lastRunsPassesAndFails = array('passes' => array(), 'fails' => array(), 'skips' => array());
 
     public function init()
     {
@@ -116,6 +118,15 @@ class UnitTestCase
         $this->_passed++;
     }
 
+    public function skip()
+    {
+        $class = get_class($this);
+        if (! isset(self::$_passesAndFails['skips'][$class])) {
+            self::$_passesAndFails['skips'][$class] = $class;
+        }
+        $this->_skipped++;
+    }
+
     public function fail($message = '')
     {
         $this->_fail($message);
@@ -177,6 +188,11 @@ class UnitTestCase
         return $this->_passed;
     }
 
+    public function getSkipCount()
+    {
+        return $this->_skipped;
+    }
+
     public function getPassesAndFailsCachePath()
     {
         $dir = dirname(__FILE__) . '/doctrine_tests';
@@ -225,7 +241,6 @@ class UnitTestCase
             }
         }
         return $newFails;
-        ;
     }
 
     public function getFixedFails()
@@ -239,7 +254,6 @@ class UnitTestCase
             }
         }
         return $fixed;
-        ;
     }
 
     public function getNumNewFails()

--- a/tests/Ticket/DC841TestCase.php
+++ b/tests/Ticket/DC841TestCase.php
@@ -78,6 +78,7 @@ class Doctrine_Ticket_DC841_TestCase extends Doctrine_UnitTestCase
 
     public function testSelectWithStaticParameter()
     {
+        $this->skip();
         return; // doesn't work
         Doctrine::getTable('Ticket_DC841_Model')
             ->createQuery('t')


### PR DESCRIPTION
With the addition of APC/APCU to travis, I wanted to make sure that when tests are skipped (mainly because the cache adapter's extension isn't available) that it's obvious that some tests are skipped.

Previously, Doctrine's test runner would just `return;` if the cache adapter wasn't "enabled", which is treated as a passing status in the test suite.  I've modified those tests to call a new `skip` method, that then shows up in the test run where it would normally say "passing" in green, it now says "skipped" in yellow and shows a total skip count at the end.

Can see the results of this on this travis build: https://travis-ci.org/jaydiablo/doctrine1/jobs/524237410

The XCache tests are skipped, and so is a DC841 Ticket test. Total skipped tests should be 6 (in all runs).