### PR TITLE
Fix values of empty SET fields

### DIFF
--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -2100,7 +2100,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
                 $values = $this->_columns[$fieldName]['values'];
                 // Convert string to array
                 if (is_string($value)) {
-                    $value = explode(',', $value);
+                    $value = $value ? explode(',', $value) : array();
                     $value = array_map('trim', $value);
                     $record->set($fieldName, $value);
                 }
@@ -2364,7 +2364,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
                     // don't do any casting here PHP INT_MAX is smaller than what the databases support
                 break;
                 case 'set':
-                    return explode(',', $value);
+                    return $value ? explode(',', $value) : array();
                 break;
                 case 'boolean':
                     return (boolean) $value;


### PR DESCRIPTION
This fixed a common mistake with using explode on empty strings. The values of empty SETs are exploded into an array with one empty string element instead of an empty array.

Before:
```php
// $value = '';
$value = explode(',', $value);
// $value = [''];
```

After:
```php
// $value = '';
$value = $value ? explode(',', $value) : array();
// $value = [];
```

The empty string becomes an incorrect SET value if you try saving the model,