### PR TITLE
Assign the SET type to fields when exporting models

### DIFF
--- a/lib/Doctrine/DataDict/Mysql.php
+++ b/lib/Doctrine/DataDict/Mysql.php
@@ -365,7 +365,7 @@ class Doctrine_DataDict_Mysql extends Doctrine_DataDict
                 break;
             case 'set':
                 $fixed  = false;
-                $type[] = 'text';
+                $type[] = 'set';
                 $type[] = 'integer';
             break;
             case 'date':


### PR DESCRIPTION
This seems to be working just fine, I don't get why it was exported as "text", while the similar ENUM fields were already using the correct type.