### PR TITLE
Fix isValidType for JSON type

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,10 +10,11 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 return $config
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules(array(
         '@PSR2'                  => true,
-        '@PHP70Migration:risky'  => true,
+        '@PHP7x0Migration:risky' => true,
         'binary_operator_spaces' => array(
             'default'   => 'align_single_space_minimal',
             'operators' => array('||' => null, '&&' => null)
@@ -26,5 +27,5 @@ return $config
         'psr_autoloading'             => false,
     ))
     ->setUsingCache(true)
-    ->setFinder($finder);
+    ->setFinder($finder)    
 ;

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "require-dev": {
         "phpunit/php-code-coverage": "^9.1.10",
-        "friendsofphp/php-cs-fixer": "^3.75.0",
+        "friendsofphp/php-cs-fixer": "^3.88.0",
         "phpstan/phpstan": "2.1.17",
         "vimeo/psalm": "6.11.0"
     },

--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -171,6 +171,9 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
             return true;
         } elseif ($var === null) {
             return true;
+        } elseif ($type === 'json') {
+            // JSON type can be object, array, string, number, boolean, or null (null handled above)
+            return is_object($var) || is_array($var) || is_string($var) || is_numeric($var) || is_bool($var);
         } elseif (is_object($var)) {
             return $type == 'object';
         } elseif (is_array($var)) {
@@ -195,8 +198,6 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
                 return is_array($var);
             case 'object':
                 return is_object($var);
-            case 'json':
-                return is_object($var) || is_array($var);
             case 'boolean':
                 return is_bool($var) || (is_numeric($var) && ($var == 0 || $var == 1));
             case 'timestamp':

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1222,7 +1222,7 @@ $ignoreErrors[] = array(
 $ignoreErrors[] = array(
     'message'    => '#^Call to function is_array\\(\\) with mixed will always evaluate to false\\.$#',
     'identifier' => 'function.impossibleType',
-    'count'      => 3,
+    'count'      => 2,
     'path'       => __DIR__ . '/lib/Doctrine/Validator.php',
 );
 $ignoreErrors[] = array(

--- a/tests/ValidatorTestCase.php
+++ b/tests/ValidatorTestCase.php
@@ -113,6 +113,30 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'float'));
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'array'));
         $this->assertTrue(Doctrine_Validator::isValidType($var, 'object'));
+
+        // Test JSON type validation
+        $var = array('key' => 'value');
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'json'));
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'array'));
+        $this->assertFalse(Doctrine_Validator::isValidType($var, 'object'));
+
+        $var = new stdClass();
+        $var->property = 'value';
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'json'));
+        $this->assertFalse(Doctrine_Validator::isValidType($var, 'array'));
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'object'));
+
+        $var = 'string';
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'json'));
+
+        $var = 123;
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'json'));
+
+        $var = null;
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'json'));
+
+        $var = true;
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'json'));
     }
 
     public function testValidate2()


### PR DESCRIPTION
Fixes #383

This changes the isValidType method to explicitly check for the "json" type and returns true if the var is a valid type for a "json" column.