### PR TITLE
Add backtick to excluded characters when generating table name alias

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -856,7 +856,7 @@ abstract class Doctrine_Query_Abstract
      */
     public function generateSqlTableAlias($componentAlias, $tableName)
     {
-        preg_match('/([^_|\d])/', $tableName, $matches);
+        preg_match('/([^_|`\d])/', $tableName, $matches);
         $char = strtolower($matches[0]);
 
         $alias = $char;


### PR DESCRIPTION
This PR fixes an issue in the `generateSqlTableAlias` function where table names that are reserved words in MySQL (e.g., `group` or `user`) or simply enclosed in backticks were not properly handled.

Table names that are reserved words must be enclosed in backticks (e.g., ```$this->setTableName('`group`');``` in the model definition). However, this backtick was incorrectly used as the initial letter for the alias (e.g., ```SELECT Group g```), causing unexpected behavior.

This PR ensures that reserved table names can be correctly enclosed in backticks without affecting alias generation.
