### PR TITLE
Mysql 8 Support

### DIFF
--- a/lib/Doctrine/Transaction/Mysql.php
+++ b/lib/Doctrine/Transaction/Mysql.php
@@ -128,11 +128,11 @@ class Doctrine_Transaction_Mysql extends Doctrine_Transaction
     public function getIsolation()
     {
         // Mysql 5.7.20 added `@@transaction_isolation` as an alias for `@@tx_isolation`
-        // Mysql 8.0.0 removes `@@tx_isolation`        
+        // Mysql 8.0.0 removes `@@tx_isolation`
         if (version_compare($this->mysqlVersion, '5.7.20', '>=')) {
             return $this->conn->fetchOne('SELECT @@transaction_isolation');
         }
-        
+
         return $this->conn->fetchOne('SELECT @@tx_isolation');
     }
 }

--- a/lib/Doctrine/Transaction/Mysql.php
+++ b/lib/Doctrine/Transaction/Mysql.php
@@ -32,6 +32,19 @@
  */
 class Doctrine_Transaction_Mysql extends Doctrine_Transaction
 {
+    protected $mysqlVersion;
+
+    /**
+     * @param Doctrine_Connection $conn     Doctrine_Connection object, every connection
+     *                                      module holds an instance of Doctrine_Connection
+     */
+    public function __construct($conn = null)
+    {
+        parent::__construct($conn);
+
+        $this->mysqlVersion = $this->conn->getDbh()->getAttribute(PDO::ATTR_SERVER_VERSION);
+    }
+
     /**
      * createSavepoint
      * creates a new savepoint
@@ -111,10 +124,9 @@ class Doctrine_Transaction_Mysql extends Doctrine_Transaction
      */
     public function getIsolation()
     {
-        // Mysql 5.7.20 added `@@transation_isolaction` as an alias for `@@tx_isolation`
-        // Mysql 8.0.0 removes `@@tx_isolation`
-        $engineVersion = $this->conn->getDbh()->getAttribute(PDO::ATTR_SERVER_VERSION);
-        if (version_compare($engineVersion, '5.7.20', '>=')) {
+        // Mysql 5.7.20 added `@@transaction_isolation` as an alias for `@@tx_isolation`
+        // Mysql 8.0.0 removes `@@tx_isolation`        
+        if (version_compare($this->mysqlVersion, '5.7.20', '>=')) {
             return $this->conn->fetchOne('SELECT @@transaction_isolation');
         }
         

--- a/lib/Doctrine/Transaction/Mysql.php
+++ b/lib/Doctrine/Transaction/Mysql.php
@@ -32,6 +32,9 @@
  */
 class Doctrine_Transaction_Mysql extends Doctrine_Transaction
 {
+    /**
+     * @var string
+     */
     protected $mysqlVersion;
 
     /**

--- a/lib/Doctrine/Transaction/Mysql.php
+++ b/lib/Doctrine/Transaction/Mysql.php
@@ -111,6 +111,13 @@ class Doctrine_Transaction_Mysql extends Doctrine_Transaction
      */
     public function getIsolation()
     {
+        // Mysql 5.7.20 added `@@transation_isolaction` as an alias for `@@tx_isolation`
+        // Mysql 8.0.0 removes `@@tx_isolation`
+        $engineVersion = $this->conn->getDbh()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        if (version_compare($engineVersion, '5.7.20', '>=')) {
+            return $this->conn->fetchOne('SELECT @@transaction_isolation');
+        }
+        
         return $this->conn->fetchOne('SELECT @@tx_isolation');
     }
 }


### PR DESCRIPTION
Mysql 8 removes the `@@tx_isolation` variable, so that has to be changed to `@@transaction_isolation`.

Doing version detection to determine which call to make, as mysql versions earlier than 5.7.20 don't have `@@transaction_isolation`.